### PR TITLE
Increase consistent skill name usage in ferias.

### DIFF
--- a/koneta/skill.htm
+++ b/koneta/skill.htm
@@ -441,9 +441,9 @@ a:visited { color: #D37AFF;}
 <tr><td class=t>Guts</td><td class=n>10</td><td>When health is 90 or higher and stamina is 50 or higher, an otherwise lethal attack will be survived with 1 HP left.</td></tr>
 <tr class=l><td class=g>Absolute Defense</td><td class=g>×</td><td class=t>Absolute Defense</td><td class=n>20</td><td>Grants the player a shield aura that completely negates hits, including all damage and status effects that the hit would cause.<br> The shield vanishes for a set duration after each hit blocked, with the duration before recharging taking longer with each hit taken.<br>Reduces physical damage dealt to around 0.8x while the shield is down.</td></tr>
 <tr></tr><tr><th colspan=5>Item/Combo Skills</th></tr>
-<tr class=l><td class=g rowspan=4>Combo Expert</td><td class=g rowspan=4>×</td><td class=t>Combo Expert+3</td><td class=n>20</td><td>Increases combo rate by 30% and grants the effects of Bullet Combination Expert which are improved along with health recovery items.</td></tr>
-<tr><td class=t>Combo Expert+2</td><td class=n>15</td><td>Increases combo rate by 20% and grants the effect of Bullet Combination Expert.</td></tr>
-<tr><td class=t>Combo Expert+1</td><td class=n>10</td><td>Increases combo rate by 10% and grants effect of Bullet Combination Expert.</td></tr>
+<tr class=l><td class=g rowspan=4>Combo Expert</td><td class=g rowspan=4>×</td><td class=t>Combo Expert+3</td><td class=n>20</td><td>Increases combo rate by 30% and grants the effects of Maximum Bullets which are improved along with health recovery items.</td></tr>
+<tr><td class=t>Combo Expert+2</td><td class=n>15</td><td>Increases combo rate by 20% and grants the effect of Maximum Bullets.</td></tr>
+<tr><td class=t>Combo Expert+1</td><td class=n>10</td><td>Increases combo rate by 10% and grants effect of Maximum Bullets.</td></tr>
 <tr><td class=t>Combo Expert-1</td><td class=n>-10</td><td>Decreases combo rate by -5%.</td></tr>
 <tr class=l><td class=g rowspan=5>Wide-Area</td><td class=g rowspan=5>○</td><td colspan=2><br></td><td colspan=3>Effective when using Herbs, healing Potions, Antidotes, Power Seeds, Armor Seeds and Flinch-Free Fruit.</td></tr>
 <tr><td class=t>Wide-Area+3</td><td class=n>30</td><td>Mega Potions, Blight Cure Fruits, Zenith Espinas Antitoxin and Crimson Raviente Blood affect allies in the same area<br>as well as the items covered in Wide-Area+2.</td></tr>
@@ -478,8 +478,8 @@ a:visited { color: #D37AFF;}
 <tr><td class=t>Trap Expert</td><td class=n>10</td><td>Lowers trap setup time to 0.8x. Grants 100% combine rate for traps, Mocha Pots and Trap-related items.</td></tr>
 <tr class=l><td class=g rowspan=2>Iron Arm</td><td class=g rowspan=2>×</td><td class=t>Iron Arm+2</td><td class=n>20</td><td>Grants the effects of Throwing Distance Up, Strong Arm+2 and Throwing Knives+2. Increases blocking duration on Great Sword Guard Slash (Heaven and Storm Styles)<br>Lance Shield Rush (Storm and Extreme Styles), and Tonfa's Standard 1, Standard 3, Standard 4, Aerial 1-3, Continuous Thrust 2 and Dash Tonfa Rotatation.</td></tr>
 <tr><td class=t>Iron Arm+1</td><td class=n>10</td><td>Grants the effects of Throwing Distance Up, Strong Arm+1 and Throwing Knives+1. Increases blocking frames duration on Great Sword Guard Slash (Heaven and Storm Styles)<br>Lance Shield Rush (Storm and Extreme Styles), and Tonfa's Standard 1, Standard 3, Standard 4, Aerial 1-3, Continuous Thrust 2 and Dash Tonfa Rotatation.</td></tr>
-<tr class=l><td class=g rowspan=2>Knife Throwing</td><td class=g rowspan=2>○</td><td class=t>Throwing Knives+2</td><td class=n>20</td><td>Throw 5 Knives at once instead of 1. Only consumes 1.</td></tr>
-<tr><td class=t>Throwing Knives+1</td><td class=n>10</td><td>Throw 3 Knives at once instead of 1. Only consumes 1.</td></tr>
+<tr class=l><td class=g rowspan=2>Knife Throwing</td><td class=g rowspan=2>○</td><td class=t>Throwing Knives+2</td><td class=n>20</td><td>Throw 5 knives at once instead of 1. Only consumes 1 knive.</td></tr>
+<tr><td class=t>Throwing Knives+1</td><td class=n>10</td><td>Throw 3 knives at once instead of 1. Only consumes 1 knive.</td></tr>
 <tr></tr><tr><th colspan=5>Map/Detection Skills</th></tr>
 <tr class=l><td class=g>Map</td><td class=g>×</td><td class=t>Map</td><td class=n>10</td><td>Map is always displayed.</td></tr>
 <tr class=l><td class=g rowspan=2>Psychic</td><td class=g rowspan=2>○</td><td class=t>Autotracker</td><td class=n>15</td><td>Monster locations and detailed icons are always displayed on the map.</td></tr>

--- a/koneta/skill.htm
+++ b/koneta/skill.htm
@@ -478,8 +478,8 @@ a:visited { color: #D37AFF;}
 <tr><td class=t>Trap Expert</td><td class=n>10</td><td>Lowers trap setup time to 0.8x. Grants 100% combine rate for traps, Mocha Pots and Trap-related items.</td></tr>
 <tr class=l><td class=g rowspan=2>Iron Arm</td><td class=g rowspan=2>×</td><td class=t>Iron Arm+2</td><td class=n>20</td><td>Grants the effects of Throwing Distance Up, Strong Arm+2 and Throwing Knives+2. Increases blocking duration on Great Sword Guard Slash (Heaven and Storm Styles)<br>Lance Shield Rush (Storm and Extreme Styles), and Tonfa's Standard 1, Standard 3, Standard 4, Aerial 1-3, Continuous Thrust 2 and Dash Tonfa Rotatation.</td></tr>
 <tr><td class=t>Iron Arm+1</td><td class=n>10</td><td>Grants the effects of Throwing Distance Up, Strong Arm+1 and Throwing Knives+1. Increases blocking frames duration on Great Sword Guard Slash (Heaven and Storm Styles)<br>Lance Shield Rush (Storm and Extreme Styles), and Tonfa's Standard 1, Standard 3, Standard 4, Aerial 1-3, Continuous Thrust 2 and Dash Tonfa Rotatation.</td></tr>
-<tr class=l><td class=g rowspan=2>Knife Throwing</td><td class=g rowspan=2>○</td><td class=t>Throwing Knives+2</td><td class=n>20</td><td>Throw 5 knives at once instead of 1. Only consumes 1 knive.</td></tr>
-<tr><td class=t>Throwing Knives+1</td><td class=n>10</td><td>Throw 3 knives at once instead of 1. Only consumes 1 knive.</td></tr>
+<tr class=l><td class=g rowspan=2>Knife Throwing</td><td class=g rowspan=2>○</td><td class=t>Throwing Knives+2</td><td class=n>20</td><td>Throw 5 knives at once instead of 1. Only consumes 1 knife.</td></tr>
+<tr><td class=t>Throwing Knives+1</td><td class=n>10</td><td>Throw 3 knives at once instead of 1. Only consumes 1 knife.</td></tr>
 <tr></tr><tr><th colspan=5>Map/Detection Skills</th></tr>
 <tr class=l><td class=g>Map</td><td class=g>×</td><td class=t>Map</td><td class=n>10</td><td>Map is always displayed.</td></tr>
 <tr class=l><td class=g rowspan=2>Psychic</td><td class=g rowspan=2>○</td><td class=t>Autotracker</td><td class=n>15</td><td>Monster locations and detailed icons are always displayed on the map.</td></tr>


### PR DESCRIPTION
Changed skill description of Combo Expert to include the correct name of the Ammo Combiner skill it contains.
Bullet Combination Expert -> Maximum Bullets.