### PR TITLE
Translations and fixes

### DIFF
--- a/mons/Vau_ng.htm
+++ b/mons/Vau_ng.htm
@@ -97,14 +97,14 @@
 <img id=icon src="../img/monsicons/voljang.webp" width="350"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>35</td><td>40</td><td>30</td><td>0</td><td>20</td><td>20</td><td>0</td><td>25</td><td>100</td></tr>
 <tr><td>？？</td><td>10</td><td>25</td><td>10</td><td>0</td><td>15</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
 <tr><td>？？</td><td>25</td><td>20</td><td>20</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>15</td><td>10</td><td>15</td><td>0</td><td>10</td><td>15</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>？？</td><td>25</td><td>20</td><td>15</td><td>0</td><td>15</td><td>20</td><td>0</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>35</td><td>40</td><td>35</td><td>0</td><td>20</td><td>25</td><td>0</td><td>35</td><td>100</td></tr>
 <tr><td>？？</td><td>20</td><td>30</td><td>15</td><td>0</td><td>15</td><td>10</td><td>0</td><td>30</td><td>0</td></tr>

--- a/mons/Vau_nh.htm
+++ b/mons/Vau_nh.htm
@@ -75,14 +75,14 @@
 <img id=icon src="../img/monsicons/voljang.webp" width="350"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>40</td><td>45</td><td>35</td><td>0</td><td>20</td><td>20</td><td>0</td><td>25</td><td>100</td></tr>
 <tr><td>？？</td><td>15</td><td>30</td><td>15</td><td>0</td><td>15</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
 <tr><td>？？</td><td>30</td><td>25</td><td>25</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>20</td><td>10</td><td>20</td><td>0</td><td>10</td><td>15</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>？？</td><td>30</td><td>25</td><td>20</td><td>0</td><td>15</td><td>20</td><td>0</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>40</td><td>45</td><td>35</td><td>0</td><td>20</td><td>25</td><td>0</td><td>35</td><td>100</td></tr>
 <tr><td>？？</td><td>20</td><td>35</td><td>20</td><td>0</td><td>15</td><td>10</td><td>0</td><td>30</td><td>0</td></tr>

--- a/mons/abio_n.htm
+++ b/mons/abio_n.htm
@@ -63,52 +63,52 @@
 <img id=icon src="../img/monsicons/abiorugu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>35</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>100</td></tr>
-<tr><td>Right Foot</td><td>40</td><td>35</td><td>30</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>Left Foot</td><td>25</td><td>25</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>手</td><td>30</td><td>30</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>40</td><td>35</td><td>30</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
+<tr><td>Left Leg</td><td>25</td><td>25</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Hand</td><td>30</td><td>30</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>30</td><td>25</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>25</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>背棘</td><td>40</td><td>45</td><td>30</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り1)</th></tr>
+<tr><td>Back Spines</td><td>40</td><td>45</td><td>30</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(怒り1)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>35</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>100</td></tr>
-<tr><td>Right Foot</td><td>45</td><td>40</td><td>35</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>Left Foot</td><td>25</td><td>25</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>手</td><td>30</td><td>30</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>45</td><td>40</td><td>35</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
+<tr><td>Left Leg</td><td>25</td><td>25</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Hand</td><td>30</td><td>30</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>30</td><td>25</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>25</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>背棘</td><td>45</td><td>50</td><td>35</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り2)</th></tr>
+<tr><td>Back Spines</td><td>45</td><td>50</td><td>35</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(怒り2)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>35</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>100</td></tr>
-<tr><td>Right Foot</td><td>50</td><td>45</td><td>40</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>Left Foot</td><td>25</td><td>25</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>手</td><td>30</td><td>30</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>50</td><td>45</td><td>40</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
+<tr><td>Left Leg</td><td>25</td><td>25</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Hand</td><td>30</td><td>30</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>30</td><td>25</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>25</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>背棘</td><td>50</td><td>55</td><td>40</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り3)</th></tr>
+<tr><td>Back Spines</td><td>50</td><td>55</td><td>40</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(怒り3)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>45</td><td>40</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>100</td></tr>
-<tr><td>Right Foot</td><td>55</td><td>50</td><td>45</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>Left Foot</td><td>25</td><td>30</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>手</td><td>35</td><td>35</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>55</td><td>50</td><td>45</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
+<tr><td>Left Leg</td><td>25</td><td>30</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Hand</td><td>35</td><td>35</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>30</td><td>25</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>30</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>背棘</td><td>55</td><td>60</td><td>45</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Back Spines</td><td>55</td><td>60</td><td>45</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>300</td><td>１ stagger(s) required<br>２ stagger(s) required</td></tr>
-<tr><td>Right Foot</td><td>300</td><td></td></tr>
-<tr><td>Left Foot</td><td>300</td><td></td></tr>
-<tr><td>右手</td><td>300</td><td></td></tr>
-<tr><td>左手</td><td>300</td><td></td></tr>
+<tr><td>Right Leg</td><td>300</td><td></td></tr>
+<tr><td>Left Leg</td><td>300</td><td></td></tr>
+<tr><td>Right Hand</td><td>300</td><td></td></tr>
+<tr><td>Left Hand</td><td>300</td><td></td></tr>
 <tr><td>Torso</td><td>300</td><td></td></tr>
 <tr><td>？</td><td>300</td><td></td></tr>
 <tr><td>Tail</td><td>600</td><td>１ stagger(s) required</td></tr>

--- a/mons/abio_ng.htm
+++ b/mons/abio_ng.htm
@@ -123,52 +123,52 @@
 <img id=icon src="../img/monsicons/abiorugu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>35</td><td>30</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>100</td></tr>
-<tr><td>Right Foot</td><td>35</td><td>30</td><td>25</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>Left Foot</td><td>20</td><td>20</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>手</td><td>25</td><td>25</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>35</td><td>30</td><td>25</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
+<tr><td>Left Leg</td><td>20</td><td>20</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Hand</td><td>25</td><td>25</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>25</td><td>20</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>20</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>背棘</td><td>35</td><td>40</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り1)</th></tr>
+<tr><td>Back Spines</td><td>35</td><td>40</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(怒り1)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>30</td><td>0</td><td>15</td><td>15</td><td>0</td><td>30</td><td>100</td></tr>
-<tr><td>Right Foot</td><td>40</td><td>35</td><td>30</td><td>0</td><td>15</td><td>15</td><td>0</td><td>30</td><td>0</td></tr>
-<tr><td>Left Foot</td><td>20</td><td>20</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>手</td><td>25</td><td>25</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>20</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>40</td><td>35</td><td>30</td><td>0</td><td>15</td><td>15</td><td>0</td><td>30</td><td>0</td></tr>
+<tr><td>Left Leg</td><td>20</td><td>20</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>20</td><td>0</td></tr>
+<tr><td>Hand</td><td>25</td><td>25</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>20</td><td>0</td></tr>
 <tr><td>Torso</td><td>25</td><td>20</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>20</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>背棘</td><td>40</td><td>45</td><td>30</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り2)</th></tr>
+<tr><td>Back Spines</td><td>40</td><td>45</td><td>30</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(怒り2)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>30</td><td>0</td><td>20</td><td>20</td><td>0</td><td>40</td><td>100</td></tr>
-<tr><td>Right Foot</td><td>45</td><td>40</td><td>35</td><td>0</td><td>20</td><td>20</td><td>0</td><td>40</td><td>0</td></tr>
-<tr><td>Left Foot</td><td>20</td><td>20</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>30</td><td>0</td></tr>
-<tr><td>手</td><td>25</td><td>25</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>30</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>45</td><td>40</td><td>35</td><td>0</td><td>20</td><td>20</td><td>0</td><td>40</td><td>0</td></tr>
+<tr><td>Left Leg</td><td>20</td><td>20</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>30</td><td>0</td></tr>
+<tr><td>Hand</td><td>25</td><td>25</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>30</td><td>0</td></tr>
 <tr><td>Torso</td><td>25</td><td>20</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>20</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>背棘</td><td>45</td><td>50</td><td>35</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り3)</th></tr>
+<tr><td>Back Spines</td><td>45</td><td>50</td><td>35</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(怒り3)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>45</td><td>35</td><td>0</td><td>25</td><td>25</td><td>0</td><td>50</td><td>100</td></tr>
-<tr><td>Right Foot</td><td>50</td><td>45</td><td>40</td><td>0</td><td>25</td><td>25</td><td>0</td><td>50</td><td>0</td></tr>
-<tr><td>Left Foot</td><td>20</td><td>25</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>40</td><td>0</td></tr>
-<tr><td>手</td><td>30</td><td>30</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>40</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>50</td><td>45</td><td>40</td><td>0</td><td>25</td><td>25</td><td>0</td><td>50</td><td>0</td></tr>
+<tr><td>Left Leg</td><td>20</td><td>25</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>40</td><td>0</td></tr>
+<tr><td>Hand</td><td>30</td><td>30</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>40</td><td>0</td></tr>
 <tr><td>Torso</td><td>25</td><td>20</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>25</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>背棘</td><td>50</td><td>55</td><td>40</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Back Spines</td><td>50</td><td>55</td><td>40</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>800</td><td>１ stagger(s) required<br>２ stagger(s) required</td></tr>
-<tr><td>Right Foot</td><td>600</td><td></td></tr>
-<tr><td>Left Foot</td><td>500</td><td></td></tr>
-<tr><td>右手</td><td>600</td><td></td></tr>
-<tr><td>左手</td><td>600</td><td></td></tr>
+<tr><td>Right Leg</td><td>600</td><td></td></tr>
+<tr><td>Left Leg</td><td>500</td><td></td></tr>
+<tr><td>Right Hand</td><td>600</td><td></td></tr>
+<tr><td>Left Hand</td><td>600</td><td></td></tr>
 <tr><td>Torso</td><td>600</td><td></td></tr>
 <tr><td>？</td><td>600</td><td></td></tr>
 <tr><td>Tail</td><td>1000</td><td>１ stagger(s) required</td></tr>

--- a/mons/abio_nh.htm
+++ b/mons/abio_nh.htm
@@ -81,52 +81,52 @@
 <img id=icon src="../img/monsicons/abiorugu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>35</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>100</td></tr>
-<tr><td>Right Foot</td><td>40</td><td>35</td><td>30</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>Left Foot</td><td>25</td><td>25</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>手</td><td>30</td><td>30</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>40</td><td>35</td><td>30</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
+<tr><td>Left Leg</td><td>25</td><td>25</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Hand</td><td>30</td><td>30</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>30</td><td>25</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>25</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>背棘</td><td>40</td><td>45</td><td>30</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り1)</th></tr>
+<tr><td>Back Spines</td><td>40</td><td>45</td><td>30</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(怒り1)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>35</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>100</td></tr>
-<tr><td>Right Foot</td><td>45</td><td>40</td><td>35</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>Left Foot</td><td>25</td><td>25</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>手</td><td>30</td><td>30</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>45</td><td>40</td><td>35</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
+<tr><td>Left Leg</td><td>25</td><td>25</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Hand</td><td>30</td><td>30</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>30</td><td>25</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>25</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>背棘</td><td>45</td><td>50</td><td>35</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り2)</th></tr>
+<tr><td>Back Spines</td><td>45</td><td>50</td><td>35</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(怒り2)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>35</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>100</td></tr>
-<tr><td>Right Foot</td><td>50</td><td>45</td><td>40</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>Left Foot</td><td>25</td><td>25</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>手</td><td>30</td><td>30</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>50</td><td>45</td><td>40</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
+<tr><td>Left Leg</td><td>25</td><td>25</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Hand</td><td>30</td><td>30</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>30</td><td>25</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>25</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>背棘</td><td>50</td><td>55</td><td>40</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り3)</th></tr>
+<tr><td>Back Spines</td><td>50</td><td>55</td><td>40</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(怒り3)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>45</td><td>40</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>100</td></tr>
-<tr><td>Right Foot</td><td>55</td><td>50</td><td>45</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>Left Foot</td><td>25</td><td>30</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>手</td><td>35</td><td>35</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>55</td><td>50</td><td>45</td><td>0</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
+<tr><td>Left Leg</td><td>25</td><td>30</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Hand</td><td>35</td><td>35</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>30</td><td>25</td><td>20</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>30</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>背棘</td><td>55</td><td>60</td><td>45</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Back Spines</td><td>55</td><td>60</td><td>45</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>800</td><td>１ stagger(s) required<br>２ stagger(s) required</td></tr>
-<tr><td>Right Foot</td><td>600</td><td></td></tr>
-<tr><td>Left Foot</td><td>500</td><td></td></tr>
-<tr><td>右手</td><td>600</td><td></td></tr>
-<tr><td>左手</td><td>600</td><td></td></tr>
+<tr><td>Right Leg</td><td>600</td><td></td></tr>
+<tr><td>Left Leg</td><td>500</td><td></td></tr>
+<tr><td>Right Hand</td><td>600</td><td></td></tr>
+<tr><td>Left Hand</td><td>600</td><td></td></tr>
 <tr><td>Torso</td><td>600</td><td></td></tr>
 <tr><td>？</td><td>600</td><td></td></tr>
 <tr><td>Tail</td><td>1000</td><td>１ stagger(s) required</td></tr>

--- a/mons/airu_n.htm
+++ b/mons/airu_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/felyne.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>120</td><td>120</td><td>120</td><td>100</td><td>100</td><td>100</td><td>10</td><td>100</td><td>100</td></tr>
 </table>

--- a/mons/akamu_n.htm
+++ b/mons/akamu_n.htm
@@ -71,23 +71,23 @@
 <img id=icon src="../img/monsicons/akantor.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>55</td><td>40</td><td>0</td><td>5</td><td>20</td><td>35</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>35</td><td>45</td><td>25</td><td>0</td><td>5</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>35</td><td>50</td><td>25</td><td>0</td><td>5</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>25</td><td>30</td><td>10</td><td>5</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>35</td><td>40</td><td>0</td><td>5</td><td>30</td><td>40</td><td>0</td><td>10</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>35</td><td>20</td><td>0</td><td>5</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>35</td><td>20</td><td>0</td><td>5</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>30</td><td>25</td><td>0</td><td>5</td><td>15</td><td>30</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(腹蓄積時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(腹蓄積時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>60</td><td>30</td><td>0</td><td>20</td><td>20</td><td>20</td><td>0</td><td>150</td></tr>
 <tr><td>Neck</td><td>35</td><td>50</td><td>25</td><td>0</td><td>15</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>50</td><td>60</td><td>25</td><td>15</td><td>25</td><td>40</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>60</td><td>30</td><td>40</td><td>0</td><td>15</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>30</td><td>20</td><td>0</td><td>10</td><td>30</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>35</td><td>25</td><td>0</td><td>10</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>35</td><td>25</td><td>0</td><td>10</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>15</td><td>20</td><td>0</td><td>10</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -96,18 +96,18 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>600</td><td>２ stagger(s) required<br>４ stagger(s) required</td></tr>
 <tr><td>Belly</td><td>650</td><td>２ stagger(s) required<br>(Deal at least 1 point of Impact damage)</td></tr>
-<tr><td>首/背中</td><td>240</td><td>２ stagger(s) required</td></tr>
+<tr><td>Neck/Back</td><td>240</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>400</td><td></td></tr>
-<tr><td>左前脚</td><td>350</td><td><div>
+<tr><td>Left Foreleg</td><td>350</td><td><div>
 <span><em>15</em>502</span>
 </div>
 ２ stagger(s) required (Only one break required for rewards)</td></tr>
-<tr><td>左後脚</td><td>250</td><td></td></tr>
-<tr><td>右前脚</td><td>350</td><td><div>
+<tr><td>Left Hind Leg</td><td>250</td><td></td></tr>
+<tr><td>Right Foreleg</td><td>350</td><td><div>
 <span><em>15</em>502</span>
 </div>
 ２ stagger(s) required</td></tr>
-<tr><td>右後脚</td><td>250</td><td></td></tr>
+<tr><td>Right Hind Leg</td><td>250</td><td></td></tr>
 <tr><td>Tail Cut</td><td>400</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/akantor.png" width="400"/>

--- a/mons/akamu_ng.htm
+++ b/mons/akamu_ng.htm
@@ -104,23 +104,23 @@
 <img id=icon src="../img/monsicons/akantor.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>30</td><td>0</td><td>5</td><td>20</td><td>30</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>25</td><td>35</td><td>15</td><td>0</td><td>5</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>25</td><td>40</td><td>15</td><td>0</td><td>5</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>10</td><td>15</td><td>20</td><td>10</td><td>5</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>20</td><td>25</td><td>30</td><td>0</td><td>5</td><td>30</td><td>35</td><td>0</td><td>10</td></tr>
-<tr><td>Fore Leg</td><td>20</td><td>25</td><td>10</td><td>0</td><td>5</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>20</td><td>25</td><td>10</td><td>0</td><td>5</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>20</td><td>15</td><td>0</td><td>5</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(腹蓄積時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(腹蓄積時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>50</td><td>20</td><td>0</td><td>25</td><td>20</td><td>35</td><td>0</td><td>150</td></tr>
 <tr><td>Neck</td><td>25</td><td>40</td><td>15</td><td>0</td><td>20</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>35</td><td>50</td><td>15</td><td>15</td><td>30</td><td>40</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>20</td><td>30</td><td>0</td><td>20</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>20</td><td>20</td><td>15</td><td>0</td><td>15</td><td>30</td><td>40</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>20</td><td>25</td><td>10</td><td>0</td><td>15</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>20</td><td>25</td><td>10</td><td>0</td><td>15</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>10</td><td>10</td><td>10</td><td>0</td><td>15</td><td>15</td><td>25</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -129,12 +129,12 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>700</td><td>２ stagger(s) required<br>４ stagger(s) required</td></tr>
 <tr><td>Belly</td><td>650</td><td>２ stagger(s) required<br>(Deal at least 1 point of Impact damage)</td></tr>
-<tr><td>首/背中</td><td>480</td><td>２ stagger(s) required</td></tr>
+<tr><td>Neck/Back</td><td>480</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>800</td><td></td></tr>
-<tr><td>左前脚</td><td>600</td><td>２ stagger(s) required (Only one break required for rewards)</td></tr>
-<tr><td>左後脚</td><td>500</td><td></td></tr>
-<tr><td>右前脚</td><td>600</td><td>２ stagger(s) required</td></tr>
-<tr><td>右後脚</td><td>500</td><td></td></tr>
+<tr><td>Left Foreleg</td><td>600</td><td>２ stagger(s) required (Only one break required for rewards)</td></tr>
+<tr><td>Left Hind Leg</td><td>500</td><td></td></tr>
+<tr><td>Right Foreleg</td><td>600</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Hind Leg</td><td>500</td><td></td></tr>
 <tr><td>Tail Cut</td><td>1000</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/akantor.png" width="400"/>

--- a/mons/akamu_nh.htm
+++ b/mons/akamu_nh.htm
@@ -77,23 +77,23 @@
 <img id=icon src="../img/monsicons/akantor.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>35</td><td>20</td><td>5</td><td>0</td><td>0</td><td>-5</td><td>-5</td><td>100</td></tr>
 <tr><td>Neck</td><td>15</td><td>30</td><td>30</td><td>0</td><td>-5</td><td>5</td><td>-10</td><td>-5</td><td>0</td></tr>
 <tr><td>Belly</td><td>30</td><td>40</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>25</td><td>20</td><td>0</td><td>5</td><td>5</td><td>-5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>35</td><td>20</td><td>0</td><td>0</td><td>0</td><td>-10</td><td>0</td><td>10</td></tr>
-<tr><td>Fore Leg</td><td>20</td><td>10</td><td>10</td><td>-5</td><td>0</td><td>-5</td><td>-10</td><td>-5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>20</td><td>10</td><td>10</td><td>-5</td><td>0</td><td>-5</td><td>-10</td><td>-5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>10</td><td>15</td><td>0</td><td>-5</td><td>-5</td><td>-10</td><td>-5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(腹蓄積時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(腹蓄積時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>15</td><td>0</td><td>0</td><td>5</td><td>-5</td><td>0</td><td>150</td></tr>
 <tr><td>Neck</td><td>30</td><td>30</td><td>40</td><td>0</td><td>5</td><td>0</td><td>0</td><td>-5</td><td>0</td></tr>
 <tr><td>Belly</td><td>50</td><td>50</td><td>15</td><td>10</td><td>10</td><td>0</td><td>30</td><td>20</td><td>0</td></tr>
 <tr><td>Back</td><td>40</td><td>30</td><td>20</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>50</td><td>20</td><td>0</td><td>0</td><td>5</td><td>-5</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>10</td><td>15</td><td>10</td><td>0</td><td>-5</td><td>5</td><td>0</td><td>-5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>10</td><td>15</td><td>10</td><td>0</td><td>-5</td><td>5</td><td>0</td><td>-5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>10</td><td>15</td><td>10</td><td>-5</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -102,12 +102,12 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>600</td><td>２ stagger(s) required<br>４ stagger(s) required</td></tr>
 <tr><td>Belly</td><td>650</td><td>２ stagger(s) required<br>(Deal at least 1 point of Impact damage)</td></tr>
-<tr><td>首/背中</td><td>240</td><td>２ stagger(s) required</td></tr>
+<tr><td>Neck/Back</td><td>240</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>400</td><td></td></tr>
-<tr><td>左前脚</td><td>350</td><td>２ stagger(s) required (Only one break required for rewards)</td></tr>
-<tr><td>左後脚</td><td>250</td><td></td></tr>
-<tr><td>右前脚</td><td>350</td><td>２ stagger(s) required</td></tr>
-<tr><td>右後脚</td><td>250</td><td></td></tr>
+<tr><td>Left Foreleg</td><td>350</td><td>２ stagger(s) required (Only one break required for rewards)</td></tr>
+<tr><td>Left Hind Leg</td><td>250</td><td></td></tr>
+<tr><td>Right Foreleg</td><td>350</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Hind Leg</td><td>250</td><td></td></tr>
 <tr><td>Tail Cut</td><td>400</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/akantorhr5.png" width="400"/>

--- a/mons/amatsu_ng.htm
+++ b/mons/amatsu_ng.htm
@@ -97,7 +97,7 @@
 <img id=icon src="../img/monsicons/amatsu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>31</td><td>35</td><td>25</td><td>20</td><td>0</td><td>10</td><td>25</td><td>10</td><td>100</td></tr>
 <tr><td>？？</td><td>22</td><td>18</td><td>15</td><td>15</td><td>0</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
@@ -106,7 +106,7 @@
 <tr><td>？？</td><td>24</td><td>24</td><td>20</td><td>15</td><td>0</td><td>10</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>？？</td><td>15</td><td>18</td><td>35</td><td>10</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>？？</td><td>21</td><td>18</td><td>20</td><td>15</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>36</td><td>40</td><td>25</td><td>20</td><td>0</td><td>10</td><td>25</td><td>10</td><td>100</td></tr>
 <tr><td>？？</td><td>22</td><td>18</td><td>15</td><td>15</td><td>0</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>

--- a/mons/amatsu_nh.htm
+++ b/mons/amatsu_nh.htm
@@ -75,7 +75,7 @@
 <img id=icon src="../img/monsicons/amatsu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>35</td><td>45</td><td>38</td><td>25</td><td>0</td><td>15</td><td>35</td><td>10</td><td>100</td></tr>
 <tr><td>？？</td><td>28</td><td>24</td><td>12</td><td>15</td><td>0</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
@@ -84,7 +84,7 @@
 <tr><td>？？</td><td>27</td><td>30</td><td>27</td><td>20</td><td>0</td><td>10</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>？？</td><td>20</td><td>26</td><td>10</td><td>15</td><td>0</td><td>0</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>？？</td><td>37</td><td>24</td><td>12</td><td>20</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>40</td><td>50</td><td>43</td><td>25</td><td>0</td><td>15</td><td>35</td><td>10</td><td>100</td></tr>
 <tr><td>？？</td><td>28</td><td>24</td><td>12</td><td>15</td><td>0</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>

--- a/mons/anolu_ng.htm
+++ b/mons/anolu_ng.htm
@@ -97,7 +97,7 @@
 <img id=icon src="../img/monsicons/anorupatisu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>50</td><td>40</td><td>20</td><td>0</td><td>40</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>30</td><td>25</td><td>25</td><td>20</td><td>0</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
@@ -106,7 +106,7 @@
 <tr><td>Leg</td><td>35</td><td>35</td><td>35</td><td>25</td><td>0</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>25</td><td>30</td><td>20</td><td>0</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>50</td><td>30</td><td>45</td><td>20</td><td>0</td><td>35</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>55</td><td>45</td><td>25</td><td>0</td><td>45</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>30</td><td>25</td><td>25</td><td>20</td><td>0</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>

--- a/mons/anolu_ni.htm
+++ b/mons/anolu_ni.htm
@@ -111,7 +111,7 @@
 <img id=icon src="../img/monsicons/zenith_anorupatisu.webp" width="350"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>35</td><td>30</td><td>15</td><td>0</td><td>10</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>30</td><td>15</td><td>15</td><td>15</td><td>0</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
@@ -120,7 +120,7 @@
 <tr><td>Leg</td><td>15</td><td>15</td><td>20</td><td>20</td><td>0</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>25</td><td>15</td><td>15</td><td>0</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>35</td><td>30</td><td>30</td><td>15</td><td>0</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>40</td><td>35</td><td>20</td><td>0</td><td>15</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>35</td><td>20</td><td>20</td><td>20</td><td>0</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>

--- a/mons/apono_n.htm
+++ b/mons/apono_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/aptonoth.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>110</td><td>110</td><td>110</td><td>50</td><td>50</td><td>50</td><td>10</td><td>50</td><td>0</td></tr>
 </table>

--- a/mons/apuke_n.htm
+++ b/mons/apuke_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/apceros.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>80</td><td>100</td><td>90</td><td>40</td><td>20</td><td>40</td><td>10</td><td>30</td><td>0</td></tr>
 <tr><td>Torso</td><td>70</td><td>100</td><td>70</td><td>40</td><td>20</td><td>40</td><td>10</td><td>30</td><td>0</td></tr>

--- a/mons/aqura_n.htm
+++ b/mons/aqura_n.htm
@@ -7,7 +7,7 @@
 </head><body>
 <div id=monsname>Akura Vashimu</div><div id=tophosoku><a href="aqura_nh.htm">Henshu</a>／<a href="aqura_ng.htm">GR</a>／<a href="aqura_ni.htm">Zenith</a>／<a href="aqura_h.htm">Carves</a></div>
 <div id=hosoku>
-<span><em>Roar</em>Lg.</span><span><em>Wind Pres.</em>Lg.</span><span><em>Tremor</em>Weak</span><span><em>Pitfall T.</em>×</span><span><em>Shock T.</em>×</span><span><em>Flash</em>×</span><span><em>Sonic</em>×</span><span><em>Meat</em>×</span><span><em>Dung</em>×</span><span><em>特殊</em><a style="margin:0" href="aqura-memo.htm">肉質変化・部位破壊</a></span>
+<span><em>Roar</em>Lg.</span><span><em>Wind Pres.</em>Lg.</span><span><em>Tremor</em>Weak</span><span><em>Pitfall T.</em>×</span><span><em>Shock T.</em>×</span><span><em>Flash</em>×</span><span><em>Sonic</em>×</span><span><em>Meat</em>×</span><span><em>Dung</em>×</span><span><em>特殊</em><a style="margin:0" href="aqura-memo.htm">Hitzones変化・部位破壊</a></span>
 </div>
 <table id=izyo>
 <col class=c1><col class=c2><col class=c3><col class=c4><col class=c5>
@@ -64,54 +64,54 @@
 <img id=icon src="../img/monsicons/akuravashimu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>40</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>15</td><td>35</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>15</td><td>35</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>15</td><td>35</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>15</td><td>35</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>5</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>結晶</td><td>5</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(1段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
+<tr><td>Crystal</td><td>5</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(1段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>15</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>35</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>35</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>35</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>35</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>5</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>結晶</td><td>5</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(2段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
+<tr><td>Crystal</td><td>5</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(2段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>35</td><td>35</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>35</td><td>35</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>35</td><td>35</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>35</td><td>35</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>15</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>5</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>結晶</td><td>5</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(転倒中)</th></tr>
+<tr><td>Crystal</td><td>5</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(転倒中)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>60</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>50</td><td>50</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>50</td><td>50</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>50</td><td>50</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>50</td><td>50</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>60</td><td>20</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>50</td><td>50</td><td>80</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>20</td><td>50</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>結晶</td><td>20</td><td>50</td><td>80</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Crystal</td><td>20</td><td>50</td><td>80</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>250</td><td>１ stagger(s) required for first crystals、２ stagger(s) required for break<br>（※Only Impact and Cutting damage works）</td></tr>
-<tr><td>右爪</td><td>200</td><td></td></tr>
-<tr><td>左爪</td><td>200</td><td></td></tr>
+<tr><td>Right Claw</td><td>200</td><td></td></tr>
+<tr><td>Left Claw</td><td>200</td><td></td></tr>
 <tr><td>Leg</td><td>300</td><td>（※Doesn't accumulate while flipped）</td></tr>
-<tr><td>胴</td><td>350</td><td></td></tr>
+<tr><td>Torso</td><td>350</td><td></td></tr>
 <tr><td>Tail</td><td>350</td><td></td></tr>
-<tr><td>結晶</td><td>10</td><td>Can be destroyed. Regenerates</td></tr>
+<tr><td>Crystal</td><td>10</td><td>Can be destroyed. Regenerates</td></tr>
 <tr><td></td><td>10</td><td></td></tr>
 <tr><td>Tail Cut</td><td>750</td><td><div>
 <span><em>若12</em>375</span>
@@ -125,9 +125,9 @@ When flipped during blue blood:<br>Reach the required HP threshold and deal enou
 <tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>突進</td><td></td><td>25</td><td>30</td><td>0</td><td></td></tr>
 <tr><td>尻尾突き刺し</td><td>Paralysis</td><td>70</td><td>50</td><td>40</td><td></td></tr>
 <tr><td>尻尾振り払い</td><td>Paralysis</td><td>60</td><td>30</td><td>30</td><td></td></tr>
-<tr><td>結晶液高圧噴射</td><td>結晶</td><td>30</td><td>30</td><td>0</td><td>スタミナ0</td></tr>
-<tr><td>結晶爆弾設置</td><td>結晶</td><td>100</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
-<tr><td>ジャンプ結晶投げ</td><td>結晶</td><td>150</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>結晶液高圧噴射</td><td>Crystal</td><td>30</td><td>30</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>結晶爆弾設置</td><td>Crystal</td><td>100</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>ジャンプ結晶投げ</td><td>Crystal</td><td>150</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
 <tr><td>回転攻撃</td><td></td><td>70</td><td>50</td><td>30</td><td>風圧大</td></tr>
 <tr><td>連続回転攻撃</td><td></td><td>60</td><td>50</td><td>30</td><td>風圧大、体質：黄、蒼、紅</td></tr>
 <tr><td>ジャンププレス</td><td>地震</td><td>70</td><td>50</td><td>30</td><td>風圧大、体質：蒼、紅</td></tr>

--- a/mons/aqura_ng.htm
+++ b/mons/aqura_ng.htm
@@ -7,7 +7,7 @@
 </head><body>
 <div id=monsname>Akura Vashimu[GR]</div><div id=tophosoku><a href="aqura_n.htm">Normal</a>／<a href="aqura_nh.htm">Henshu</a>／<a href="aqura_ni.htm">Zenith</a>／<a href="aqura_h.htm">Carves</a></div>
 <div id=hosoku>
-<span><em>Roar</em>Lg.</span><span><em>Wind Pres.</em>Lg.</span><span><em>Tremor</em>Weak</span><span><em>Pitfall T.</em>×</span><span><em>Shock T.</em>×</span><span><em>Flash</em>×</span><span><em>Sonic</em>×</span><span><em>Meat</em>×</span><span><em>Dung</em>×</span><span><em>特殊</em><a style="margin:0" href="aqura-memo.htm">肉質変化・部位破壊</a></span>
+<span><em>Roar</em>Lg.</span><span><em>Wind Pres.</em>Lg.</span><span><em>Tremor</em>Weak</span><span><em>Pitfall T.</em>×</span><span><em>Shock T.</em>×</span><span><em>Flash</em>×</span><span><em>Sonic</em>×</span><span><em>Meat</em>×</span><span><em>Dung</em>×</span><span><em>特殊</em><a style="margin:0" href="aqura-memo.htm">Hitzones変化・部位破壊</a></span>
 </div>
 <table id=izyo>
 <col class=c1><col class=c2><col class=c3><col class=c4><col class=c5>
@@ -107,54 +107,54 @@
 <img id=icon src="../img/monsicons/akuravashimu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>40</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>15</td><td>35</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>15</td><td>35</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>15</td><td>35</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>15</td><td>35</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>5</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>結晶</td><td>5</td><td>40</td><td>60</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(1段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
+<tr><td>Crystal</td><td>5</td><td>40</td><td>60</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(1段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>15</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>35</td><td>15</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>35</td><td>15</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>35</td><td>15</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>35</td><td>15</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>5</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>結晶</td><td>5</td><td>40</td><td>60</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(2段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
+<tr><td>Crystal</td><td>5</td><td>40</td><td>60</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(2段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>35</td><td>35</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>35</td><td>35</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>35</td><td>35</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>35</td><td>35</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>15</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>5</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>結晶</td><td>5</td><td>40</td><td>60</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(転倒中)</th></tr>
+<tr><td>Crystal</td><td>5</td><td>40</td><td>60</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(転倒中)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>60</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>50</td><td>50</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>50</td><td>50</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>50</td><td>50</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>50</td><td>50</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>60</td><td>20</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>50</td><td>50</td><td>80</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>20</td><td>60</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>結晶</td><td>20</td><td>50</td><td>80</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Crystal</td><td>20</td><td>50</td><td>80</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>550</td><td>１ stagger(s) required for first crystals、２ stagger(s) required for break<br>（※Only Impact and Cutting damage works）</td></tr>
-<tr><td>右爪</td><td>400</td><td></td></tr>
-<tr><td>左爪</td><td>400</td><td></td></tr>
+<tr><td>Right Claw</td><td>400</td><td></td></tr>
+<tr><td>Left Claw</td><td>400</td><td></td></tr>
 <tr><td>Leg</td><td>800</td><td>（※Doesn't accumulate while flipped）</td></tr>
-<tr><td>胴</td><td>850</td><td></td></tr>
+<tr><td>Torso</td><td>850</td><td></td></tr>
 <tr><td>Tail</td><td>650</td><td></td></tr>
-<tr><td>結晶</td><td>10</td><td>Can be destroyed. Regenerates</td></tr>
+<tr><td>Crystal</td><td>10</td><td>Can be destroyed. Regenerates</td></tr>
 <tr><td></td><td>10</td><td></td></tr>
 <tr><td>Tail Cut</td><td>900</td><td>When flipped during blue blood:<br>Reach the required HP threshold and deal enough Cutting damage<br>Can be severed starting from under 40% HP</td></tr>
 </table>
@@ -165,9 +165,9 @@
 <tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>突進</td><td></td><td>25</td><td>30</td><td>0</td><td></td></tr>
 <tr><td>尻尾突き刺し</td><td>Paralysis</td><td>70</td><td>50</td><td>40</td><td></td></tr>
 <tr><td>尻尾振り払い</td><td>Paralysis</td><td>60</td><td>30</td><td>30</td><td></td></tr>
-<tr><td>結晶液高圧噴射</td><td>結晶</td><td>30</td><td>30</td><td>0</td><td>スタミナ0</td></tr>
-<tr><td>結晶爆弾設置</td><td>結晶</td><td>100</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
-<tr><td>ジャンプ結晶投げ</td><td>結晶</td><td>150</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>結晶液高圧噴射</td><td>Crystal</td><td>30</td><td>30</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>結晶爆弾設置</td><td>Crystal</td><td>100</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>ジャンプ結晶投げ</td><td>Crystal</td><td>150</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
 <tr><td>回転攻撃</td><td></td><td>70</td><td>50</td><td>30</td><td>風圧大</td></tr>
 <tr><td>連続回転攻撃</td><td></td><td>60</td><td>50</td><td>30</td><td>風圧大、体質：黄、蒼、紅</td></tr>
 <tr><td>ジャンププレス</td><td>地震</td><td>70</td><td>50</td><td>30</td><td>風圧大、体質：蒼、紅</td></tr>

--- a/mons/aqura_nh.htm
+++ b/mons/aqura_nh.htm
@@ -7,7 +7,7 @@
 </head><body>
 <div id=monsname>Akura Vashimu[Henshu]</div><div id=tophosoku><a href="aqura_n.htm">Normal</a>／<a href="aqura_ng.htm">GR</a>／<a href="aqura_ni.htm">Zenith</a>／<a href="aqura_h.htm">Carves</a></div>
 <div id=hosoku>
-<span><em>Roar</em>Lg.</span><span><em>Wind Pres.</em>Lg.</span><span><em>Tremor</em>Weak</span><span><em>Pitfall T.</em>×</span><span><em>Shock T.</em>×</span><span><em>Flash</em>×</span><span><em>Sonic</em>×</span><span><em>Meat</em>×</span><span><em>Dung</em>×</span><span><em>特殊</em><a style="margin:0" href="aqura-memo.htm">肉質変化・部位破壊</a></span>
+<span><em>Roar</em>Lg.</span><span><em>Wind Pres.</em>Lg.</span><span><em>Tremor</em>Weak</span><span><em>Pitfall T.</em>×</span><span><em>Shock T.</em>×</span><span><em>Flash</em>×</span><span><em>Sonic</em>×</span><span><em>Meat</em>×</span><span><em>Dung</em>×</span><span><em>特殊</em><a style="margin:0" href="aqura-memo.htm">Hitzones変化・部位破壊</a></span>
 </div>
 <table id=izyo>
 <col class=c1><col class=c2><col class=c3><col class=c4><col class=c5>
@@ -66,54 +66,54 @@
 <img id=icon src="../img/monsicons/akuravashimu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>10</td><td>35</td><td>20</td><td>0</td><td>0</td><td>0</td><td>-5</td><td>15</td><td>150</td></tr>
-<tr><td>右爪</td><td>15</td><td>35</td><td>15</td><td>0</td><td>0</td><td>20</td><td>-10</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>15</td><td>35</td><td>15</td><td>20</td><td>0</td><td>0</td><td>-5</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>15</td><td>35</td><td>15</td><td>0</td><td>0</td><td>20</td><td>-10</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>15</td><td>35</td><td>15</td><td>20</td><td>0</td><td>0</td><td>-5</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>10</td><td>-10</td><td>0</td><td>-10</td><td>-10</td><td>-10</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>10</td><td>-10</td><td>0</td><td>-10</td><td>-5</td><td>-10</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>5</td><td>20</td><td>0</td><td>0</td><td>0</td><td>-10</td><td>0</td><td>0</td></tr>
-<tr><td>結晶</td><td>5</td><td>35</td><td>30</td><td>0</td><td>0</td><td>0</td><td>-5</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(1段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
+<tr><td>Crystal</td><td>5</td><td>35</td><td>30</td><td>0</td><td>0</td><td>0</td><td>-5</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(1段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>15</td><td>20</td><td>0</td><td>0</td><td>0</td><td>-5</td><td>20</td><td>150</td></tr>
-<tr><td>右爪</td><td>35</td><td>10</td><td>15</td><td>0</td><td>0</td><td>25</td><td>-5</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>35</td><td>10</td><td>15</td><td>25</td><td>0</td><td>0</td><td>-5</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>35</td><td>10</td><td>15</td><td>0</td><td>0</td><td>25</td><td>-5</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>35</td><td>10</td><td>15</td><td>25</td><td>0</td><td>0</td><td>-5</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>10</td><td>-10</td><td>0</td><td>-10</td><td>-5</td><td>-10</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>10</td><td>-15</td><td>0</td><td>-15</td><td>-5</td><td>-15</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>5</td><td>25</td><td>0</td><td>0</td><td>0</td><td>-5</td><td>0</td><td>0</td></tr>
-<tr><td>結晶</td><td>5</td><td>35</td><td>35</td><td>0</td><td>0</td><td>0</td><td>-5</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(2段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
+<tr><td>Crystal</td><td>5</td><td>35</td><td>35</td><td>0</td><td>0</td><td>0</td><td>-5</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(2段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>35</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>25</td><td>150</td></tr>
-<tr><td>右爪</td><td>35</td><td>35</td><td>30</td><td>0</td><td>0</td><td>30</td><td>-5</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>35</td><td>35</td><td>30</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>35</td><td>35</td><td>30</td><td>0</td><td>0</td><td>30</td><td>-5</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>35</td><td>35</td><td>30</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>10</td><td>-10</td><td>0</td><td>-10</td><td>-5</td><td>-10</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>10</td><td>-20</td><td>0</td><td>-20</td><td>0</td><td>-20</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>5</td><td>20</td><td>0</td><td>0</td><td>0</td><td>-5</td><td>0</td><td>0</td></tr>
-<tr><td>結晶</td><td>5</td><td>35</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(転倒中)</th></tr>
+<tr><td>Crystal</td><td>5</td><td>35</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(転倒中)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>55</td><td>30</td><td>5</td><td>20</td><td>5</td><td>0</td><td>5</td><td>150</td></tr>
-<tr><td>右爪</td><td>45</td><td>45</td><td>30</td><td>5</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>左爪</td><td>45</td><td>45</td><td>30</td><td>5</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>45</td><td>45</td><td>30</td><td>5</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>45</td><td>45</td><td>30</td><td>5</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>55</td><td>15</td><td>20</td><td>5</td><td>30</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Torso</td><td>45</td><td>45</td><td>70</td><td>5</td><td>30</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>15</td><td>40</td><td>5</td><td>30</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>結晶</td><td>15</td><td>45</td><td>70</td><td>5</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Crystal</td><td>15</td><td>45</td><td>70</td><td>5</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>250</td><td>１ stagger(s) required for first crystals、２ stagger(s) required for break<br>（※Only Impact and Cutting damage works）</td></tr>
-<tr><td>右爪</td><td>200</td><td></td></tr>
-<tr><td>左爪</td><td>200</td><td></td></tr>
+<tr><td>Right Claw</td><td>200</td><td></td></tr>
+<tr><td>Left Claw</td><td>200</td><td></td></tr>
 <tr><td>Leg</td><td>300</td><td>（※Doesn't accumulate while flipped）</td></tr>
-<tr><td>胴</td><td>350</td><td></td></tr>
+<tr><td>Torso</td><td>350</td><td></td></tr>
 <tr><td>Tail</td><td>350</td><td></td></tr>
-<tr><td>結晶</td><td>10</td><td>Can be destroyed. Regenerates</td></tr>
+<tr><td>Crystal</td><td>10</td><td>Can be destroyed. Regenerates</td></tr>
 <tr><td></td><td>10</td><td></td></tr>
 <tr><td>Tail Cut</td><td>750</td><td>When flipped during blue blood:<br>Reach the required HP threshold and deal enough Cutting damage<br>Can be severed starting from under 40% HP</td></tr>
 </table>
@@ -124,9 +124,9 @@
 <tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>突進</td><td></td><td>25</td><td>30</td><td>0</td><td></td></tr>
 <tr><td>尻尾突き刺し</td><td>Paralysis</td><td>70</td><td>50</td><td>40</td><td></td></tr>
 <tr><td>尻尾振り払い</td><td>Paralysis</td><td>60</td><td>30</td><td>30</td><td></td></tr>
-<tr><td>結晶液高圧噴射</td><td>結晶</td><td>30</td><td>30</td><td>0</td><td>スタミナ0</td></tr>
-<tr><td>結晶爆弾設置</td><td>結晶</td><td>100</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
-<tr><td>ジャンプ結晶投げ</td><td>結晶</td><td>150</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>結晶液高圧噴射</td><td>Crystal</td><td>30</td><td>30</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>結晶爆弾設置</td><td>Crystal</td><td>100</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>ジャンプ結晶投げ</td><td>Crystal</td><td>150</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
 <tr><td>回転攻撃</td><td></td><td>70</td><td>50</td><td>30</td><td>風圧大</td></tr>
 <tr><td>連続回転攻撃</td><td></td><td>60</td><td>50</td><td>30</td><td>風圧大、体質：黄、蒼、紅</td></tr>
 <tr><td>ジャンププレス</td><td>地震</td><td>70</td><td>50</td><td>30</td><td>風圧大、体質：蒼、紅</td></tr>

--- a/mons/aqura_ni.htm
+++ b/mons/aqura_ni.htm
@@ -7,7 +7,7 @@
 </head><body>
 <div id=monsname>Akura Vashimu[Zenith]</div><div id=tophosoku><a href="aqura_n.htm">Normal</a>／<a href="aqura_nh.htm">Henshu</a>／<a href="aqura_ng.htm">GR</a>／<a href="aqura_h.htm">Carves</a></div>
 <div id=hosoku>
-<span><em>Roar</em>Lg.</span><span><em>Wind Pres.</em>Lg.</span><span><em>Tremor</em>Weak</span><span><em>Pitfall T.</em>×</span><span><em>Shock T.</em>×</span><span><em>Flash</em>×</span><span><em>Sonic</em>×</span><span><em>Meat</em>×</span><span><em>Dung</em>×</span><span><em>特殊</em><a style="margin:0" href="aqura-memo.htm">肉質変化・部位破壊</a></span>
+<span><em>Roar</em>Lg.</span><span><em>Wind Pres.</em>Lg.</span><span><em>Tremor</em>Weak</span><span><em>Pitfall T.</em>×</span><span><em>Shock T.</em>×</span><span><em>Flash</em>×</span><span><em>Sonic</em>×</span><span><em>Meat</em>×</span><span><em>Dung</em>×</span><span><em>特殊</em><a style="margin:0" href="aqura-memo.htm">Hitzones変化・部位破壊</a></span>
 </div>
 <table id=izyo>
 <col class=c1><col class=c2><col class=c3><col class=c4><col class=c5>
@@ -96,52 +96,52 @@
 <img id=icon src="../img/monsicons/zenith_akuravashimu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>10</td><td>35</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>10</td><td>35</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>10</td><td>35</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>10</td><td>35</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>10</td><td>35</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>5</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>結晶</td><td>5</td><td>35</td><td>45</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(1段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
+<tr><td>Crystal</td><td>5</td><td>35</td><td>45</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(1段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>35</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>35</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>35</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>35</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>5</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>結晶</td><td>5</td><td>35</td><td>45</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(2段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
+<tr><td>Crystal</td><td>5</td><td>35</td><td>45</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(2段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>35</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>35</td><td>35</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>35</td><td>35</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>35</td><td>35</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>35</td><td>35</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>5</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>結晶</td><td>5</td><td>35</td><td>45</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(転倒中)</th></tr>
+<tr><td>Crystal</td><td>5</td><td>35</td><td>45</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(転倒中)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>35</td><td>35</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>35</td><td>35</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>35</td><td>35</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>35</td><td>35</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>35</td><td>15</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>35</td><td>35</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>20</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>結晶</td><td>15</td><td>35</td><td>45</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Crystal</td><td>15</td><td>35</td><td>45</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>775</td><td>１ stagger(s) required for first crystals、２ stagger(s) required for break<br>（※Only Impact and Cutting damage works）</td></tr>
-<tr><td>右爪</td><td>750</td><td></td></tr>
-<tr><td>左爪</td><td>750</td><td></td></tr>
+<tr><td>Right Claw</td><td>750</td><td></td></tr>
+<tr><td>Left Claw</td><td>750</td><td></td></tr>
 <tr><td>Leg</td><td>1200</td><td>（※Doesn't accumulate while flipped）</td></tr>
-<tr><td>胴</td><td>1500</td><td></td></tr>
+<tr><td>Torso</td><td>1500</td><td></td></tr>
 <tr><td>Tail</td><td>1250</td><td></td></tr>
 <tr><td>Tail Cut</td><td>1400</td><td>When flipped during blue blood:<br>Reach the required HP threshold and deal enough Cutting damage<br>Can be severed starting from under 40% HP</td></tr>
 </table>
@@ -152,9 +152,9 @@
 <tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>突進</td><td></td><td>25</td><td>30</td><td>0</td><td></td></tr>
 <tr><td>尻尾突き刺し</td><td>Paralysis</td><td>70</td><td>50</td><td>40</td><td></td></tr>
 <tr><td>尻尾振り払い</td><td>Paralysis</td><td>60</td><td>30</td><td>30</td><td></td></tr>
-<tr><td>結晶液高圧噴射</td><td>結晶</td><td>30</td><td>30</td><td>0</td><td>スタミナ0</td></tr>
-<tr><td>結晶爆弾設置</td><td>結晶</td><td>100</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
-<tr><td>ジャンプ結晶投げ</td><td>結晶</td><td>150</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>結晶液高圧噴射</td><td>Crystal</td><td>30</td><td>30</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>結晶爆弾設置</td><td>Crystal</td><td>100</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>ジャンプ結晶投げ</td><td>Crystal</td><td>150</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
 <tr><td>回転攻撃</td><td></td><td>70</td><td>50</td><td>30</td><td>風圧大</td></tr>
 <tr><td>連続回転攻撃</td><td></td><td>60</td><td>50</td><td>30</td><td>風圧大、体質：黄、蒼、紅</td></tr>
 <tr><td>ジャンププレス</td><td>地震</td><td>70</td><td>50</td><td>30</td><td>風圧大、体質：蒼、紅</td></tr>

--- a/mons/aquraj_n.htm
+++ b/mons/aquraj_n.htm
@@ -7,7 +7,7 @@
 </head><body>
 <div id=monsname>Akura Jebia</div><div id=tophosoku><a href="aquraj_nh.htm">Kishu</a>／<a href="aquraj_ng.htm">GR</a>／<a href="aquraj_h.htm">Carves</a></div>
 <div id=hosoku>
-<span><em>Roar</em>Lg.</span><span><em>Wind Pres.</em>Lg.</span><span><em>Tremor</em>Weak</span><span><em>Pitfall T.</em>×</span><span><em>Shock T.</em>×</span><span><em>Flash</em>×</span><span><em>Sonic</em>×</span><span><em>Meat</em>×</span><span><em>Dung</em>×</span><span><em>特殊</em><a style="margin:0" href="aquraj-memo.htm">肉質変化・部位破壊</a></span>
+<span><em>Roar</em>Lg.</span><span><em>Wind Pres.</em>Lg.</span><span><em>Tremor</em>Weak</span><span><em>Pitfall T.</em>×</span><span><em>Shock T.</em>×</span><span><em>Flash</em>×</span><span><em>Sonic</em>×</span><span><em>Meat</em>×</span><span><em>Dung</em>×</span><span><em>特殊</em><a style="margin:0" href="aquraj-memo.htm">Hitzones変化・部位破壊</a></span>
 </div>
 <table id=izyo>
 <col class=c1><col class=c2><col class=c3><col class=c4><col class=c5>
@@ -57,55 +57,55 @@
 <img id=icon src="../img/monsicons/akurajebia.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>5</td><td>40</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>5</td><td>35</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>5</td><td>35</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>5</td><td>35</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>5</td><td>35</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>30</td><td>25</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>15</td><td>5</td><td>30</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
-<tr><td>結晶</td><td>5</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(1段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
+<tr><td>Crystal</td><td>5</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(1段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>10</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>35</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>35</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>35</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>35</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>30</td><td>25</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>15</td><td>35</td><td>30</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
-<tr><td>結晶</td><td>5</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(2段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
+<tr><td>Crystal</td><td>5</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(2段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>35</td><td>35</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>35</td><td>35</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>35</td><td>35</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>35</td><td>35</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>30</td><td>25</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>15</td><td>30</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
-<tr><td>結晶</td><td>5</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(転倒中)</th></tr>
+<tr><td>Crystal</td><td>5</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(転倒中)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>60</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>50</td><td>50</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>50</td><td>50</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>50</td><td>50</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>50</td><td>50</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>60</td><td>20</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>50</td><td>50</td><td>80</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>15</td><td>15</td><td>50</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
-<tr><td>結晶</td><td>20</td><td>50</td><td>80</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Crystal</td><td>20</td><td>50</td><td>80</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>300</td><td>１ stagger(s) required for first crystals、２ stagger(s) required for break<br>（※Only Impact and Cutting damage works）</td></tr>
-<tr><td>右爪</td><td>200</td><td></td></tr>
-<tr><td>左爪</td><td>250</td><td></td></tr>
+<tr><td>Right Claw</td><td>200</td><td></td></tr>
+<tr><td>Left Claw</td><td>250</td><td></td></tr>
 <tr><td>Leg</td><td>600</td><td><div>
 <span><em>若12</em>350</span>
 </div>
 （※Doesn't accumulate while flipped）</td></tr>
-<tr><td>胴</td><td>600</td><td><div>
+<tr><td>Torso</td><td>600</td><td><div>
 <span><em>若12</em>350</span>
 </div>
 </td></tr>
@@ -113,8 +113,8 @@
 <span><em>若12</em>350</span>
 </div>
 </td></tr>
-<tr><td>結晶</td><td>5</td><td>Can be destroyed. Regenerates</td></tr>
-<tr><td>切断面結晶</td><td>5</td><td><div>
+<tr><td>Crystal</td><td>5</td><td>Can be destroyed. Regenerates</td></tr>
+<tr><td>Tail Stump Crystal</td><td>5</td><td><div>
 <span><em>若12</em>25</span>
 </div>
 Can be destroyed. Regenerates</td></tr>
@@ -130,18 +130,18 @@ When flipped during blue blood:<br>Deal enough Cutting & Impact damage<br>Sever 
 <tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>突進</td><td></td><td>25</td><td>30</td><td>0</td><td></td></tr>
 <tr><td>尻尾突き刺し</td><td>Paralysis</td><td>70</td><td>50</td><td>40</td><td></td></tr>
 <tr><td>尻尾振り払い</td><td>Paralysis</td><td>60</td><td>30</td><td>30</td><td></td></tr>
-<tr><td>結晶液高圧噴射</td><td>結晶</td><td>30</td><td>30</td><td>0</td><td>スタミナ0</td></tr>
-<tr><td>結晶爆弾設置</td><td>結晶</td><td>100</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
-<tr><td>ジャンプ結晶投げ</td><td>結晶</td><td>150</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>結晶液高圧噴射</td><td>Crystal</td><td>30</td><td>30</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>結晶爆弾設置</td><td>Crystal</td><td>100</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>ジャンプ結晶投げ</td><td>Crystal</td><td>150</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
 <tr><td>回転攻撃</td><td></td><td>70</td><td>50</td><td>30</td><td>風圧大</td></tr>
 <tr><td>連続回転攻撃</td><td></td><td>60</td><td>50</td><td>30</td><td>風圧大、体質：黄、蒼、紅</td></tr>
 <tr><td>ジャンププレス</td><td>地震</td><td>70</td><td>50</td><td>30</td><td>風圧大、体質：蒼、紅</td></tr>
 <tr><td>爪振り回し</td><td></td><td>100</td><td>50</td><td>0</td><td>体質：紅</td></tr>
 <tr><td>側面爪攻撃</td><td></td><td>60</td><td>50</td><td>0</td><td></td></tr>
 <tr><td>小ジャンプ攻撃</td><td></td><td>75</td><td>50</td><td>0</td><td>風圧大</td></tr>
-<tr><td>結晶水平投射</td><td>結晶</td><td>80</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
-<tr><td>赤結晶爆弾設置</td><td>結晶</td><td>225</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
-<tr><td>結晶拡散投射</td><td>結晶</td><td>80</td><td>50</td><td>0</td><td>スタミナ0、体質：紅</td></tr>
+<tr><td>結晶水平投射</td><td>Crystal</td><td>80</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>赤結晶爆弾設置</td><td>Crystal</td><td>225</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>結晶拡散投射</td><td>Crystal</td><td>80</td><td>50</td><td>0</td><td>スタミナ0、体質：紅</td></tr>
 <tr><td>バインドボイス【大】</td><td></td><td>0</td><td>40</td><td>0</td><td></td></tr>
 <tr><td>尻尾暴れ</td><td></td><td></td><td></td><td></td><td>３部位破壊時ホストのみ発生</td></tr>
 <tr><td>結晶液浴び</td><td></td><td></td><td></td><td></td><td>破壊状態を１段階戻し、800回復</td></tr>

--- a/mons/aquraj_ng.htm
+++ b/mons/aquraj_ng.htm
@@ -7,7 +7,7 @@
 </head><body>
 <div id=monsname>Akura Jebia[GR]</div><div id=tophosoku><a href="aquraj_n.htm">Normal</a>／<a href="aquraj_nh.htm">Kishu</a>／<a href="aquraj_h.htm">Carves</a></div>
 <div id=hosoku>
-<span><em>Roar</em>Lg.</span><span><em>Wind Pres.</em>Lg.</span><span><em>Tremor</em>Weak</span><span><em>Pitfall T.</em>×</span><span><em>Shock T.</em>×</span><span><em>Flash</em>×</span><span><em>Sonic</em>×</span><span><em>Meat</em>×</span><span><em>Dung</em>×</span><span><em>特殊</em><a style="margin:0" href="aquraj-memo.htm">肉質変化・部位破壊</a></span>
+<span><em>Roar</em>Lg.</span><span><em>Wind Pres.</em>Lg.</span><span><em>Tremor</em>Weak</span><span><em>Pitfall T.</em>×</span><span><em>Shock T.</em>×</span><span><em>Flash</em>×</span><span><em>Sonic</em>×</span><span><em>Meat</em>×</span><span><em>Dung</em>×</span><span><em>特殊</em><a style="margin:0" href="aquraj-memo.htm">Hitzones変化・部位破壊</a></span>
 </div>
 <table id=izyo>
 <col class=c1><col class=c2><col class=c3><col class=c4><col class=c5>
@@ -87,55 +87,55 @@
 <img id=icon src="../img/monsicons/akurajebia.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>10</td><td>40</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>10</td><td>40</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>10</td><td>40</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>10</td><td>40</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>10</td><td>40</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>30</td><td>35</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>20</td><td>5</td><td>25</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
-<tr><td>結晶</td><td>5</td><td>40</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(1段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
+<tr><td>Crystal</td><td>5</td><td>40</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(1段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>15</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>50</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>50</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>50</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>50</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>30</td><td>35</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>5</td><td>50</td><td>30</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
-<tr><td>結晶</td><td>5</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(2段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
+<tr><td>Crystal</td><td>5</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(2段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>40</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>40</td><td>40</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>40</td><td>40</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>40</td><td>40</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>40</td><td>40</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>30</td><td>35</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>5</td><td>25</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
-<tr><td>結晶</td><td>10</td><td>45</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(転倒中)</th></tr>
+<tr><td>Crystal</td><td>10</td><td>45</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(転倒中)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>55</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>45</td><td>45</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>45</td><td>45</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>45</td><td>45</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>45</td><td>45</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>40</td><td>15</td><td>25</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>35</td><td>35</td><td>80</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>20</td><td>20</td><td>40</td><td>30</td><td>30</td><td>30</td><td>30</td><td>30</td><td>0</td></tr>
-<tr><td>結晶</td><td>20</td><td>40</td><td>70</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Crystal</td><td>20</td><td>40</td><td>70</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>500</td><td>１ stagger(s) required for first crystals、２ stagger(s) required for break<br>（※Only Impact and Cutting damage works）</td></tr>
-<tr><td>右爪</td><td>400</td><td></td></tr>
-<tr><td>左爪</td><td>450</td><td></td></tr>
+<tr><td>Right Claw</td><td>400</td><td></td></tr>
+<tr><td>Left Claw</td><td>450</td><td></td></tr>
 <tr><td>Leg</td><td>700</td><td>（※Doesn't accumulate while flipped）</td></tr>
-<tr><td>胴</td><td>700</td><td></td></tr>
+<tr><td>Torso</td><td>700</td><td></td></tr>
 <tr><td>Tail</td><td>700</td><td></td></tr>
-<tr><td>結晶</td><td>2</td><td>Can be destroyed. Regenerates</td></tr>
-<tr><td>切断面結晶</td><td>5</td><td>Can be destroyed. Regenerates</td></tr>
+<tr><td>Crystal</td><td>2</td><td>Can be destroyed. Regenerates</td></tr>
+<tr><td>Tail Stump Crystal</td><td>5</td><td>Can be destroyed. Regenerates</td></tr>
 <tr><td>Tail Cut</td><td>800</td><td>When flipped during blue blood:<br>Deal enough Cutting & Impact damage<br>Sever using a Cutting attack<br>Can be severed starting from under 40% HP<br>Step 1: Deal 400 Impact Damage (Hitzone Set 1)<br>Step 2: Deal 400 Cutting Damage (Hitzone Set 2)</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/akurajebia.png" width="400"/>
@@ -145,18 +145,18 @@
 <tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>突進</td><td></td><td>25</td><td>30</td><td>0</td><td></td></tr>
 <tr><td>尻尾突き刺し</td><td>Paralysis</td><td>70</td><td>50</td><td>40</td><td></td></tr>
 <tr><td>尻尾振り払い</td><td>Paralysis</td><td>60</td><td>30</td><td>30</td><td></td></tr>
-<tr><td>結晶液高圧噴射</td><td>結晶</td><td>30</td><td>30</td><td>0</td><td>スタミナ0</td></tr>
-<tr><td>結晶爆弾設置</td><td>結晶</td><td>100</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
-<tr><td>ジャンプ結晶投げ</td><td>結晶</td><td>150</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>結晶液高圧噴射</td><td>Crystal</td><td>30</td><td>30</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>結晶爆弾設置</td><td>Crystal</td><td>100</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>ジャンプ結晶投げ</td><td>Crystal</td><td>150</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
 <tr><td>回転攻撃</td><td></td><td>70</td><td>50</td><td>30</td><td>風圧大</td></tr>
 <tr><td>連続回転攻撃</td><td></td><td>60</td><td>50</td><td>30</td><td>風圧大、体質：黄、蒼、紅</td></tr>
 <tr><td>ジャンププレス</td><td>地震</td><td>70</td><td>50</td><td>30</td><td>風圧大、体質：蒼、紅</td></tr>
 <tr><td>爪振り回し</td><td></td><td>100</td><td>50</td><td>0</td><td>体質：紅</td></tr>
 <tr><td>側面爪攻撃</td><td></td><td>60</td><td>50</td><td>0</td><td></td></tr>
 <tr><td>小ジャンプ攻撃</td><td></td><td>75</td><td>50</td><td>0</td><td>風圧大</td></tr>
-<tr><td>結晶水平投射</td><td>結晶</td><td>80</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
-<tr><td>赤結晶爆弾設置</td><td>結晶</td><td>225</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
-<tr><td>結晶拡散投射</td><td>結晶</td><td>80</td><td>50</td><td>0</td><td>スタミナ0、体質：紅</td></tr>
+<tr><td>結晶水平投射</td><td>Crystal</td><td>80</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>赤結晶爆弾設置</td><td>Crystal</td><td>225</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>結晶拡散投射</td><td>Crystal</td><td>80</td><td>50</td><td>0</td><td>スタミナ0、体質：紅</td></tr>
 <tr><td>バインドボイス【大】</td><td></td><td>0</td><td>40</td><td>0</td><td></td></tr>
 <tr><td>尻尾暴れ</td><td></td><td></td><td></td><td></td><td>３部位破壊時ホストのみ発生</td></tr>
 <tr><td>結晶液浴び</td><td></td><td></td><td></td><td></td><td>破壊状態を１段階戻し、800回復</td></tr>

--- a/mons/aquraj_nh.htm
+++ b/mons/aquraj_nh.htm
@@ -7,7 +7,7 @@
 </head><body>
 <div id=monsname>Akura Jebia[Kishu]</div><div id=tophosoku><a href="aquraj_n.htm">Normal</a>／<a href="aquraj_ng.htm">GR</a>／<a href="aquraj_h.htm">Carves</a></div>
 <div id=hosoku>
-<span><em>Roar</em>Lg.</span><span><em>Wind Pres.</em>Lg.</span><span><em>Tremor</em>Weak</span><span><em>Pitfall T.</em>×</span><span><em>Shock T.</em>×</span><span><em>Flash</em>×</span><span><em>Sonic</em>×</span><span><em>Meat</em>×</span><span><em>Dung</em>×</span><span><em>特殊</em><a style="margin:0" href="aquraj-memo.htm">肉質変化・部位破壊</a></span>
+<span><em>Roar</em>Lg.</span><span><em>Wind Pres.</em>Lg.</span><span><em>Tremor</em>Weak</span><span><em>Pitfall T.</em>×</span><span><em>Shock T.</em>×</span><span><em>Flash</em>×</span><span><em>Sonic</em>×</span><span><em>Meat</em>×</span><span><em>Dung</em>×</span><span><em>特殊</em><a style="margin:0" href="aquraj-memo.htm">Hitzones変化・部位破壊</a></span>
 </div>
 <table id=izyo>
 <col class=c1><col class=c2><col class=c3><col class=c4><col class=c5>
@@ -76,55 +76,55 @@
 <img id=icon src="../img/monsicons/akurajebia.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>10</td><td>40</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>10</td><td>40</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>10</td><td>40</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>10</td><td>40</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>10</td><td>40</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>20</td><td>5</td><td>25</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
-<tr><td>結晶</td><td>5</td><td>40</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(1段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
+<tr><td>Crystal</td><td>5</td><td>40</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(1段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>15</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>40</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>40</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>40</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>40</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>5</td><td>50</td><td>30</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
-<tr><td>結晶</td><td>5</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(2段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
+<tr><td>Crystal</td><td>5</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(2段破壊<small>[※破壊した部位のみ変化]</small>)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>40</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>40</td><td>40</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>40</td><td>40</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>40</td><td>40</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>40</td><td>40</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>10</td><td>25</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
-<tr><td>結晶</td><td>10</td><td>45</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(転倒中)</th></tr>
+<tr><td>Crystal</td><td>10</td><td>45</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(転倒中)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>55</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
-<tr><td>右爪</td><td>45</td><td>45</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左爪</td><td>45</td><td>45</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>45</td><td>45</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>45</td><td>45</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>55</td><td>15</td><td>25</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>45</td><td>45</td><td>80</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>20</td><td>20</td><td>40</td><td>30</td><td>30</td><td>30</td><td>30</td><td>30</td><td>0</td></tr>
-<tr><td>結晶</td><td>20</td><td>50</td><td>70</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Crystal</td><td>20</td><td>50</td><td>70</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>350</td><td>１ stagger(s) required for first crystals、２ stagger(s) required for break<br>（※Only Impact and Cutting damage works）</td></tr>
-<tr><td>右爪</td><td>200</td><td></td></tr>
-<tr><td>左爪</td><td>250</td><td></td></tr>
+<tr><td>Right Claw</td><td>200</td><td></td></tr>
+<tr><td>Left Claw</td><td>250</td><td></td></tr>
 <tr><td>Leg</td><td>700</td><td>（※Doesn't accumulate while flipped）</td></tr>
-<tr><td>胴</td><td>700</td><td></td></tr>
+<tr><td>Torso</td><td>700</td><td></td></tr>
 <tr><td>Tail</td><td>700</td><td></td></tr>
-<tr><td>結晶</td><td>5</td><td>Can be destroyed. Regenerates</td></tr>
-<tr><td>切断面結晶</td><td>5</td><td>Can be destroyed. Regenerates</td></tr>
+<tr><td>Crystal</td><td>5</td><td>Can be destroyed. Regenerates</td></tr>
+<tr><td>Tail Stump Crystal</td><td>5</td><td>Can be destroyed. Regenerates</td></tr>
 <tr><td>Tail Cut</td><td>800</td><td>When flipped during blue blood:<br>Deal enough Cutting & Impact damage<br>Sever using a Cutting attack<br>Can be severed starting from under 40% HP<br>Step 1: Deal 400 Impact Damage (Hitzone Set 1)<br>Step 2: Deal 400 Cutting Damage (Hitzone Set 2)</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/akurajebia.png" width="400"/>
@@ -134,18 +134,18 @@
 <tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>突進</td><td></td><td>25</td><td>30</td><td>0</td><td></td></tr>
 <tr><td>尻尾突き刺し</td><td>Paralysis</td><td>70</td><td>50</td><td>40</td><td></td></tr>
 <tr><td>尻尾振り払い</td><td>Paralysis</td><td>60</td><td>30</td><td>30</td><td></td></tr>
-<tr><td>結晶液高圧噴射</td><td>結晶</td><td>30</td><td>30</td><td>0</td><td>スタミナ0</td></tr>
-<tr><td>結晶爆弾設置</td><td>結晶</td><td>100</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
-<tr><td>ジャンプ結晶投げ</td><td>結晶</td><td>150</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>結晶液高圧噴射</td><td>Crystal</td><td>30</td><td>30</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>結晶爆弾設置</td><td>Crystal</td><td>100</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>ジャンプ結晶投げ</td><td>Crystal</td><td>150</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
 <tr><td>回転攻撃</td><td></td><td>70</td><td>50</td><td>30</td><td>風圧大</td></tr>
 <tr><td>連続回転攻撃</td><td></td><td>60</td><td>50</td><td>30</td><td>風圧大、体質：黄、蒼、紅</td></tr>
 <tr><td>ジャンププレス</td><td>地震</td><td>70</td><td>50</td><td>30</td><td>風圧大、体質：蒼、紅</td></tr>
 <tr><td>爪振り回し</td><td></td><td>100</td><td>50</td><td>0</td><td>体質：紅</td></tr>
 <tr><td>側面爪攻撃</td><td></td><td>60</td><td>50</td><td>0</td><td></td></tr>
 <tr><td>小ジャンプ攻撃</td><td></td><td>75</td><td>50</td><td>0</td><td>風圧大</td></tr>
-<tr><td>結晶水平投射</td><td>結晶</td><td>80</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
-<tr><td>赤結晶爆弾設置</td><td>結晶</td><td>225</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
-<tr><td>結晶拡散投射</td><td>結晶</td><td>80</td><td>50</td><td>0</td><td>スタミナ0、体質：紅</td></tr>
+<tr><td>結晶水平投射</td><td>Crystal</td><td>80</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>赤結晶爆弾設置</td><td>Crystal</td><td>225</td><td>50</td><td>0</td><td>スタミナ0</td></tr>
+<tr><td>結晶拡散投射</td><td>Crystal</td><td>80</td><td>50</td><td>0</td><td>スタミナ0、体質：紅</td></tr>
 <tr><td>バインドボイス【大】</td><td></td><td>0</td><td>40</td><td>0</td><td></td></tr>
 <tr><td>尻尾暴れ</td><td></td><td></td><td></td><td></td><td>３部位破壊時ホストのみ発生</td></tr>
 <tr><td>結晶液浴び</td><td></td><td></td><td></td><td></td><td>破壊状態を１段階戻し、800回復</td></tr>

--- a/mons/babakonga_n.htm
+++ b/mons/babakonga_n.htm
@@ -81,17 +81,17 @@
 <img id=icon src="../img/monsicons/congalala.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>65</td><td>75</td><td>60</td><td>30</td><td>10</td><td>10</td><td>0</td><td>15</td><td>50</td></tr>
-<tr><td>Fore Leg</td><td>45</td><td>40</td><td>35</td><td>15</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>45</td><td>40</td><td>35</td><td>15</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>45</td><td>40</td><td>35</td><td>15</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Torso</td><td>40</td><td>40</td><td>40</td><td>18</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>30</td><td>25</td><td>15</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info(Chest Puffed)</th></tr>
+<tr class=l><th colspan=10>Hitzones(Chest Puffed)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>65</td><td>75</td><td>60</td><td>30</td><td>10</td><td>10</td><td>0</td><td>5</td><td>50</td></tr>
-<tr><td>Fore Leg</td><td>65</td><td>15</td><td>15</td><td>15</td><td>10</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>65</td><td>15</td><td>15</td><td>15</td><td>10</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>65</td><td>15</td><td>15</td><td>15</td><td>10</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Torso</td><td>5</td><td>5</td><td>5</td><td>18</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>15</td><td>15</td><td>10</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
@@ -101,8 +101,8 @@
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>200</td><td>2nd time destroys head</td></tr>
-<tr><td>Right Foot</td><td>150</td><td>2nd time destroys left claw（Reward for destroying both）</td></tr>
-<tr><td>Left Foot</td><td>150</td><td><div>
+<tr><td>Right Leg</td><td>150</td><td>2nd time destroys left claw（Reward for destroying both）</td></tr>
+<tr><td>Left Leg</td><td>150</td><td><div>
 <span><em>12</em>203</span><span><em>13</em>207</span><span><em>14</em>211</span><span><em>15</em>215</span><span><em>16</em>219</span>
 </div>
 2nd time destroys right claw</td></tr>

--- a/mons/babakonga_ng.htm
+++ b/mons/babakonga_ng.htm
@@ -122,17 +122,17 @@
 <img id=icon src="../img/monsicons/congalala.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>55</td><td>40</td><td>30</td><td>10</td><td>10</td><td>0</td><td>15</td><td>50</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>25</td><td>25</td><td>15</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>25</td><td>25</td><td>15</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>25</td><td>25</td><td>15</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
 <tr><td>Torso</td><td>25</td><td>25</td><td>15</td><td>50</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>20</td><td>30</td><td>15</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info(Chest Puffed)</th></tr>
+<tr class=l><th colspan=10>Hitzones(Chest Puffed)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>55</td><td>40</td><td>30</td><td>10</td><td>10</td><td>0</td><td>5</td><td>50</td></tr>
-<tr><td>Fore Leg</td><td>45</td><td>15</td><td>15</td><td>15</td><td>10</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>45</td><td>15</td><td>15</td><td>15</td><td>10</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>45</td><td>15</td><td>15</td><td>15</td><td>10</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Torso</td><td>5</td><td>5</td><td>5</td><td>50</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>20</td><td>20</td><td>20</td><td>15</td><td>10</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
@@ -142,8 +142,8 @@
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>400</td><td>2nd time destroys head</td></tr>
-<tr><td>Right Foot</td><td>300</td><td>2nd time destroys left claw（Reward for destroying both）</td></tr>
-<tr><td>Left Foot</td><td>300</td><td>2nd time destroys right claw</td></tr>
+<tr><td>Right Leg</td><td>300</td><td>2nd time destroys left claw（Reward for destroying both）</td></tr>
+<tr><td>Left Leg</td><td>300</td><td>2nd time destroys right claw</td></tr>
 <tr><td>Torso</td><td>380</td><td></td></tr>
 <tr><td>Tail</td><td>340</td><td>Drops Item, 2nd time</td></tr>
 </table>

--- a/mons/babakonga_nh.htm
+++ b/mons/babakonga_nh.htm
@@ -77,17 +77,17 @@
 <img id=icon src="../img/monsicons/congalala.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>50</td><td>50</td><td>10</td><td>0</td><td>0</td><td>10</td><td>20</td><td>50</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>55</td><td>40</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>55</td><td>40</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>40</td><td>35</td><td>30</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>35</td><td>35</td><td>35</td><td>5</td><td>0</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>35</td><td>30</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info(Chest Puffed)</th></tr>
+<tr class=l><th colspan=10>Hitzones(Chest Puffed)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>85</td><td>85</td><td>80</td><td>10</td><td>0</td><td>0</td><td>10</td><td>20</td><td>50</td></tr>
-<tr><td>Fore Leg</td><td>85</td><td>20</td><td>35</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>85</td><td>20</td><td>35</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>85</td><td>20</td><td>20</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>5</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>35</td><td>20</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
@@ -97,8 +97,8 @@
 <tr class=l><th colspan=3>Part Break Tolerance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>200</td><td>2nd time destroys head</td></tr>
-<tr><td>Right Foot</td><td>150</td><td>2nd time destroys left claw（Reward for destroying both）</td></tr>
-<tr><td>Left Foot</td><td>150</td><td>2nd time destroys right claw</td></tr>
+<tr><td>Right Leg</td><td>150</td><td>2nd time destroys left claw（Reward for destroying both）</td></tr>
+<tr><td>Left Leg</td><td>150</td><td>2nd time destroys right claw</td></tr>
 <tr><td>Torso</td><td>180</td><td></td></tr>
 <tr><td>Tail</td><td>140</td><td>Drops Item, 2nd time</td></tr>
 </table>

--- a/mons/bal_ng.htm
+++ b/mons/bal_ng.htm
@@ -103,40 +103,40 @@
 <img id=icon src="../img/monsicons/baruragaru.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>25</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td><td>100</td></tr>
-<tr><td>舌</td><td>50</td><td>50</td><td>50</td><td>0</td><td>0</td><td>20</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Tongue</td><td>50</td><td>50</td><td>50</td><td>0</td><td>0</td><td>20</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Neck</td><td>40</td><td>30</td><td>20</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>25</td><td>30</td><td>0</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>20</td><td>15</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>20</td><td>15</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>25</td><td>15</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>20</td><td>40</td><td>0</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(吸血中？)</th></tr>
+<tr class=l><th colspan=10>Hitzones(吸血中？)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>50</td><td>35</td><td>25</td><td>0</td><td>10</td><td>15</td><td>0</td><td>100</td></tr>
-<tr><td>舌</td><td>60</td><td>60</td><td>60</td><td>35</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Tongue</td><td>60</td><td>60</td><td>60</td><td>35</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Neck</td><td>50</td><td>40</td><td>30</td><td>25</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>30</td><td>35</td><td>40</td><td>20</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>30</td><td>25</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>30</td><td>25</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>35</td><td>25</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>30</td><td>50</td><td>30</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(毒麻痺状態)</th></tr>
+<tr class=l><th colspan=10>Hitzones(毒麻痺状態)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>25</td><td>15</td><td>0</td><td>10</td><td>10</td><td>0</td><td>100</td></tr>
-<tr><td>舌</td><td>50</td><td>50</td><td>50</td><td>20</td><td>0</td><td>20</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Tongue</td><td>50</td><td>50</td><td>50</td><td>20</td><td>0</td><td>20</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Neck</td><td>40</td><td>30</td><td>20</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>25</td><td>30</td><td>5</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>20</td><td>15</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>20</td><td>15</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>25</td><td>15</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>20</td><td>40</td><td>10</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(粘液状態？)</th></tr>
+<tr class=l><th colspan=10>Hitzones(粘液状態？)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>25</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td><td>100</td></tr>
-<tr><td>舌</td><td>50</td><td>50</td><td>50</td><td>20</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Tongue</td><td>50</td><td>50</td><td>50</td><td>20</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Neck</td><td>40</td><td>30</td><td>20</td><td>10</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>25</td><td>30</td><td>5</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>20</td><td>15</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>20</td><td>15</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>25</td><td>15</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>20</td><td>40</td><td>10</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
 </table>
@@ -145,10 +145,10 @@
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>900</td><td>２ stagger(s) required</td></tr>
-<tr><td>舌</td><td>1200</td><td>１ stagger(s) required</td></tr>
+<tr><td>Tongue</td><td>1200</td><td>１ stagger(s) required</td></tr>
 <tr><td>Torso</td><td>1300</td><td></td></tr>
-<tr><td>左前脚</td><td>1000</td><td>１ stagger(s) required</td></tr>
-<tr><td>右前脚</td><td>1000</td><td>１ stagger(s) required</td></tr>
+<tr><td>Left Foreleg</td><td>1000</td><td>１ stagger(s) required</td></tr>
+<tr><td>Right Foreleg</td><td>1000</td><td>１ stagger(s) required</td></tr>
 <tr><td>Hind Leg</td><td>1100</td><td></td></tr>
 <tr><td>Back</td><td>600</td><td>１ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>750</td><td>１ stagger(s) required</td></tr>

--- a/mons/bal_nh.htm
+++ b/mons/bal_nh.htm
@@ -71,40 +71,40 @@
 <img id=icon src="../img/monsicons/baruragaru.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>25</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td><td>100</td></tr>
-<tr><td>舌</td><td>50</td><td>50</td><td>50</td><td>0</td><td>0</td><td>20</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Tongue</td><td>50</td><td>50</td><td>50</td><td>0</td><td>0</td><td>20</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Neck</td><td>40</td><td>30</td><td>20</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>25</td><td>30</td><td>0</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>20</td><td>15</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>20</td><td>15</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>25</td><td>15</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>20</td><td>40</td><td>0</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(吸血中？)</th></tr>
+<tr class=l><th colspan=10>Hitzones(吸血中？)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>50</td><td>35</td><td>25</td><td>0</td><td>10</td><td>15</td><td>0</td><td>100</td></tr>
-<tr><td>舌</td><td>60</td><td>60</td><td>60</td><td>35</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Tongue</td><td>60</td><td>60</td><td>60</td><td>35</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Neck</td><td>50</td><td>40</td><td>30</td><td>25</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>30</td><td>35</td><td>40</td><td>20</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>30</td><td>25</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>30</td><td>25</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>35</td><td>25</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>30</td><td>50</td><td>30</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(毒麻痺状態)</th></tr>
+<tr class=l><th colspan=10>Hitzones(毒麻痺状態)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>25</td><td>15</td><td>0</td><td>10</td><td>10</td><td>0</td><td>100</td></tr>
-<tr><td>舌</td><td>50</td><td>50</td><td>50</td><td>20</td><td>0</td><td>20</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Tongue</td><td>50</td><td>50</td><td>50</td><td>20</td><td>0</td><td>20</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Neck</td><td>40</td><td>30</td><td>20</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>25</td><td>30</td><td>5</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>20</td><td>15</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>20</td><td>15</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>25</td><td>15</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>20</td><td>40</td><td>10</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(粘液状態？)</th></tr>
+<tr class=l><th colspan=10>Hitzones(粘液状態？)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>25</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td><td>100</td></tr>
-<tr><td>舌</td><td>50</td><td>50</td><td>50</td><td>20</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Tongue</td><td>50</td><td>50</td><td>50</td><td>20</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Neck</td><td>40</td><td>30</td><td>20</td><td>10</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>25</td><td>30</td><td>5</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>20</td><td>15</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>20</td><td>15</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>25</td><td>15</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>20</td><td>40</td><td>10</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
 </table>
@@ -113,10 +113,10 @@
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>450</td><td>２ stagger(s) required</td></tr>
-<tr><td>舌</td><td>600</td><td>１ stagger(s) required</td></tr>
+<tr><td>Tongue</td><td>600</td><td>１ stagger(s) required</td></tr>
 <tr><td>Torso</td><td>700</td><td></td></tr>
-<tr><td>左前脚</td><td>500</td><td>１ stagger(s) required</td></tr>
-<tr><td>右前脚</td><td>500</td><td>１ stagger(s) required</td></tr>
+<tr><td>Left Foreleg</td><td>500</td><td>１ stagger(s) required</td></tr>
+<tr><td>Right Foreleg</td><td>500</td><td>１ stagger(s) required</td></tr>
 <tr><td>Hind Leg</td><td>550</td><td></td></tr>
 <tr><td>Back</td><td>300</td><td>１ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>400</td><td>１ stagger(s) required</td></tr>

--- a/mons/bal_ni.htm
+++ b/mons/bal_ni.htm
@@ -112,40 +112,40 @@
 <img id=icon src="../img/monsicons/zenith_baruragaru.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td></tr>
-<tr><td>舌</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td></tr>
+<tr><td>Tongue</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td></tr>
 <tr><td>Neck</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>0</td></tr>
 <tr><td>Torso</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>0</td></tr>
 <tr><td>Tail</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(吸血中？)</th></tr>
+<tr class=l><th colspan=10>Hitzones(吸血中？)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>30</td><td>20</td><td>0</td><td>15</td><td>15</td><td>0</td><td>100</td></tr>
-<tr><td>舌</td><td>40</td><td>45</td><td>40</td><td>30</td><td>0</td><td>40</td><td>20</td><td>0</td><td>100</td></tr>
+<tr><td>Tongue</td><td>40</td><td>45</td><td>40</td><td>30</td><td>0</td><td>40</td><td>20</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>35</td><td>30</td><td>30</td><td>20</td><td>0</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>35</td><td>30</td><td>20</td><td>0</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>35</td><td>30</td><td>20</td><td>0</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>35</td><td>30</td><td>20</td><td>0</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>25</td><td>30</td><td>30</td><td>0</td><td>20</td><td>15</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(毒麻痺状態)</th></tr>
+<tr class=l><th colspan=10>Hitzones(毒麻痺状態)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>25</td><td>25</td><td>15</td><td>0</td><td>15</td><td>10</td><td>0</td><td>100</td></tr>
-<tr><td>舌</td><td>30</td><td>30</td><td>30</td><td>20</td><td>0</td><td>25</td><td>15</td><td>0</td><td>100</td></tr>
+<tr><td>Tongue</td><td>30</td><td>30</td><td>30</td><td>20</td><td>0</td><td>25</td><td>15</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>15</td><td>15</td><td>5</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>15</td><td>25</td><td>10</td><td>5</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>20</td><td>25</td><td>20</td><td>5</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>20</td><td>25</td><td>20</td><td>5</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>10</td><td>10</td><td>10</td><td>5</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>15</td><td>20</td><td>15</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(粘液状態？)</th></tr>
+<tr class=l><th colspan=10>Hitzones(粘液状態？)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>30</td><td>30</td><td>20</td><td>0</td><td>10</td><td>10</td><td>0</td><td>100</td></tr>
-<tr><td>舌</td><td>35</td><td>35</td><td>35</td><td>25</td><td>0</td><td>15</td><td>15</td><td>0</td><td>100</td></tr>
+<tr><td>Tongue</td><td>35</td><td>35</td><td>35</td><td>25</td><td>0</td><td>15</td><td>15</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>15</td><td>15</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>15</td><td>25</td><td>10</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>20</td><td>25</td><td>20</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>20</td><td>25</td><td>20</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>15</td><td>20</td><td>20</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
 </table>
@@ -154,8 +154,8 @@
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>7000</td><td>２ stagger(s) required</td></tr>
-<tr><td>左前脚</td><td>1000</td><td>１ stagger(s) required</td></tr>
-<tr><td>右前脚</td><td>1000</td><td>１ stagger(s) required</td></tr>
+<tr><td>Left Foreleg</td><td>1000</td><td>１ stagger(s) required</td></tr>
+<tr><td>Right Foreleg</td><td>1000</td><td>１ stagger(s) required</td></tr>
 <tr><td>Hind Leg</td><td>1200</td><td></td></tr>
 <tr><td>Back</td><td>3500</td><td>１ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>750</td><td>１ stagger(s) required</td></tr>

--- a/mons/basa_n.htm
+++ b/mons/basa_n.htm
@@ -73,7 +73,7 @@
 <img id=icon src="../img/monsicons/basarios.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>25</td><td>20</td><td>10</td><td>15</td><td>10</td><td>18</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>15</td><td>20</td><td>20</td><td>10</td><td>15</td><td>10</td><td>18</td><td>10</td><td>0</td></tr>
@@ -99,11 +99,11 @@
 <span><em>59</em>390</span>
 </div>
 </td></tr>
-<tr><td>Left Foot</td><td>100</td><td><div>
+<tr><td>Left Leg</td><td>100</td><td><div>
 <span><em>11</em>133</span><span><em>12</em>135</span><span><em>13</em>138</span><span><em>14</em>141</span><span><em>15</em>143</span><span><em>16</em>146</span><span><em>59</em>300</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>100</td><td><div>
+<tr><td>Right Leg</td><td>100</td><td><div>
 <span><em>11</em>133</span><span><em>12</em>135</span><span><em>13</em>138</span><span><em>14</em>141</span><span><em>15</em>143</span><span><em>16</em>146</span><span><em>59</em>300</span>
 </div>
 </td></tr>

--- a/mons/basa_ng.htm
+++ b/mons/basa_ng.htm
@@ -104,7 +104,7 @@
 <img id=icon src="../img/monsicons/basarios.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>35</td><td>35</td><td>10</td><td>30</td><td>30</td><td>18</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>20</td><td>10</td><td>20</td><td>10</td><td>18</td><td>10</td><td>0</td></tr>
@@ -121,8 +121,8 @@
 <tr><td>Torso</td><td>400</td><td></td></tr>
 <tr><td>Left Wing</td><td>330</td><td></td></tr>
 <tr><td>Right Wing</td><td>330</td><td></td></tr>
-<tr><td>Left Foot</td><td>300</td><td></td></tr>
-<tr><td>Right Foot</td><td>300</td><td></td></tr>
+<tr><td>Left Leg</td><td>300</td><td></td></tr>
+<tr><td>Right Leg</td><td>300</td><td></td></tr>
 <tr><td>Head</td><td>300</td><td></td></tr>
 <tr><td>Belly</td><td>500</td><td>１ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>340</td><td></td></tr>

--- a/mons/basa_nh.htm
+++ b/mons/basa_nh.htm
@@ -77,7 +77,7 @@
 <img id=icon src="../img/monsicons/basarios.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>10</td><td>25</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>15</td><td>100</td></tr>
 <tr><td>Neck</td><td>10</td><td>30</td><td>20</td><td>25</td><td>0</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
@@ -94,8 +94,8 @@
 <tr><td>Torso</td><td>200</td><td></td></tr>
 <tr><td>Left Wing</td><td>130</td><td></td></tr>
 <tr><td>Right Wing</td><td>130</td><td></td></tr>
-<tr><td>Left Foot</td><td>100</td><td></td></tr>
-<tr><td>Right Foot</td><td>100</td><td></td></tr>
+<tr><td>Left Leg</td><td>100</td><td></td></tr>
+<tr><td>Right Leg</td><td>100</td><td></td></tr>
 <tr><td>Head</td><td>100</td><td></td></tr>
 <tr><td>Belly</td><td>300</td><td>１ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>140</td><td></td></tr>

--- a/mons/basa_nt.htm
+++ b/mons/basa_nt.htm
@@ -104,7 +104,7 @@
 <img id=icon src="../img/monsicons/basarios.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>35</td><td>35</td><td>10</td><td>30</td><td>30</td><td>18</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>20</td><td>10</td><td>20</td><td>10</td><td>18</td><td>10</td><td>0</td></tr>
@@ -121,8 +121,8 @@
 <tr><td>Torso</td><td>200</td><td></td></tr>
 <tr><td>Left Wing</td><td>130</td><td></td></tr>
 <tr><td>Right Wing</td><td>130</td><td></td></tr>
-<tr><td>Left Foot</td><td>100</td><td></td></tr>
-<tr><td>Right Foot</td><td>100</td><td></td></tr>
+<tr><td>Left Leg</td><td>100</td><td></td></tr>
+<tr><td>Right Leg</td><td>100</td><td></td></tr>
 <tr><td>Head</td><td>100</td><td></td></tr>
 <tr><td>Belly</td><td>300</td><td>１ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>140</td><td></td></tr>

--- a/mons/berio_ng.htm
+++ b/mons/berio_ng.htm
@@ -116,7 +116,7 @@
 <img id=icon src="../img/monsicons/barioth.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>42</td><td>45</td><td>49</td><td>30</td><td>10</td><td>25</td><td>15</td><td>0</td><td>100</td></tr>
 <tr><td>？？</td><td>21</td><td>17</td><td>21</td><td>5</td><td>5</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>

--- a/mons/berio_nh.htm
+++ b/mons/berio_nh.htm
@@ -75,7 +75,7 @@
 <img id=icon src="../img/monsicons/barioth.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>42</td><td>45</td><td>49</td><td>30</td><td>10</td><td>25</td><td>15</td><td>0</td><td>100</td></tr>
 <tr><td>？？</td><td>21</td><td>17</td><td>21</td><td>5</td><td>5</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>

--- a/mons/beru_n.htm
+++ b/mons/beru_n.htm
@@ -69,30 +69,30 @@
 <img id=icon src="../img/monsicons/berukyurosu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>35</td><td>15</td><td>5</td><td>5</td><td>0</td><td>5</td><td>20</td><td>150</td></tr>
 <tr><td>Torso</td><td>30</td><td>30</td><td>10</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
 <tr><td>Wing</td><td>30</td><td>15</td><td>30</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
-<tr><td>鉤爪</td><td>15</td><td>30</td><td>60</td><td>5</td><td>15</td><td>0</td><td>5</td><td>35</td><td>0</td></tr>
+<tr><td>Talon</td><td>15</td><td>30</td><td>60</td><td>5</td><td>15</td><td>0</td><td>5</td><td>35</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>15</td><td>5</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
-<tr><td>副尾</td><td>35</td><td>15</td><td>50</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
+<tr><td>Subtail</td><td>35</td><td>15</td><td>50</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>15</td><td>40</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(破壊した部位単位で変化<small>[右記参照]</small>)</th></tr>
+<tr class=l><th colspan=10>Hitzones(破壊した部位単位で変化<small>[右記参照]</small>)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>45</td><td>25</td><td>5</td><td>5</td><td>0</td><td>5</td><td>20</td><td>150</td></tr>
 <tr><td>Torso</td><td>40</td><td>40</td><td>20</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
 <tr><td>Wing</td><td>40</td><td>25</td><td>40</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
-<tr><td>鉤爪</td><td>25</td><td>40</td><td>70</td><td>5</td><td>15</td><td>0</td><td>5</td><td>35</td><td>0</td></tr>
+<tr><td>Talon</td><td>25</td><td>40</td><td>70</td><td>5</td><td>15</td><td>0</td><td>5</td><td>35</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>15</td><td>5</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
-<tr><td>副尾</td><td>45</td><td>25</td><td>60</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
+<tr><td>Subtail</td><td>45</td><td>25</td><td>60</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>25</td><td>50</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
-<tr><td>頭/首</td><td>300</td><td>3rd time breaks horns<br>Won't break in pitfalls</td></tr>
+<tr><td>Head/Neck</td><td>300</td><td>3rd time breaks horns<br>Won't break in pitfalls</td></tr>
 <tr><td>Torso</td><td>500</td><td><div>
 <span><em>12若</em>350</span>
 </div>
@@ -103,8 +103,8 @@
 <span><em>12若</em>350</span>
 </div>
 </td></tr>
-<tr><td>左副尾</td><td>300</td><td>２ stagger(s) required<br>Won't break in pitfalls</td></tr>
-<tr><td>右副尾</td><td>300</td><td>Breaking both Sub-Tails changes the hitzones</td></tr>
+<tr><td>Left Subtail</td><td>300</td><td>２ stagger(s) required<br>Won't break in pitfalls</td></tr>
+<tr><td>Right Subtail</td><td>300</td><td>Breaking both Subtails changes the hitzones</td></tr>
 <tr><td>Tail</td><td>300</td><td></td></tr>
 <tr><td>Tail Cut</td><td>1200</td><td><div>
 <span><em>12若</em>600</span>

--- a/mons/beru_ng.htm
+++ b/mons/beru_ng.htm
@@ -123,36 +123,36 @@
 <img id=icon src="../img/monsicons/berukyurosu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>40</td><td>15</td><td>5</td><td>5</td><td>0</td><td>5</td><td>20</td><td>150</td></tr>
 <tr><td>Torso</td><td>25</td><td>30</td><td>10</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>15</td><td>25</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
-<tr><td>鉤爪</td><td>20</td><td>35</td><td>50</td><td>5</td><td>15</td><td>0</td><td>5</td><td>35</td><td>0</td></tr>
+<tr><td>Talon</td><td>20</td><td>35</td><td>50</td><td>5</td><td>15</td><td>0</td><td>5</td><td>35</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>30</td><td>15</td><td>5</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
-<tr><td>副尾</td><td>40</td><td>15</td><td>40</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
+<tr><td>Subtail</td><td>40</td><td>15</td><td>40</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>15</td><td>35</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(破壊した部位単位で変化<small>[右記参照]</small>)</th></tr>
+<tr class=l><th colspan=10>Hitzones(破壊した部位単位で変化<small>[右記参照]</small>)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>50</td><td>20</td><td>5</td><td>5</td><td>0</td><td>5</td><td>20</td><td>150</td></tr>
 <tr><td>Torso</td><td>35</td><td>40</td><td>20</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
 <tr><td>Wing</td><td>35</td><td>25</td><td>35</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
-<tr><td>鉤爪</td><td>30</td><td>45</td><td>60</td><td>5</td><td>15</td><td>0</td><td>5</td><td>35</td><td>0</td></tr>
+<tr><td>Talon</td><td>30</td><td>45</td><td>60</td><td>5</td><td>15</td><td>0</td><td>5</td><td>35</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>30</td><td>15</td><td>5</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
-<tr><td>副尾</td><td>45</td><td>25</td><td>50</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
+<tr><td>Subtail</td><td>45</td><td>25</td><td>50</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
 <tr><td>Tail</td><td>55</td><td>25</td><td>50</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
-<tr><td>頭/首</td><td>450</td><td>3rd time breaks horns<br>Won't break in pitfalls</td></tr>
+<tr><td>Head/Neck</td><td>450</td><td>3rd time breaks horns<br>Won't break in pitfalls</td></tr>
 <tr><td>Torso</td><td>600</td><td>３ stagger(s) required<br>Won't break in pitfalls</td></tr>
 <tr><td>Left Wing</td><td>450</td><td>１ stagger(s) required<br>２ stagger(s) required<br>Won't break in pitfalls</td></tr>
 <tr><td>Right Wing</td><td>450</td><td>Breaking both Wings and Claws changes the hitzones</td></tr>
 <tr><td>Leg</td><td>900</td><td></td></tr>
-<tr><td>左副尾</td><td>500</td><td>２ stagger(s) required<br>Won't break in pitfalls</td></tr>
-<tr><td>右副尾</td><td>500</td><td>Breaking both Sub-Tails changes the hitzones</td></tr>
+<tr><td>Left Subtail</td><td>500</td><td>２ stagger(s) required<br>Won't break in pitfalls</td></tr>
+<tr><td>Right Subtail</td><td>500</td><td>Breaking both Subtails changes the hitzones</td></tr>
 <tr><td>Tail</td><td>600</td><td></td></tr>
 <tr><td>Tail Cut</td><td>2000</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>

--- a/mons/beru_nh.htm
+++ b/mons/beru_nh.htm
@@ -81,36 +81,36 @@
 <img id=icon src="../img/monsicons/berukyurosu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>35</td><td>15</td><td>5</td><td>5</td><td>0</td><td>5</td><td>20</td><td>150</td></tr>
 <tr><td>Torso</td><td>30</td><td>30</td><td>10</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
 <tr><td>Wing</td><td>30</td><td>15</td><td>30</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
-<tr><td>鉤爪</td><td>15</td><td>30</td><td>60</td><td>5</td><td>15</td><td>0</td><td>5</td><td>35</td><td>0</td></tr>
+<tr><td>Talon</td><td>15</td><td>30</td><td>60</td><td>5</td><td>15</td><td>0</td><td>5</td><td>35</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>15</td><td>5</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
-<tr><td>副尾</td><td>35</td><td>15</td><td>50</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
+<tr><td>Subtail</td><td>35</td><td>15</td><td>50</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>15</td><td>40</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(破壊した部位単位で変化<small>[右記参照]</small>)</th></tr>
+<tr class=l><th colspan=10>Hitzones(破壊した部位単位で変化<small>[右記参照]</small>)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>45</td><td>25</td><td>5</td><td>5</td><td>0</td><td>5</td><td>20</td><td>150</td></tr>
 <tr><td>Torso</td><td>40</td><td>40</td><td>20</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
 <tr><td>Wing</td><td>40</td><td>25</td><td>40</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
-<tr><td>鉤爪</td><td>25</td><td>40</td><td>70</td><td>5</td><td>15</td><td>0</td><td>5</td><td>35</td><td>0</td></tr>
+<tr><td>Talon</td><td>25</td><td>40</td><td>70</td><td>5</td><td>15</td><td>0</td><td>5</td><td>35</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>15</td><td>5</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
-<tr><td>副尾</td><td>45</td><td>25</td><td>60</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
+<tr><td>Subtail</td><td>45</td><td>25</td><td>60</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>25</td><td>50</td><td>5</td><td>10</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
-<tr><td>頭/首</td><td>300</td><td>3rd time breaks horns<br>Won't break in pitfalls</td></tr>
+<tr><td>Head/Neck</td><td>300</td><td>3rd time breaks horns<br>Won't break in pitfalls</td></tr>
 <tr><td>Torso</td><td>500</td><td>３ stagger(s) required<br>Won't break in pitfalls</td></tr>
 <tr><td>Left Wing</td><td>250</td><td>１ stagger(s) required<br>２ stagger(s) required<br>Won't break in pitfalls</td></tr>
 <tr><td>Right Wing</td><td>250</td><td>Breaking both Wings and Claws changes the hitzones</td></tr>
 <tr><td>Leg</td><td>600</td><td></td></tr>
-<tr><td>左副尾</td><td>300</td><td>２ stagger(s) required<br>Won't break in pitfalls</td></tr>
-<tr><td>右副尾</td><td>300</td><td>Breaking both Sub-Tails changes the hitzones</td></tr>
+<tr><td>Left Subtail</td><td>300</td><td>２ stagger(s) required<br>Won't break in pitfalls</td></tr>
+<tr><td>Right Subtail</td><td>300</td><td>Breaking both Subtails changes the hitzones</td></tr>
 <tr><td>Tail</td><td>300</td><td></td></tr>
 <tr><td>Tail Cut</td><td>1200</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>

--- a/mons/bogaK_ni.htm
+++ b/mons/bogaK_ni.htm
@@ -99,7 +99,7 @@
 <img id=icon src="../img/monsicons/musou_bogabadorumu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>25</td><td>30</td><td>25</td><td>5</td><td>15</td><td>10</td><td>5</td><td>20</td><td>100</td></tr>
 <tr><td>？？</td><td>20</td><td>15</td><td>15</td><td>5</td><td>10</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>
@@ -108,7 +108,7 @@
 <tr><td>？？</td><td>20</td><td>20</td><td>15</td><td>5</td><td>15</td><td>10</td><td>5</td><td>20</td><td>0</td></tr>
 <tr><td>？？</td><td>10</td><td>15</td><td>15</td><td>5</td><td>10</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>？？</td><td>25</td><td>15</td><td>20</td><td>5</td><td>15</td><td>10</td><td>5</td><td>20</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質()</th></tr>
+<tr class=l><th colspan=10>Hitzones()</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>30</td><td>40</td><td>30</td><td>5</td><td>20</td><td>10</td><td>5</td><td>30</td><td>100</td></tr>
 <tr><td>？？</td><td>20</td><td>15</td><td>15</td><td>5</td><td>10</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>

--- a/mons/boga_ng.htm
+++ b/mons/boga_ng.htm
@@ -44,7 +44,7 @@
 <img id=icon src="../img/monsicons/zenith_bogabadorumu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>25</td><td>30</td><td>25</td><td>5</td><td>15</td><td>10</td><td>5</td><td>20</td><td>100</td></tr>
 <tr><td>？？</td><td>20</td><td>15</td><td>15</td><td>5</td><td>10</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>
@@ -53,7 +53,7 @@
 <tr><td>？？</td><td>20</td><td>20</td><td>15</td><td>5</td><td>15</td><td>10</td><td>5</td><td>20</td><td>0</td></tr>
 <tr><td>？？</td><td>10</td><td>15</td><td>15</td><td>5</td><td>10</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>？？</td><td>25</td><td>15</td><td>20</td><td>5</td><td>15</td><td>10</td><td>5</td><td>20</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質()</th></tr>
+<tr class=l><th colspan=10>Hitzones()</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>30</td><td>40</td><td>30</td><td>5</td><td>20</td><td>10</td><td>5</td><td>30</td><td>100</td></tr>
 <tr><td>？？</td><td>20</td><td>15</td><td>15</td><td>5</td><td>10</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>

--- a/mons/boga_ni.htm
+++ b/mons/boga_ni.htm
@@ -111,7 +111,7 @@
 <img id=icon src="../img/monsicons/zenith_bogabadorumu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>25</td><td>30</td><td>25</td><td>5</td><td>15</td><td>10</td><td>5</td><td>20</td><td>100</td></tr>
 <tr><td>？？</td><td>20</td><td>15</td><td>15</td><td>5</td><td>10</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>
@@ -120,7 +120,7 @@
 <tr><td>？？</td><td>20</td><td>20</td><td>15</td><td>5</td><td>15</td><td>10</td><td>5</td><td>20</td><td>0</td></tr>
 <tr><td>？？</td><td>10</td><td>15</td><td>15</td><td>5</td><td>10</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>？？</td><td>25</td><td>15</td><td>20</td><td>5</td><td>15</td><td>10</td><td>5</td><td>20</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質()</th></tr>
+<tr class=l><th colspan=10>Hitzones()</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>30</td><td>40</td><td>30</td><td>5</td><td>20</td><td>10</td><td>5</td><td>30</td><td>100</td></tr>
 <tr><td>？？</td><td>20</td><td>15</td><td>15</td><td>5</td><td>10</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>

--- a/mons/brook_n.htm
+++ b/mons/brook_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/burukku.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>60</td><td>70</td><td>50</td><td>50</td><td>10</td><td>10</td><td>0</td><td>10</td><td>0</td></tr>
 </table>

--- a/mons/bura_n.htm
+++ b/mons/bura_n.htm
@@ -97,10 +97,10 @@
 <img id=icon src="../img/monsicons/blango.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>70</td><td>70</td><td>75</td><td>55</td><td>5</td><td>15</td><td>0</td><td>5</td><td>50</td></tr>
-<tr><td>Fore Leg</td><td>45</td><td>40</td><td>50</td><td>45</td><td>5</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>45</td><td>40</td><td>50</td><td>45</td><td>5</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>45</td><td>40</td><td>50</td><td>45</td><td>5</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Torso</td><td>45</td><td>50</td><td>55</td><td>45</td><td>5</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>40</td><td>40</td><td>45</td><td>5</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
@@ -110,8 +110,8 @@
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>50</td><td></td></tr>
-<tr><td>Right Foot</td><td>50</td><td></td></tr>
-<tr><td>Left Foot</td><td>50</td><td></td></tr>
+<tr><td>Right Leg</td><td>50</td><td></td></tr>
+<tr><td>Left Leg</td><td>50</td><td></td></tr>
 <tr><td>Torso</td><td>50</td><td></td></tr>
 <tr><td>Tail</td><td>50</td><td></td></tr>
 </table>

--- a/mons/buraki_ng.htm
+++ b/mons/buraki_ng.htm
@@ -116,15 +116,15 @@
 <img id=icon src="../img/monsicons/brachydios.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>角</td><td>14</td><td>18</td><td>11</td><td>0</td><td>30</td><td>5</td><td>5</td><td>20</td><td>120</td></tr>
-<tr><td>頭部</td><td>38</td><td>38</td><td>36</td><td>0</td><td>20</td><td>10</td><td>5</td><td>15</td><td>100</td></tr>
+<tr><td>Horn</td><td>14</td><td>18</td><td>11</td><td>0</td><td>30</td><td>5</td><td>5</td><td>20</td><td>120</td></tr>
+<tr><td>Head</td><td>38</td><td>38</td><td>36</td><td>0</td><td>20</td><td>10</td><td>5</td><td>15</td><td>100</td></tr>
 <tr><td>Torso</td><td>33</td><td>30</td><td>15</td><td>0</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>23</td><td>27</td><td>23</td><td>0</td><td>10</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>23</td><td>27</td><td>23</td><td>0</td><td>10</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>23</td><td>27</td><td>27</td><td>0</td><td>10</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>27</td><td>19</td><td>36</td><td>0</td><td>15</td><td>10</td><td>5</td><td>10</td><td>0</td></tr>
-<tr><td>尾先端</td><td>15</td><td>10</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Tail Tip</td><td>15</td><td>10</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>

--- a/mons/buraki_nh.htm
+++ b/mons/buraki_nh.htm
@@ -75,15 +75,15 @@
 <img id=icon src="../img/monsicons/brachydios.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>角</td><td>17</td><td>21</td><td>13</td><td>0</td><td>30</td><td>5</td><td>5</td><td>20</td><td>120</td></tr>
-<tr><td>頭部</td><td>44</td><td>44</td><td>40</td><td>0</td><td>20</td><td>10</td><td>5</td><td>15</td><td>100</td></tr>
+<tr><td>Horn</td><td>17</td><td>21</td><td>13</td><td>0</td><td>30</td><td>5</td><td>5</td><td>20</td><td>120</td></tr>
+<tr><td>Head</td><td>44</td><td>44</td><td>40</td><td>0</td><td>20</td><td>10</td><td>5</td><td>15</td><td>100</td></tr>
 <tr><td>Torso</td><td>38</td><td>35</td><td>17</td><td>0</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>26</td><td>30</td><td>26</td><td>0</td><td>10</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>26</td><td>30</td><td>26</td><td>0</td><td>10</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>26</td><td>30</td><td>30</td><td>0</td><td>10</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>22</td><td>40</td><td>0</td><td>15</td><td>10</td><td>5</td><td>10</td><td>0</td></tr>
-<tr><td>尾先端</td><td>17</td><td>10</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Tail Tip</td><td>17</td><td>10</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>

--- a/mons/buru_n.htm
+++ b/mons/buru_n.htm
@@ -97,7 +97,7 @@
 <img id=icon src="../img/monsicons/bullfango.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>100</td><td>100</td><td>160</td><td>50</td><td>50</td><td>100</td><td>10</td><td>40</td><td>150</td></tr>
 </table>

--- a/mons/cyacyaKing_n.htm
+++ b/mons/cyacyaKing_n.htm
@@ -78,7 +78,7 @@
 <img id=icon src="../img/monsicons/kingshakalaka.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>70</td><td>70</td><td>70</td><td>20</td><td>20</td><td>20</td><td>20</td><td>40</td><td>100</td></tr>
 </table>

--- a/mons/cyacya_n.htm
+++ b/mons/cyacya_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/shakalaka.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>70</td><td>70</td><td>70</td><td>20</td><td>20</td><td>20</td><td>20</td><td>40</td><td>100</td></tr>
 </table>

--- a/mons/daimyo_n.htm
+++ b/mons/daimyo_n.htm
@@ -86,44 +86,44 @@
 <img id=icon src="../img/monsicons/daimyohermitaur.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>80</td><td>40</td><td>30</td><td>10</td><td>35</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Torso</td><td>40</td><td>60</td><td>30</td><td>15</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>ヤド</td><td>30</td><td>50</td><td>25</td><td>20</td><td>5</td><td>25</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Shell</td><td>30</td><td>50</td><td>25</td><td>20</td><td>5</td><td>25</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>35</td><td>50</td><td>30</td><td>15</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>鋏</td><td>25</td><td>35</td><td>15</td><td>35</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>腕</td><td>40</td><td>50</td><td>30</td><td>15</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(爪破壊後防御)</th></tr>
+<tr><td>Pincer</td><td>25</td><td>35</td><td>15</td><td>35</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>40</td><td>50</td><td>30</td><td>15</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(爪破壊後防御)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>40</td><td>20</td><td>30</td><td>10</td><td>35</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Torso</td><td>20</td><td>30</td><td>15</td><td>15</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>ヤド</td><td>20</td><td>30</td><td>15</td><td>20</td><td>5</td><td>25</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Shell</td><td>20</td><td>30</td><td>15</td><td>20</td><td>5</td><td>25</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>30</td><td>15</td><td>15</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>鋏</td><td>40</td><td>50</td><td>25</td><td>35</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>腕</td><td>20</td><td>30</td><td>15</td><td>15</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(爪破壊前防御)</th></tr>
+<tr><td>Pincer</td><td>40</td><td>50</td><td>25</td><td>35</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>20</td><td>30</td><td>15</td><td>15</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(爪破壊前防御)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>40</td><td>20</td><td>30</td><td>10</td><td>35</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Torso</td><td>20</td><td>30</td><td>15</td><td>15</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>ヤド</td><td>20</td><td>30</td><td>15</td><td>20</td><td>5</td><td>25</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Shell</td><td>20</td><td>30</td><td>15</td><td>20</td><td>5</td><td>25</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>30</td><td>15</td><td>15</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>鋏</td><td>15</td><td>20</td><td>10</td><td>35</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>腕</td><td>20</td><td>30</td><td>15</td><td>15</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Pincer</td><td>15</td><td>20</td><td>10</td><td>35</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>20</td><td>30</td><td>15</td><td>15</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>150</td><td></td></tr>
-<tr><td>胴</td><td>100</td><td></td></tr>
-<tr><td>ヤド</td><td>200</td><td>Only Impact damage works<br>１ stagger(s) required for first partbreak stage<br>２ stagger(s) required for full partbreak</td></tr>
-<tr><td>Left Foot</td><td>150</td><td></td></tr>
-<tr><td>Right Foot</td><td>150</td><td></td></tr>
-<tr><td>左爪</td><td>100</td><td>２ stagger(s) required (Both Claws must be broken for the reward)</td></tr>
-<tr><td>右爪</td><td>100</td><td>２ stagger(s) required</td></tr>
-<tr><td>腕</td><td>100</td><td></td></tr>
-<tr><td>殻破壊</td><td>200</td><td>Only Impact damage works<br>２ stagger(s) required</td></tr>
+<tr><td>Torso</td><td>100</td><td></td></tr>
+<tr><td>Shell</td><td>200</td><td>Only Impact damage works<br>１ stagger(s) required for first partbreak stage<br>２ stagger(s) required for full partbreak</td></tr>
+<tr><td>Left Leg</td><td>150</td><td></td></tr>
+<tr><td>Right Leg</td><td>150</td><td></td></tr>
+<tr><td>Left Claw</td><td>100</td><td>２ stagger(s) required (Both Claws must be broken for the reward)</td></tr>
+<tr><td>Right Claw</td><td>100</td><td>２ stagger(s) required</td></tr>
+<tr><td>Arm</td><td>100</td><td></td></tr>
+<tr><td>Shell Break</td><td>200</td><td>Only Impact damage works<br>２ stagger(s) required</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/daimyohermitaur.png" width="400"/>
 <table id=kou>

--- a/mons/daimyo_ng.htm
+++ b/mons/daimyo_ng.htm
@@ -124,44 +124,44 @@
 <img id=icon src="../img/monsicons/daimyohermitaur.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>50</td><td>40</td><td>30</td><td>10</td><td>35</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Torso</td><td>30</td><td>20</td><td>20</td><td>15</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>ヤド</td><td>20</td><td>30</td><td>25</td><td>0</td><td>5</td><td>30</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Shell</td><td>20</td><td>30</td><td>25</td><td>0</td><td>5</td><td>30</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>40</td><td>20</td><td>0</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>鋏</td><td>20</td><td>20</td><td>15</td><td>50</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>腕</td><td>30</td><td>30</td><td>25</td><td>15</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(爪破壊後防御)</th></tr>
+<tr><td>Pincer</td><td>20</td><td>20</td><td>15</td><td>50</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>30</td><td>30</td><td>25</td><td>15</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(爪破壊後防御)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>20</td><td>15</td><td>30</td><td>10</td><td>35</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>15</td><td>15</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>ヤド</td><td>20</td><td>20</td><td>15</td><td>0</td><td>5</td><td>30</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Shell</td><td>20</td><td>20</td><td>15</td><td>0</td><td>5</td><td>30</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>15</td><td>0</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>鋏</td><td>40</td><td>50</td><td>25</td><td>50</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>腕</td><td>15</td><td>20</td><td>15</td><td>15</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(爪破壊前防御)</th></tr>
+<tr><td>Pincer</td><td>40</td><td>50</td><td>25</td><td>50</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>15</td><td>20</td><td>15</td><td>15</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(爪破壊前防御)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>20</td><td>5</td><td>30</td><td>10</td><td>35</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Torso</td><td>15</td><td>15</td><td>5</td><td>15</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>ヤド</td><td>15</td><td>15</td><td>5</td><td>0</td><td>5</td><td>30</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Shell</td><td>15</td><td>15</td><td>5</td><td>0</td><td>5</td><td>30</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>15</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>鋏</td><td>15</td><td>20</td><td>5</td><td>50</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>腕</td><td>15</td><td>15</td><td>5</td><td>15</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Pincer</td><td>15</td><td>20</td><td>5</td><td>50</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>15</td><td>15</td><td>5</td><td>15</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>350</td><td></td></tr>
-<tr><td>胴</td><td>300</td><td></td></tr>
-<tr><td>ヤド</td><td>400</td><td>Only Impact damage works<br>１ stagger(s) required for first partbreak stage<br>２ stagger(s) required for full partbreak</td></tr>
-<tr><td>Left Foot</td><td>350</td><td></td></tr>
-<tr><td>Right Foot</td><td>350</td><td></td></tr>
-<tr><td>左爪</td><td>300</td><td>２ stagger(s) required (Both Claws must be broken for the reward)</td></tr>
-<tr><td>右爪</td><td>300</td><td>２ stagger(s) required</td></tr>
-<tr><td>腕</td><td>300</td><td></td></tr>
-<tr><td>殻破壊</td><td>400</td><td>Only Impact damage works<br>２ stagger(s) required</td></tr>
+<tr><td>Torso</td><td>300</td><td></td></tr>
+<tr><td>Shell</td><td>400</td><td>Only Impact damage works<br>１ stagger(s) required for first partbreak stage<br>２ stagger(s) required for full partbreak</td></tr>
+<tr><td>Left Leg</td><td>350</td><td></td></tr>
+<tr><td>Right Leg</td><td>350</td><td></td></tr>
+<tr><td>Left Claw</td><td>300</td><td>２ stagger(s) required (Both Claws must be broken for the reward)</td></tr>
+<tr><td>Right Claw</td><td>300</td><td>２ stagger(s) required</td></tr>
+<tr><td>Arm</td><td>300</td><td></td></tr>
+<tr><td>Shell Break</td><td>400</td><td>Only Impact damage works<br>２ stagger(s) required</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/daimyohermitaur.png" width="400"/>
 <table id=kou>

--- a/mons/daimyo_nh.htm
+++ b/mons/daimyo_nh.htm
@@ -90,44 +90,44 @@
 <img id=icon src="../img/monsicons/daimyohermitaur.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>50</td><td>20</td><td>15</td><td>-5</td><td>0</td><td>0</td><td>10</td><td>100</td></tr>
 <tr><td>Torso</td><td>40</td><td>45</td><td>35</td><td>5</td><td>15</td><td>0</td><td>10</td><td>15</td><td>0</td></tr>
-<tr><td>ヤド</td><td>30</td><td>40</td><td>20</td><td>5</td><td>0</td><td>10</td><td>0</td><td>-5</td><td>0</td></tr>
+<tr><td>Shell</td><td>30</td><td>40</td><td>20</td><td>5</td><td>0</td><td>10</td><td>0</td><td>-5</td><td>0</td></tr>
 <tr><td>Leg</td><td>35</td><td>40</td><td>40</td><td>5</td><td>0</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
-<tr><td>鋏</td><td>25</td><td>35</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>腕</td><td>40</td><td>50</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(爪破壊後防御)</th></tr>
+<tr><td>Pincer</td><td>25</td><td>35</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Arm</td><td>40</td><td>50</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(爪破壊後防御)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>40</td><td>15</td><td>15</td><td>-5</td><td>0</td><td>0</td><td>10</td><td>100</td></tr>
 <tr><td>Torso</td><td>20</td><td>30</td><td>20</td><td>5</td><td>15</td><td>0</td><td>20</td><td>15</td><td>0</td></tr>
-<tr><td>ヤド</td><td>20</td><td>30</td><td>15</td><td>5</td><td>0</td><td>10</td><td>0</td><td>-5</td><td>0</td></tr>
+<tr><td>Shell</td><td>20</td><td>30</td><td>15</td><td>5</td><td>0</td><td>10</td><td>0</td><td>-5</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>30</td><td>20</td><td>5</td><td>0</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
-<tr><td>鋏</td><td>20</td><td>30</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>腕</td><td>20</td><td>30</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(爪破壊前防御)</th></tr>
+<tr><td>Pincer</td><td>20</td><td>30</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Arm</td><td>20</td><td>30</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(爪破壊前防御)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>10</td><td>30</td><td>10</td><td>15</td><td>-5</td><td>0</td><td>0</td><td>10</td><td>100</td></tr>
 <tr><td>Torso</td><td>10</td><td>30</td><td>15</td><td>5</td><td>15</td><td>0</td><td>20</td><td>15</td><td>0</td></tr>
-<tr><td>ヤド</td><td>10</td><td>30</td><td>15</td><td>5</td><td>0</td><td>10</td><td>0</td><td>-5</td><td>0</td></tr>
+<tr><td>Shell</td><td>10</td><td>30</td><td>15</td><td>5</td><td>0</td><td>10</td><td>0</td><td>-5</td><td>0</td></tr>
 <tr><td>Leg</td><td>10</td><td>30</td><td>15</td><td>5</td><td>0</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
-<tr><td>鋏</td><td>15</td><td>20</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>腕</td><td>10</td><td>30</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Pincer</td><td>15</td><td>20</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Arm</td><td>10</td><td>30</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>150</td><td></td></tr>
-<tr><td>胴</td><td>100</td><td></td></tr>
-<tr><td>ヤド</td><td>200</td><td>Only Impact damage works<br>１ stagger(s) required for first partbreak stage<br>２ stagger(s) required for full partbreak</td></tr>
-<tr><td>Left Foot</td><td>150</td><td></td></tr>
-<tr><td>Right Foot</td><td>150</td><td></td></tr>
-<tr><td>左爪</td><td>100</td><td>２ stagger(s) required (Both Claws must be broken for the reward)</td></tr>
-<tr><td>右爪</td><td>100</td><td>２ stagger(s) required</td></tr>
-<tr><td>腕</td><td>100</td><td></td></tr>
-<tr><td>殻破壊</td><td>200</td><td>Only Impact damage works<br>２ stagger(s) required</td></tr>
+<tr><td>Torso</td><td>100</td><td></td></tr>
+<tr><td>Shell</td><td>200</td><td>Only Impact damage works<br>１ stagger(s) required for first partbreak stage<br>２ stagger(s) required for full partbreak</td></tr>
+<tr><td>Left Leg</td><td>150</td><td></td></tr>
+<tr><td>Right Leg</td><td>150</td><td></td></tr>
+<tr><td>Left Claw</td><td>100</td><td>２ stagger(s) required (Both Claws must be broken for the reward)</td></tr>
+<tr><td>Right Claw</td><td>100</td><td>２ stagger(s) required</td></tr>
+<tr><td>Arm</td><td>100</td><td></td></tr>
+<tr><td>Shell Break</td><td>200</td><td>Only Impact damage works<br>２ stagger(s) required</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/daimyohermitaurhr5.png" width="400"/>
 <table id=kou>

--- a/mons/daimyo_ni.htm
+++ b/mons/daimyo_ni.htm
@@ -112,84 +112,84 @@
 <img id=icon src="../img/monsicons/zenith_daimyohermitaur.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>30</td><td>15</td><td>10</td><td>25</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Torso</td><td>25</td><td>10</td><td>10</td><td>15</td><td>5</td><td>10</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>ヤド</td><td>20</td><td>25</td><td>15</td><td>0</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Shell</td><td>20</td><td>25</td><td>15</td><td>0</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>25</td><td>10</td><td>0</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>鋏</td><td>25</td><td>25</td><td>15</td><td>30</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>腕</td><td>25</td><td>30</td><td>15</td><td>15</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(砂纏)</th></tr>
+<tr><td>Pincer</td><td>25</td><td>25</td><td>15</td><td>30</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>25</td><td>30</td><td>15</td><td>15</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(砂纏)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>30</td><td>35</td><td>25</td><td>15</td><td>30</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Torso</td><td>20</td><td>10</td><td>15</td><td>15</td><td>10</td><td>15</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>ヤド</td><td>10</td><td>20</td><td>25</td><td>0</td><td>10</td><td>20</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Shell</td><td>10</td><td>20</td><td>25</td><td>0</td><td>10</td><td>20</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Leg</td><td>10</td><td>15</td><td>25</td><td>0</td><td>10</td><td>15</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>鋏</td><td>15</td><td>20</td><td>25</td><td>40</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>腕</td><td>20</td><td>20</td><td>30</td><td>15</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(防御)</th></tr>
+<tr><td>Pincer</td><td>15</td><td>20</td><td>25</td><td>40</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Arm</td><td>20</td><td>20</td><td>30</td><td>15</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(防御)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>20</td><td>5</td><td>15</td><td>10</td><td>25</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Torso</td><td>15</td><td>15</td><td>5</td><td>15</td><td>5</td><td>10</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>ヤド</td><td>15</td><td>15</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Shell</td><td>15</td><td>15</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>15</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>鋏</td><td>15</td><td>20</td><td>5</td><td>30</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>腕</td><td>15</td><td>15</td><td>5</td><td>15</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(砂纏防御)</th></tr>
+<tr><td>Pincer</td><td>15</td><td>20</td><td>5</td><td>30</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>15</td><td>15</td><td>5</td><td>15</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(砂纏防御)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>5</td><td>15</td><td>20</td><td>25</td><td>15</td><td>30</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Torso</td><td>5</td><td>15</td><td>15</td><td>15</td><td>10</td><td>15</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>ヤド</td><td>5</td><td>15</td><td>15</td><td>0</td><td>10</td><td>20</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Shell</td><td>5</td><td>15</td><td>15</td><td>0</td><td>10</td><td>20</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Leg</td><td>5</td><td>15</td><td>15</td><td>0</td><td>10</td><td>15</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>鋏</td><td>5</td><td>15</td><td>20</td><td>40</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>腕</td><td>5</td><td>15</td><td>15</td><td>15</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(爪破壊後)</th></tr>
+<tr><td>Pincer</td><td>5</td><td>15</td><td>20</td><td>40</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Arm</td><td>5</td><td>15</td><td>15</td><td>15</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(爪破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>30</td><td>15</td><td>10</td><td>25</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Torso</td><td>25</td><td>10</td><td>10</td><td>15</td><td>5</td><td>10</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>ヤド</td><td>20</td><td>25</td><td>15</td><td>0</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Shell</td><td>20</td><td>25</td><td>15</td><td>0</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>25</td><td>10</td><td>0</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>鋏</td><td>40</td><td>40</td><td>35</td><td>30</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>腕</td><td>25</td><td>30</td><td>15</td><td>15</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(爪破壊後砂纏)</th></tr>
+<tr><td>Pincer</td><td>40</td><td>40</td><td>35</td><td>30</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>25</td><td>30</td><td>15</td><td>15</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(爪破壊後砂纏)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>30</td><td>35</td><td>25</td><td>15</td><td>30</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Torso</td><td>20</td><td>10</td><td>15</td><td>15</td><td>10</td><td>15</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>ヤド</td><td>10</td><td>20</td><td>25</td><td>0</td><td>10</td><td>20</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Shell</td><td>10</td><td>20</td><td>25</td><td>0</td><td>10</td><td>20</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Leg</td><td>10</td><td>15</td><td>25</td><td>0</td><td>10</td><td>15</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>鋏</td><td>35</td><td>35</td><td>40</td><td>40</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>腕</td><td>20</td><td>20</td><td>30</td><td>15</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(爪破壊後防御)</th></tr>
+<tr><td>Pincer</td><td>35</td><td>35</td><td>40</td><td>40</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Arm</td><td>20</td><td>20</td><td>30</td><td>15</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(爪破壊後防御)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>20</td><td>5</td><td>15</td><td>10</td><td>25</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Torso</td><td>15</td><td>15</td><td>5</td><td>15</td><td>5</td><td>10</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>ヤド</td><td>15</td><td>15</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Shell</td><td>15</td><td>15</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>15</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>鋏</td><td>25</td><td>30</td><td>20</td><td>30</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>腕</td><td>15</td><td>15</td><td>5</td><td>15</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(爪破壊後砂纏防御)</th></tr>
+<tr><td>Pincer</td><td>25</td><td>30</td><td>20</td><td>30</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>15</td><td>15</td><td>5</td><td>15</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(爪破壊後砂纏防御)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>5</td><td>15</td><td>20</td><td>25</td><td>15</td><td>30</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Torso</td><td>5</td><td>15</td><td>15</td><td>15</td><td>10</td><td>15</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>ヤド</td><td>5</td><td>15</td><td>15</td><td>0</td><td>10</td><td>20</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Shell</td><td>5</td><td>15</td><td>15</td><td>0</td><td>10</td><td>20</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Leg</td><td>5</td><td>15</td><td>15</td><td>0</td><td>10</td><td>15</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>鋏</td><td>15</td><td>25</td><td>30</td><td>40</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>腕</td><td>5</td><td>15</td><td>15</td><td>15</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Pincer</td><td>15</td><td>25</td><td>30</td><td>40</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Arm</td><td>5</td><td>15</td><td>15</td><td>15</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>1200</td><td></td></tr>
-<tr><td>胴</td><td>1500</td><td></td></tr>
-<tr><td>ヤド</td><td>2000</td><td>Only Impact damage works<br>１ stagger(s) required for first partbreak stage<br>２ stagger(s) required for full partbreak</td></tr>
-<tr><td>Left Foot</td><td>1500</td><td></td></tr>
-<tr><td>Right Foot</td><td>1500</td><td></td></tr>
-<tr><td>左爪</td><td>2500</td><td>２ stagger(s) required (Both Claws must be broken for the reward)</td></tr>
-<tr><td>右爪</td><td>2500</td><td>２ stagger(s) required</td></tr>
-<tr><td>腕</td><td>1000</td><td></td></tr>
-<tr><td>殻破壊</td><td>2000</td><td>Only Impact damage works<br>２ stagger(s) required</td></tr>
+<tr><td>Torso</td><td>1500</td><td></td></tr>
+<tr><td>Shell</td><td>2000</td><td>Only Impact damage works<br>１ stagger(s) required for first partbreak stage<br>２ stagger(s) required for full partbreak</td></tr>
+<tr><td>Left Leg</td><td>1500</td><td></td></tr>
+<tr><td>Right Leg</td><td>1500</td><td></td></tr>
+<tr><td>Left Claw</td><td>2500</td><td>２ stagger(s) required (Both Claws must be broken for the reward)</td></tr>
+<tr><td>Right Claw</td><td>2500</td><td>２ stagger(s) required</td></tr>
+<tr><td>Arm</td><td>1000</td><td></td></tr>
+<tr><td>Shell Break</td><td>2000</td><td>Only Impact damage works<br>２ stagger(s) required</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/zenith_daimyohermitaur.png" width="400"/>
 <table id=kou>

--- a/mons/dea_n.htm
+++ b/mons/dea_n.htm
@@ -80,7 +80,7 @@
 <img id=icon src="../img/monsicons/diablos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>10</td><td>25</td><td>0</td><td>15</td><td>15</td><td>15</td><td>30</td><td>150</td></tr>
 <tr><td>Neck</td><td>45</td><td>65</td><td>55</td><td>0</td><td>10</td><td>15</td><td>15</td><td>20</td><td>0</td></tr>
@@ -106,11 +106,11 @@
 <span><em>36</em>250</span>
 </div>
 </td></tr>
-<tr><td>Left Foot</td><td>200</td><td><div>
+<tr><td>Left Leg</td><td>200</td><td><div>
 <span><em>13</em>276</span><span><em>14</em>282</span><span><em>15</em>287</span><span><em>16</em>292</span><span><em>17</em>298</span><span><em>36</em>500</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>200</td><td><div>
+<tr><td>Right Leg</td><td>200</td><td><div>
 <span><em>13</em>276</span><span><em>14</em>282</span><span><em>15</em>287</span><span><em>16</em>292</span><span><em>17</em>298</span><span><em>36</em>500</span>
 </div>
 </td></tr>

--- a/mons/dea_ng.htm
+++ b/mons/dea_ng.htm
@@ -118,7 +118,7 @@
 <img id=icon src="../img/monsicons/diablos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>20</td><td>15</td><td>0</td><td>20</td><td>15</td><td>15</td><td>50</td><td>150</td></tr>
 <tr><td>Neck</td><td>45</td><td>55</td><td>40</td><td>0</td><td>5</td><td>15</td><td>15</td><td>10</td><td>0</td></tr>
@@ -135,8 +135,8 @@
 <tr><td>Torso</td><td>700</td><td></td></tr>
 <tr><td>Left Wing</td><td>600</td><td></td></tr>
 <tr><td>Right Wing</td><td>600</td><td></td></tr>
-<tr><td>Left Foot</td><td>550</td><td></td></tr>
-<tr><td>Right Foot</td><td>550</td><td></td></tr>
+<tr><td>Left Leg</td><td>550</td><td></td></tr>
+<tr><td>Right Leg</td><td>550</td><td></td></tr>
 <tr><td>Neck</td><td>500</td><td></td></tr>
 <tr><td>Head</td><td>750</td><td>１ stagger(s) required to break Horn<br>２ stagger(s) required (Requires both for the reward)</td></tr>
 <tr><td>Tail</td><td>1000</td><td></td></tr>

--- a/mons/dea_nh.htm
+++ b/mons/dea_nh.htm
@@ -93,7 +93,7 @@
 <img id=icon src="../img/monsicons/diablos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>10</td><td>30</td><td>0</td><td>25</td><td>10</td><td>0</td><td>5</td><td>150</td></tr>
 <tr><td>Neck</td><td>45</td><td>40</td><td>65</td><td>0</td><td>20</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
@@ -110,8 +110,8 @@
 <tr><td>Torso</td><td>220</td><td></td></tr>
 <tr><td>Left Wing</td><td>100</td><td></td></tr>
 <tr><td>Right Wing</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>200</td><td></td></tr>
-<tr><td>Right Foot</td><td>200</td><td></td></tr>
+<tr><td>Left Leg</td><td>200</td><td></td></tr>
+<tr><td>Right Leg</td><td>200</td><td></td></tr>
 <tr><td>Neck</td><td>100</td><td></td></tr>
 <tr><td>Head</td><td>300</td><td>１ stagger(s) required to break Horn<br>２ stagger(s) required (Requires both for the reward)</td></tr>
 <tr><td>Tail</td><td>180</td><td></td></tr>

--- a/mons/deakuro_n.htm
+++ b/mons/deakuro_n.htm
@@ -74,7 +74,7 @@
 <img id=icon src="../img/monsicons/blackdiablos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>10</td><td>25</td><td>0</td><td>20</td><td>25</td><td>15</td><td>0</td><td>150</td></tr>
 <tr><td>Neck</td><td>40</td><td>55</td><td>50</td><td>0</td><td>15</td><td>20</td><td>15</td><td>0</td><td>0</td></tr>
@@ -91,11 +91,11 @@
 <tr><td>Torso</td><td>220</td><td></td></tr>
 <tr><td>Left Wing</td><td>100</td><td></td></tr>
 <tr><td>Right Wing</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>200</td><td><div>
+<tr><td>Left Leg</td><td>200</td><td><div>
 <span><em>14</em>282</span><span><em>15</em>287</span><span><em>16</em>292</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>200</td><td><div>
+<tr><td>Right Leg</td><td>200</td><td><div>
 <span><em>14</em>282</span><span><em>15</em>287</span><span><em>16</em>292</span>
 </div>
 </td></tr>

--- a/mons/deakuro_ng.htm
+++ b/mons/deakuro_ng.htm
@@ -104,7 +104,7 @@
 <img id=icon src="../img/monsicons/blackdiablos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>20</td><td>15</td><td>0</td><td>20</td><td>50</td><td>15</td><td>0</td><td>150</td></tr>
 <tr><td>Neck</td><td>45</td><td>55</td><td>40</td><td>0</td><td>5</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
@@ -121,8 +121,8 @@
 <tr><td>Torso</td><td>800</td><td></td></tr>
 <tr><td>Left Wing</td><td>700</td><td></td></tr>
 <tr><td>Right Wing</td><td>700</td><td></td></tr>
-<tr><td>Left Foot</td><td>650</td><td></td></tr>
-<tr><td>Right Foot</td><td>650</td><td></td></tr>
+<tr><td>Left Leg</td><td>650</td><td></td></tr>
+<tr><td>Right Leg</td><td>650</td><td></td></tr>
 <tr><td>Neck</td><td>600</td><td></td></tr>
 <tr><td>Head</td><td>850</td><td>１ stagger(s) required to break Horn<br>２ stagger(s) required (Requires both for the reward)</td></tr>
 <tr><td>Tail</td><td>1100</td><td></td></tr>

--- a/mons/deakuro_nh.htm
+++ b/mons/deakuro_nh.htm
@@ -93,7 +93,7 @@
 <img id=icon src="../img/monsicons/blackdiablos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>30</td><td>25</td><td>0</td><td>20</td><td>25</td><td>15</td><td>0</td><td>150</td></tr>
 <tr><td>Neck</td><td>45</td><td>55</td><td>45</td><td>0</td><td>10</td><td>25</td><td>15</td><td>0</td><td>0</td></tr>
@@ -110,8 +110,8 @@
 <tr><td>Torso</td><td>350</td><td></td></tr>
 <tr><td>Left Wing</td><td>300</td><td></td></tr>
 <tr><td>Right Wing</td><td>300</td><td></td></tr>
-<tr><td>Left Foot</td><td>350</td><td></td></tr>
-<tr><td>Right Foot</td><td>350</td><td></td></tr>
+<tr><td>Left Leg</td><td>350</td><td></td></tr>
+<tr><td>Right Leg</td><td>350</td><td></td></tr>
 <tr><td>Neck</td><td>500</td><td></td></tr>
 <tr><td>Head</td><td>350</td><td>１ stagger(s) required to break Horn<br>２ stagger(s) required (Requires both for the reward)</td></tr>
 <tr><td>Tail</td><td>500</td><td></td></tr>

--- a/mons/dio_ng.htm
+++ b/mons/dio_ng.htm
@@ -97,41 +97,41 @@
 <img id=icon src="../img/monsicons/diorex.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>10</td><td>15</td><td>15</td><td>-20</td><td>-10</td><td>-20</td><td>30</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>15</td><td>15</td><td>10</td><td>-20</td><td>-10</td><td>-20</td><td>20</td><td>0</td><td>10</td></tr>
 <tr><td>Belly</td><td>10</td><td>10</td><td>10</td><td>-20</td><td>-10</td><td>-20</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>10</td><td>10</td><td>10</td><td>-20</td><td>-10</td><td>-20</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>10</td><td>10</td><td>10</td><td>-20</td><td>-10</td><td>-20</td><td>20</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>10</td><td>10</td><td>10</td><td>-20</td><td>-10</td><td>-20</td><td>20</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>10</td><td>10</td><td>10</td><td>-20</td><td>-10</td><td>-20</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>15</td><td>10</td><td>15</td><td>-20</td><td>-10</td><td>-20</td><td>30</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(外殻破壊後)</th></tr>
+<tr class=l><th colspan=10>Hitzones(外殻破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>35</td><td>25</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>15</td><td>15</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>10</td></tr>
 <tr><td>Belly</td><td>30</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>35</td><td>30</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(部位破壊後)</th></tr>
+<tr class=l><th colspan=10>Hitzones(部位破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>55</td><td>35</td><td>0</td><td>0</td><td>0</td><td>20</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>15</td><td>15</td><td>10</td><td>0</td><td>0</td><td>0</td><td>10</td><td>0</td><td>10</td></tr>
 <tr><td>Belly</td><td>40</td><td>45</td><td>25</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Back</td><td>40</td><td>45</td><td>25</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>40</td><td>30</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>45</td><td>40</td><td>30</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>45</td><td>40</td><td>30</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>55</td><td>50</td><td>35</td><td>0</td><td>0</td><td>0</td><td>20</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(攻撃準備中)</th></tr>
+<tr class=l><th colspan=10>Hitzones(攻撃準備中)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>55</td><td>60</td><td>40</td><td>0</td><td>0</td><td>0</td><td>20</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>15</td><td>15</td><td>10</td><td>0</td><td>0</td><td>0</td><td>10</td><td>0</td><td>10</td></tr>
 <tr><td>Belly</td><td>45</td><td>50</td><td>30</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Back</td><td>45</td><td>50</td><td>30</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>45</td><td>35</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>50</td><td>45</td><td>35</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>50</td><td>45</td><td>35</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>60</td><td>55</td><td>40</td><td>0</td><td>0</td><td>0</td><td>20</td><td>10</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -140,12 +140,12 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>500</td><td>２ stagger(s) required</td></tr>
 <tr><td>Belly</td><td>1000</td><td></td></tr>
-<tr><td>首/背中</td><td>1000</td><td></td></tr>
+<tr><td>Neck/Back</td><td>1000</td><td></td></tr>
 <tr><td>Tail</td><td>500</td><td></td></tr>
-<tr><td>左前脚</td><td>450</td><td>１ stagger(s) required</td></tr>
-<tr><td>左後脚</td><td>450</td><td>１ stagger(s) required</td></tr>
-<tr><td>右前脚</td><td>450</td><td>１ stagger(s) required</td></tr>
-<tr><td>右後脚</td><td>450</td><td>１ stagger(s) required</td></tr>
+<tr><td>Left Foreleg</td><td>450</td><td>１ stagger(s) required</td></tr>
+<tr><td>Left Hind Leg</td><td>450</td><td>１ stagger(s) required</td></tr>
+<tr><td>Right Foreleg</td><td>450</td><td>１ stagger(s) required</td></tr>
+<tr><td>Right Hind Leg</td><td>450</td><td>１ stagger(s) required</td></tr>
 <tr><td>Tail Cut</td><td>1500</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/diorex.png" width="400"/>

--- a/mons/dio_nh.htm
+++ b/mons/dio_nh.htm
@@ -75,41 +75,41 @@
 <img id=icon src="../img/monsicons/diorex.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>25</td><td>20</td><td>-20</td><td>-10</td><td>-20</td><td>30</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>15</td><td>15</td><td>10</td><td>-20</td><td>-10</td><td>-20</td><td>20</td><td>0</td><td>10</td></tr>
 <tr><td>Belly</td><td>20</td><td>20</td><td>15</td><td>-20</td><td>-10</td><td>-20</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>20</td><td>15</td><td>-20</td><td>-10</td><td>-20</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>15</td><td>15</td><td>15</td><td>-20</td><td>-10</td><td>-20</td><td>20</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>15</td><td>15</td><td>15</td><td>-20</td><td>-10</td><td>-20</td><td>20</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>15</td><td>15</td><td>15</td><td>-20</td><td>-10</td><td>-20</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>15</td><td>25</td><td>-20</td><td>-10</td><td>-20</td><td>30</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(外殻破壊後)</th></tr>
+<tr class=l><th colspan=10>Hitzones(外殻破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>35</td><td>25</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>15</td><td>15</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>10</td></tr>
 <tr><td>Belly</td><td>30</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>35</td><td>30</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(部位破壊後)</th></tr>
+<tr class=l><th colspan=10>Hitzones(部位破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>55</td><td>35</td><td>0</td><td>0</td><td>0</td><td>20</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>15</td><td>15</td><td>10</td><td>0</td><td>0</td><td>0</td><td>10</td><td>0</td><td>10</td></tr>
 <tr><td>Belly</td><td>40</td><td>45</td><td>25</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Back</td><td>40</td><td>45</td><td>25</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>40</td><td>30</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>45</td><td>40</td><td>30</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>45</td><td>40</td><td>30</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>55</td><td>50</td><td>35</td><td>0</td><td>0</td><td>0</td><td>20</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(攻撃準備中)</th></tr>
+<tr class=l><th colspan=10>Hitzones(攻撃準備中)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>55</td><td>60</td><td>40</td><td>0</td><td>0</td><td>0</td><td>20</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>15</td><td>15</td><td>10</td><td>0</td><td>0</td><td>0</td><td>10</td><td>0</td><td>10</td></tr>
 <tr><td>Belly</td><td>45</td><td>50</td><td>30</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Back</td><td>45</td><td>50</td><td>30</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>45</td><td>35</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>50</td><td>45</td><td>35</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>50</td><td>45</td><td>35</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>60</td><td>55</td><td>40</td><td>0</td><td>0</td><td>0</td><td>20</td><td>10</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -118,12 +118,12 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>350</td><td>２ stagger(s) required</td></tr>
 <tr><td>Belly</td><td>700</td><td></td></tr>
-<tr><td>首/背中</td><td>700</td><td></td></tr>
+<tr><td>Neck/Back</td><td>700</td><td></td></tr>
 <tr><td>Tail</td><td>400</td><td></td></tr>
-<tr><td>左前脚</td><td>270</td><td>１ stagger(s) required</td></tr>
-<tr><td>左後脚</td><td>270</td><td>１ stagger(s) required</td></tr>
-<tr><td>右前脚</td><td>270</td><td>１ stagger(s) required</td></tr>
-<tr><td>右後脚</td><td>270</td><td>１ stagger(s) required</td></tr>
+<tr><td>Left Foreleg</td><td>270</td><td>１ stagger(s) required</td></tr>
+<tr><td>Left Hind Leg</td><td>270</td><td>１ stagger(s) required</td></tr>
+<tr><td>Right Foreleg</td><td>270</td><td>１ stagger(s) required</td></tr>
+<tr><td>Right Hind Leg</td><td>270</td><td>１ stagger(s) required</td></tr>
 <tr><td>Tail Cut</td><td>650</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/diorex.png" width="400"/>

--- a/mons/disf_ng.htm
+++ b/mons/disf_ng.htm
@@ -101,22 +101,22 @@
 <img id=icon src="../img/monsicons/disufiroa.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>50</td><td>50</td><td>0</td><td>10</td><td>20</td><td>30</td><td>0</td><td>100</td></tr>
 <tr><td>Wing</td><td>45</td><td>35</td><td>20</td><td>0</td><td>10</td><td>20</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>30</td><td>20</td><td>0</td><td>30</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>30</td><td>40</td><td>40</td><td>10</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>25</td><td>25</td><td>35</td><td>0</td><td>30</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>35</td><td>20</td><td>0</td><td>30</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(覚醒後)</th></tr>
+<tr><td>Foreleg</td><td>30</td><td>35</td><td>20</td><td>0</td><td>30</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(覚醒後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>45</td><td>45</td><td>0</td><td>10</td><td>15</td><td>15</td><td>0</td><td>100</td></tr>
 <tr><td>Wing</td><td>45</td><td>30</td><td>15</td><td>0</td><td>10</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>25</td><td>15</td><td>0</td><td>15</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>25</td><td>35</td><td>20</td><td>10</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>30</td><td>0</td><td>15</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>30</td><td>15</td><td>0</td><td>15</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>30</td><td>15</td><td>0</td><td>15</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
@@ -124,10 +124,10 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>1200</td><td>２ stagger(s) required</td></tr>
 <tr><td>Wing</td><td>1400</td><td>２ stagger(s) required</td></tr>
-<tr><td>左前脚</td><td>800</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
-<tr><td>右前脚</td><td>800</td><td>１ stagger(s) required</td></tr>
-<tr><td>左後脚</td><td>1000</td><td></td></tr>
-<tr><td>右後脚</td><td>1000</td><td></td></tr>
+<tr><td>Left Foreleg</td><td>800</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
+<tr><td>Right Foreleg</td><td>800</td><td>１ stagger(s) required</td></tr>
+<tr><td>Left Hind Leg</td><td>1000</td><td></td></tr>
+<tr><td>Right Hind Leg</td><td>1000</td><td></td></tr>
 <tr><td>Tail</td><td>2000</td><td></td></tr>
 <tr><td>Torso</td><td>1000</td><td></td></tr>
 <tr><td>Tail Cut</td><td>4000</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>

--- a/mons/dodobura_n.htm
+++ b/mons/dodobura_n.htm
@@ -87,10 +87,10 @@
 <img id=icon src="../img/monsicons/blangonga.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>70</td><td>70</td><td>75</td><td>15</td><td>5</td><td>15</td><td>0</td><td>0</td><td>50</td></tr>
-<tr><td>Fore Leg</td><td>45</td><td>40</td><td>30</td><td>10</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>45</td><td>40</td><td>30</td><td>10</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>45</td><td>40</td><td>30</td><td>10</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>45</td><td>50</td><td>40</td><td>15</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>40</td><td>25</td><td>15</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
@@ -103,11 +103,11 @@
 <span><em>13</em>484</span><span><em>14</em>493</span><span><em>15</em>502</span><span><em>16</em>512</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>150</td><td><div>
+<tr><td>Right Leg</td><td>150</td><td><div>
 <span><em>13</em>207</span><span><em>14</em>211</span><span><em>15</em>215</span><span><em>16</em>219</span>
 </div>
 </td></tr>
-<tr><td>Left Foot</td><td>150</td><td><div>
+<tr><td>Left Leg</td><td>150</td><td><div>
 <span><em>13</em>207</span><span><em>14</em>211</span><span><em>15</em>215</span><span><em>16</em>219</span>
 </div>
 </td></tr>

--- a/mons/dodobura_ng.htm
+++ b/mons/dodobura_ng.htm
@@ -118,10 +118,10 @@
 <img id=icon src="../img/monsicons/blangonga.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>55</td><td>45</td><td>25</td><td>5</td><td>15</td><td>0</td><td>0</td><td>50</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>30</td><td>30</td><td>15</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>30</td><td>30</td><td>15</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>35</td><td>30</td><td>15</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>35</td><td>40</td><td>40</td><td>25</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>40</td><td>35</td><td>30</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
@@ -131,8 +131,8 @@
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>500</td><td></td></tr>
-<tr><td>Right Foot</td><td>300</td><td></td></tr>
-<tr><td>Left Foot</td><td>300</td><td></td></tr>
+<tr><td>Right Leg</td><td>300</td><td></td></tr>
+<tr><td>Left Leg</td><td>300</td><td></td></tr>
 <tr><td>Torso</td><td>450</td><td></td></tr>
 <tr><td>Tail</td><td>900</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 <tr><td></td><td>550</td><td>Can only be broken through Fire damage to the head</td></tr>

--- a/mons/dodobura_nh.htm
+++ b/mons/dodobura_nh.htm
@@ -101,10 +101,10 @@
 <img id=icon src="../img/monsicons/blangonga.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>40</td><td>20</td><td>15</td><td>5</td><td>5</td><td>-2</td><td>5</td><td>50</td></tr>
-<tr><td>Fore Leg</td><td>45</td><td>40</td><td>30</td><td>-5</td><td>5</td><td>5</td><td>-2</td><td>15</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>45</td><td>40</td><td>30</td><td>-5</td><td>5</td><td>5</td><td>-2</td><td>15</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>45</td><td>40</td><td>30</td><td>10</td><td>5</td><td>-5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>45</td><td>50</td><td>40</td><td>10</td><td>5</td><td>5</td><td>-2</td><td>-5</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>40</td><td>25</td><td>10</td><td>5</td><td>15</td><td>-2</td><td>0</td><td>0</td></tr>
@@ -114,8 +114,8 @@
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>350</td><td></td></tr>
-<tr><td>Right Foot</td><td>150</td><td></td></tr>
-<tr><td>Left Foot</td><td>150</td><td></td></tr>
+<tr><td>Right Leg</td><td>150</td><td></td></tr>
+<tr><td>Left Leg</td><td>150</td><td></td></tr>
 <tr><td>Torso</td><td>160</td><td></td></tr>
 <tr><td>Tail</td><td>600</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 <tr><td></td><td>350</td><td>Can only be broken through Fire damage to the head</td></tr>

--- a/mons/dodobura_ni.htm
+++ b/mons/dodobura_ni.htm
@@ -112,10 +112,10 @@
 <img id=icon src="../img/monsicons/zenith_blangonga.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>35</td><td>25</td><td>5</td><td>15</td><td>0</td><td>0</td><td>50</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>30</td><td>20</td><td>15</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>30</td><td>20</td><td>15</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>15</td><td>20</td><td>15</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>25</td><td>25</td><td>30</td><td>25</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>25</td><td>25</td><td>30</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
@@ -125,12 +125,12 @@
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>1200</td><td></td></tr>
-<tr><td>右前脚</td><td>6500</td><td>？ stagger(s) required腕破壊</td></tr>
-<tr><td>左前脚</td><td>6500</td><td>？ stagger(s) required腕破壊</td></tr>
+<tr><td>Right Foreleg</td><td>6500</td><td>？ stagger(s) required腕破壊</td></tr>
+<tr><td>Left Foreleg</td><td>6500</td><td>？ stagger(s) required腕破壊</td></tr>
 <tr><td>Torso</td><td>1150</td><td></td></tr>
 <tr><td>Tail</td><td>1500</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
-<tr><td>右後脚</td><td>800</td><td></td></tr>
-<tr><td>左後脚</td><td>800</td><td></td></tr>
+<tr><td>Right Hind Leg</td><td>800</td><td></td></tr>
+<tr><td>Left Hind Leg</td><td>800</td><td></td></tr>
 <tr><td></td><td>1200</td><td>Can only be broken through Fire damage to the head</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/zenith_blangonga.png" width="400"/>

--- a/mons/dolem1_nt.htm
+++ b/mons/dolem1_nt.htm
@@ -94,13 +94,13 @@
 <img id=icon src="../img/monsicons/duremudirafirstdistrict.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>35</td><td>35</td><td>15</td><td>5</td><td>5</td><td>15</td><td>0</td><td>100</td></tr>
 <tr><td>Belly</td><td>20</td><td>20</td><td>20</td><td>15</td><td>5</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>20</td><td>20</td><td>15</td><td>5</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>25</td><td>35</td><td>15</td><td>5</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>30</td><td>15</td><td>10</td><td>5</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>30</td><td>15</td><td>10</td><td>5</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>25</td><td>15</td><td>10</td><td>5</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>35</td><td>30</td><td>15</td><td>10</td><td>5</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
 </table>
@@ -111,8 +111,8 @@
 <tr><td>Head</td><td>1500</td><td></td></tr>
 <tr><td>Torso</td><td>2000</td><td></td></tr>
 <tr><td>Tail</td><td>1200</td><td></td></tr>
-<tr><td>Left Foot</td><td>1200</td><td></td></tr>
-<tr><td>Right Foot</td><td>1200</td><td></td></tr>
+<tr><td>Left Leg</td><td>1200</td><td></td></tr>
+<tr><td>Right Leg</td><td>1200</td><td></td></tr>
 <tr><td>Wing</td><td>1200</td><td></td></tr>
 <tr><td>-</td><td>2000</td><td></td></tr>
 <tr><td>Tail Cut</td><td>2400</td><td></td></tr>

--- a/mons/dolem2_nt.htm
+++ b/mons/dolem2_nt.htm
@@ -94,13 +94,13 @@
 <img id=icon src="../img/monsicons/duremudirafirstdistrict.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>35</td><td>35</td><td>15</td><td>5</td><td>5</td><td>15</td><td>0</td><td>100</td></tr>
 <tr><td>Belly</td><td>20</td><td>20</td><td>20</td><td>15</td><td>5</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>20</td><td>20</td><td>15</td><td>5</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>25</td><td>35</td><td>15</td><td>5</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>30</td><td>15</td><td>10</td><td>5</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>30</td><td>15</td><td>10</td><td>5</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>25</td><td>15</td><td>10</td><td>5</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>35</td><td>30</td><td>15</td><td>10</td><td>5</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
 </table>
@@ -111,8 +111,8 @@
 <tr><td>Head</td><td>1500</td><td></td></tr>
 <tr><td>Torso</td><td>2000</td><td></td></tr>
 <tr><td>Tail</td><td>1200</td><td></td></tr>
-<tr><td>Left Foot</td><td>1200</td><td></td></tr>
-<tr><td>Right Foot</td><td>1200</td><td></td></tr>
+<tr><td>Left Leg</td><td>1200</td><td></td></tr>
+<tr><td>Right Leg</td><td>1200</td><td></td></tr>
 <tr><td>Wing</td><td>1200</td><td></td></tr>
 <tr><td>-</td><td>2000</td><td></td></tr>
 <tr><td>Tail Cut</td><td>2400</td><td></td></tr>

--- a/mons/dolem_nt.htm
+++ b/mons/dolem_nt.htm
@@ -99,13 +99,13 @@
 <img id=icon src="../img/monsicons/musou_duremudira.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>30</td><td>30</td><td>10</td><td>5</td><td>0</td><td>20</td><td>25</td><td>100</td></tr>
 <tr><td>Belly</td><td>10</td><td>15</td><td>10</td><td>10</td><td>5</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Back</td><td>15</td><td>10</td><td>15</td><td>10</td><td>5</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>25</td><td>25</td><td>10</td><td>5</td><td>0</td><td>15</td><td>15</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>15</td><td>20</td><td>10</td><td>10</td><td>5</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>15</td><td>20</td><td>10</td><td>10</td><td>5</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>15</td><td>15</td><td>10</td><td>10</td><td>5</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>20</td><td>15</td><td>10</td><td>5</td><td>0</td><td>15</td><td>20</td><td>0</td></tr>
 </table>
@@ -116,8 +116,8 @@
 <tr><td>Head</td><td>1500</td><td></td></tr>
 <tr><td>Torso</td><td>2000</td><td></td></tr>
 <tr><td>Tail</td><td>1200</td><td></td></tr>
-<tr><td>Left Foot</td><td>1200</td><td></td></tr>
-<tr><td>Right Foot</td><td>1200</td><td></td></tr>
+<tr><td>Left Leg</td><td>1200</td><td></td></tr>
+<tr><td>Right Leg</td><td>1200</td><td></td></tr>
 <tr><td>Wing</td><td>1200</td><td></td></tr>
 <tr><td>-</td><td>2000</td><td></td></tr>
 <tr><td>Tail Cut</td><td>2400</td><td></td></tr>

--- a/mons/doragyu_n.htm
+++ b/mons/doragyu_n.htm
@@ -62,36 +62,36 @@
 <img id=icon src="../img/monsicons/doragyurosu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>50</td><td>30</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Torso</td><td>25</td><td>40</td><td>10</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>45</td><td>15</td><td>20</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>鉤爪</td><td>30</td><td>40</td><td>50</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Talon</td><td>30</td><td>40</td><td>50</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>15</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>副尾</td><td>45</td><td>25</td><td>45</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Subtail</td><td>45</td><td>25</td><td>45</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>30</td><td>30</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り)</th></tr>
+<tr class=l><th colspan=10>Hitzones(怒り)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>55</td><td>35</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Torso</td><td>35</td><td>45</td><td>20</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>50</td><td>20</td><td>30</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>鉤爪</td><td>35</td><td>45</td><td>55</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Talon</td><td>35</td><td>45</td><td>55</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>15</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>副尾</td><td>50</td><td>30</td><td>50</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Subtail</td><td>50</td><td>30</td><td>50</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>55</td><td>35</td><td>40</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
-<tr><td>頭/首</td><td>1200</td><td>２ stagger(s) required</td></tr>
+<tr><td>Head/Neck</td><td>1200</td><td>２ stagger(s) required</td></tr>
 <tr><td>Torso</td><td>800</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>500</td><td>１ stagger(s) required<br>２ stagger(s) required</td></tr>
 <tr><td>Right Wing</td><td>500</td><td></td></tr>
 <tr><td>Leg</td><td>800</td><td></td></tr>
-<tr><td>左副尾</td><td>1000</td><td>２ stagger(s) required</td></tr>
-<tr><td>右副尾</td><td>1000</td><td></td></tr>
+<tr><td>Left Subtail</td><td>1000</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Subtail</td><td>1000</td><td></td></tr>
 <tr><td>Tail</td><td>600</td><td></td></tr>
 <tr><td>Tail Cut</td><td>1200</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>

--- a/mons/doragyu_ng.htm
+++ b/mons/doragyu_ng.htm
@@ -121,36 +121,36 @@
 <img id=icon src="../img/monsicons/doragyurosu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>45</td><td>25</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Torso</td><td>20</td><td>35</td><td>10</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>40</td><td>10</td><td>15</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>鉤爪</td><td>25</td><td>35</td><td>40</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Talon</td><td>25</td><td>35</td><td>40</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>15</td><td>10</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>副尾</td><td>40</td><td>20</td><td>35</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Subtail</td><td>40</td><td>20</td><td>35</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>25</td><td>25</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り)</th></tr>
+<tr class=l><th colspan=10>Hitzones(怒り)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>50</td><td>30</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Torso</td><td>30</td><td>40</td><td>15</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>45</td><td>15</td><td>20</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>鉤爪</td><td>30</td><td>40</td><td>45</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Talon</td><td>30</td><td>40</td><td>45</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>15</td><td>10</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>副尾</td><td>45</td><td>25</td><td>40</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Subtail</td><td>45</td><td>25</td><td>40</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>30</td><td>30</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
-<tr><td>頭/首</td><td>600</td><td>２ stagger(s) required</td></tr>
+<tr><td>Head/Neck</td><td>600</td><td>２ stagger(s) required</td></tr>
 <tr><td>Torso</td><td>900</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>550</td><td>１ stagger(s) required<br>２ stagger(s) required</td></tr>
 <tr><td>Right Wing</td><td>550</td><td></td></tr>
 <tr><td>Leg</td><td>1000</td><td></td></tr>
-<tr><td>左副尾</td><td>800</td><td>２ stagger(s) required</td></tr>
-<tr><td>右副尾</td><td>800</td><td></td></tr>
+<tr><td>Left Subtail</td><td>800</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Subtail</td><td>800</td><td></td></tr>
 <tr><td>Tail</td><td>700</td><td></td></tr>
 <tr><td>Tail Cut</td><td>1500</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>

--- a/mons/doragyu_nh.htm
+++ b/mons/doragyu_nh.htm
@@ -84,54 +84,54 @@
 <img id=icon src="../img/monsicons/doragyurosu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>45</td><td>25</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Torso</td><td>20</td><td>35</td><td>10</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>40</td><td>10</td><td>15</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>鉤爪</td><td>25</td><td>35</td><td>40</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Talon</td><td>25</td><td>35</td><td>40</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>15</td><td>10</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>副尾</td><td>40</td><td>20</td><td>35</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Subtail</td><td>40</td><td>20</td><td>35</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>25</td><td>25</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り)</th></tr>
+<tr class=l><th colspan=10>Hitzones(怒り)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>50</td><td>30</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Torso</td><td>30</td><td>40</td><td>15</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>45</td><td>15</td><td>20</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>鉤爪</td><td>30</td><td>40</td><td>45</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Talon</td><td>30</td><td>40</td><td>45</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>15</td><td>10</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>副尾</td><td>45</td><td>25</td><td>40</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Subtail</td><td>45</td><td>25</td><td>40</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>30</td><td>30</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(復活後(覇種))</th></tr>
+<tr class=l><th colspan=10>Hitzones(復活後(覇種))</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>50</td><td>20</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Torso</td><td>25</td><td>40</td><td>10</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>45</td><td>15</td><td>20</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>鉤爪</td><td>30</td><td>40</td><td>40</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Talon</td><td>30</td><td>40</td><td>40</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>15</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>副尾</td><td>45</td><td>25</td><td>25</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Subtail</td><td>45</td><td>25</td><td>25</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>30</td><td>20</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(復活後怒(覇種))</th></tr>
+<tr class=l><th colspan=10>Hitzones(復活後怒(覇種))</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>55</td><td>25</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Torso</td><td>35</td><td>45</td><td>10</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>50</td><td>20</td><td>20</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>鉤爪</td><td>35</td><td>45</td><td>45</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Talon</td><td>35</td><td>45</td><td>45</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>15</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>副尾</td><td>50</td><td>30</td><td>30</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Subtail</td><td>50</td><td>30</td><td>30</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>55</td><td>35</td><td>20</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
-<tr><td>頭/首</td><td>600</td><td>２ stagger(s) required</td></tr>
+<tr><td>Head/Neck</td><td>600</td><td>２ stagger(s) required</td></tr>
 <tr><td>Torso</td><td>900</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>550</td><td>１ stagger(s) required<br>２ stagger(s) required</td></tr>
 <tr><td>Right Wing</td><td>550</td><td></td></tr>
 <tr><td>Leg</td><td>1000</td><td></td></tr>
-<tr><td>左副尾</td><td>800</td><td>２ stagger(s) required</td></tr>
-<tr><td>右副尾</td><td>800</td><td></td></tr>
+<tr><td>Left Subtail</td><td>800</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Subtail</td><td>800</td><td></td></tr>
 <tr><td>Tail</td><td>700</td><td></td></tr>
 <tr><td>Tail Cut</td><td>1500</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>

--- a/mons/doragyu_ni.htm
+++ b/mons/doragyu_ni.htm
@@ -111,36 +111,36 @@
 <img id=icon src="../img/monsicons/zenith_doragyurosu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>18</td><td>32</td><td>17</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Torso</td><td>15</td><td>22</td><td>10</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>23</td><td>12</td><td>10</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>鉤爪</td><td>18</td><td>22</td><td>27</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Talon</td><td>18</td><td>22</td><td>27</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>10</td><td>10</td><td>10</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>副尾</td><td>18</td><td>12</td><td>22</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Subtail</td><td>18</td><td>12</td><td>22</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>28</td><td>17</td><td>17</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り)</th></tr>
+<tr class=l><th colspan=10>Hitzones(怒り)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>22</td><td>35</td><td>20</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Torso</td><td>17</td><td>25</td><td>12</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>27</td><td>15</td><td>12</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>鉤爪</td><td>22</td><td>25</td><td>30</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Talon</td><td>22</td><td>25</td><td>30</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>12</td><td>12</td><td>12</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>副尾</td><td>22</td><td>15</td><td>25</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Subtail</td><td>22</td><td>15</td><td>25</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>20</td><td>20</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
-<tr><td>頭/首</td><td>5000</td><td>２ stagger(s) required</td></tr>
+<tr><td>Head/Neck</td><td>5000</td><td>２ stagger(s) required</td></tr>
 <tr><td>Torso</td><td>1000</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>1000</td><td>１ stagger(s) required<br>２ stagger(s) required</td></tr>
 <tr><td>Right Wing</td><td>1000</td><td></td></tr>
 <tr><td>Leg</td><td>1000</td><td></td></tr>
-<tr><td>左副尾</td><td>1000</td><td>２ stagger(s) required</td></tr>
-<tr><td>右副尾</td><td>1000</td><td></td></tr>
+<tr><td>Left Subtail</td><td>1000</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Subtail</td><td>1000</td><td></td></tr>
 <tr><td>Tail</td><td>1000</td><td></td></tr>
 <tr><td>Tail Cut</td><td>1500</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>

--- a/mons/dosburu_n.htm
+++ b/mons/dosburu_n.htm
@@ -80,7 +80,7 @@
 <img id=icon src="../img/monsicons/bulldrome.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>80</td><td>70</td><td>80</td><td>50</td><td>50</td><td>120</td><td>10</td><td>40</td><td>150</td></tr>
 <tr><td>Torso</td><td>80</td><td>70</td><td>80</td><td>50</td><td>50</td><td>120</td><td>10</td><td>40</td><td>0</td></tr>

--- a/mons/dosburu_ng.htm
+++ b/mons/dosburu_ng.htm
@@ -123,7 +123,7 @@
 <img id=icon src="../img/monsicons/bulldrome.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>40</td><td>40</td><td>40</td><td>20</td><td>30</td><td>0</td><td>10</td><td>100</td></tr>
 <tr><td>Torso</td><td>40</td><td>30</td><td>40</td><td>50</td><td>20</td><td>30</td><td>0</td><td>10</td><td>0</td></tr>

--- a/mons/dosburu_nh.htm
+++ b/mons/dosburu_nh.htm
@@ -76,7 +76,7 @@
 <img id=icon src="../img/monsicons/bulldrome.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>20</td><td>15</td><td>-10</td><td>-10</td><td>-15</td><td>-20</td><td>-10</td><td>250</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>15</td><td>-10</td><td>-10</td><td>-15</td><td>-20</td><td>-10</td><td>0</td></tr>

--- a/mons/dosburu_nt.htm
+++ b/mons/dosburu_nt.htm
@@ -103,7 +103,7 @@
 <img id=icon src="../img/monsicons/bulldrome.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>40</td><td>40</td><td>50</td><td>50</td><td>60</td><td>0</td><td>40</td><td>100</td></tr>
 <tr><td>Torso</td><td>40</td><td>30</td><td>40</td><td>50</td><td>50</td><td>60</td><td>0</td><td>40</td><td>0</td></tr>

--- a/mons/dosgare_n.htm
+++ b/mons/dosgare_n.htm
@@ -80,7 +80,7 @@
 <img id=icon src="../img/monsicons/cephadrome.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>50</td><td>60</td><td>0</td><td>10</td><td>15</td><td>5</td><td>30</td><td>80</td></tr>
 <tr><td>Neck</td><td>110</td><td>100</td><td>150</td><td>5</td><td>10</td><td>15</td><td>5</td><td>15</td><td>0</td></tr>
@@ -97,11 +97,11 @@
 <tr><td>Torso</td><td>150</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>100</td><td></td></tr>
 <tr><td>Right Wing</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>170</td><td><div>
+<tr><td>Left Leg</td><td>170</td><td><div>
 <span><em>11</em>226</span><span><em>12</em>230</span><span><em>13</em>235</span><span><em>14</em>241</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>170</td><td><div>
+<tr><td>Right Leg</td><td>170</td><td><div>
 <span><em>11</em>226</span><span><em>12</em>230</span><span><em>13</em>235</span><span><em>14</em>241</span>
 </div>
 </td></tr>

--- a/mons/dosgare_ng.htm
+++ b/mons/dosgare_ng.htm
@@ -104,7 +104,7 @@
 <img id=icon src="../img/monsicons/cephadrome.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>35</td><td>30</td><td>0</td><td>10</td><td>15</td><td>5</td><td>30</td><td>80</td></tr>
 <tr><td>Neck</td><td>60</td><td>65</td><td>70</td><td>5</td><td>10</td><td>15</td><td>5</td><td>15</td><td>0</td></tr>
@@ -121,8 +121,8 @@
 <tr><td>Torso</td><td>500</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>300</td><td></td></tr>
 <tr><td>Right Wing</td><td>300</td><td></td></tr>
-<tr><td>Left Foot</td><td>350</td><td></td></tr>
-<tr><td>Right Foot</td><td>350</td><td></td></tr>
+<tr><td>Left Leg</td><td>350</td><td></td></tr>
+<tr><td>Right Leg</td><td>350</td><td></td></tr>
 <tr><td>Neck</td><td>600</td><td></td></tr>
 <tr><td>Head</td><td>350</td><td></td></tr>
 <tr><td>Tail</td><td>350</td><td></td></tr>

--- a/mons/dosgare_nh.htm
+++ b/mons/dosgare_nh.htm
@@ -77,7 +77,7 @@
 <img id=icon src="../img/monsicons/cephadrome.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>40</td><td>10</td><td>5</td><td>15</td><td>5</td><td>0</td><td>80</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>10</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
@@ -94,8 +94,8 @@
 <tr><td>Torso</td><td>150</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>100</td><td></td></tr>
 <tr><td>Right Wing</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>170</td><td></td></tr>
-<tr><td>Right Foot</td><td>170</td><td></td></tr>
+<tr><td>Left Leg</td><td>170</td><td></td></tr>
+<tr><td>Right Leg</td><td>170</td><td></td></tr>
 <tr><td>Neck</td><td>80</td><td></td></tr>
 <tr><td>Head</td><td>100</td><td></td></tr>
 <tr><td>Tail</td><td>100</td><td></td></tr>

--- a/mons/dosgene_n.htm
+++ b/mons/dosgene_n.htm
@@ -70,7 +70,7 @@
 <img id=icon src="../img/monsicons/gendrome.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>90</td><td>90</td><td>90</td><td>35</td><td>10</td><td>40</td><td>10</td><td>50</td><td>100</td></tr>
 </table>

--- a/mons/dosgene_ng.htm
+++ b/mons/dosgene_ng.htm
@@ -102,7 +102,7 @@
 <img id=icon src="../img/monsicons/gendrome.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>55</td><td>55</td><td>55</td><td>25</td><td>5</td><td>25</td><td>5</td><td>40</td><td>100</td></tr>
 </table>

--- a/mons/dosgene_nh.htm
+++ b/mons/dosgene_nh.htm
@@ -75,7 +75,7 @@
 <img id=icon src="../img/monsicons/gendrome.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>75</td><td>55</td><td>40</td><td>15</td><td>15</td><td>5</td><td>0</td><td>5</td><td>100</td></tr>
 </table>

--- a/mons/dosios_n.htm
+++ b/mons/dosios_n.htm
@@ -70,7 +70,7 @@
 <img id=icon src="../img/monsicons/iodrome.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>80</td><td>80</td><td>80</td><td>20</td><td>30</td><td>30</td><td>10</td><td>10</td><td>100</td></tr>
 </table>

--- a/mons/dosios_ng.htm
+++ b/mons/dosios_ng.htm
@@ -97,7 +97,7 @@
 <img id=icon src="../img/monsicons/iodrome.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>50</td><td>50</td><td>50</td><td>10</td><td>30</td><td>30</td><td>10</td><td>5</td><td>100</td></tr>
 </table>

--- a/mons/dosios_nh.htm
+++ b/mons/dosios_nh.htm
@@ -76,7 +76,7 @@
 <img id=icon src="../img/monsicons/iodrome.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>75</td><td>70</td><td>45</td><td>10</td><td>5</td><td>10</td><td>0</td><td>15</td><td>100</td></tr>
 </table>

--- a/mons/dosran_n.htm
+++ b/mons/dosran_n.htm
@@ -78,7 +78,7 @@
 <img id=icon src="../img/monsicons/velocidrome.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>100</td><td>100</td><td>100</td><td>50</td><td>50</td><td>50</td><td>10</td><td>60</td><td>100</td></tr>
 </table>

--- a/mons/dosran_ng.htm
+++ b/mons/dosran_ng.htm
@@ -103,7 +103,7 @@
 <img id=icon src="../img/monsicons/velocidrome.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>60</td><td>60</td><td>60</td><td>20</td><td>20</td><td>20</td><td>10</td><td>30</td><td>100</td></tr>
 </table>

--- a/mons/dosran_nh.htm
+++ b/mons/dosran_nh.htm
@@ -76,7 +76,7 @@
 <img id=icon src="../img/monsicons/velocidrome.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>50</td><td>60</td><td>40</td><td>20</td><td>5</td><td>10</td><td>0</td><td>5</td><td>100</td></tr>
 </table>

--- a/mons/dosran_nt.htm
+++ b/mons/dosran_nt.htm
@@ -103,7 +103,7 @@
 <img id=icon src="../img/monsicons/velocidrome.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>60</td><td>60</td><td>60</td><td>50</td><td>50</td><td>50</td><td>10</td><td>60</td><td>100</td></tr>
 </table>

--- a/mons/dura_n.htm
+++ b/mons/dura_n.htm
@@ -73,32 +73,32 @@
 <img id=icon src="../img/monsicons/dyuragaua.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>55</td><td>30</td><td>10</td><td>0</td><td>15</td><td>15</td><td>0</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>50</td><td>40</td><td>25</td><td>10</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>50</td><td>40</td><td>25</td><td>10</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>45</td><td>40</td><td>35</td><td>15</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>25</td><td>20</td><td>30</td><td>15</td><td>0</td><td>10</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>35</td><td>25</td><td>15</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
-<tr><td>尾</td><td>20</td><td>15</td><td>20</td><td>15</td><td>0</td><td>10</td><td>25</td><td>0</td><td>0</td></tr>
+<tr><td>Tail</td><td>20</td><td>15</td><td>20</td><td>15</td><td>0</td><td>10</td><td>25</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>55</td><td>45</td><td>35</td><td>10</td><td>0</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>60</td><td>35</td><td>15</td><td>0</td><td>10</td><td>20</td><td>0</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>55</td><td>45</td><td>30</td><td>15</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>55</td><td>45</td><td>30</td><td>15</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>45</td><td>40</td><td>50</td><td>10</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>25</td><td>20</td><td>45</td><td>10</td><td>0</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>35</td><td>40</td><td>10</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>尾</td><td>20</td><td>15</td><td>20</td><td>10</td><td>0</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
+<tr><td>Tail</td><td>20</td><td>15</td><td>20</td><td>10</td><td>0</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>60</td><td>50</td><td>40</td><td>15</td><td>0</td><td>10</td><td>25</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(回転攻撃時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(回転攻撃時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>60</td><td>30</td><td>10</td><td>0</td><td>15</td><td>15</td><td>0</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>55</td><td>45</td><td>25</td><td>10</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>55</td><td>45</td><td>25</td><td>10</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>45</td><td>40</td><td>35</td><td>15</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>25</td><td>20</td><td>30</td><td>15</td><td>0</td><td>10</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>35</td><td>25</td><td>15</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
-<tr><td>尾</td><td>20</td><td>15</td><td>20</td><td>15</td><td>0</td><td>10</td><td>25</td><td>0</td><td>0</td></tr>
+<tr><td>Tail</td><td>20</td><td>15</td><td>20</td><td>15</td><td>0</td><td>10</td><td>25</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>60</td><td>50</td><td>35</td><td>10</td><td>0</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -109,11 +109,11 @@
 <span><em>若</em>350</span>
 </div>
 ２ stagger(s) required (Must be Enraged)</td></tr>
-<tr><td>右爪</td><td>700</td><td><div>
+<tr><td>Right Claw</td><td>700</td><td><div>
 <span><em>若</em>350</span>
 </div>
 ２ stagger(s) required (Must be Enraged)</td></tr>
-<tr><td>左爪</td><td>700</td><td><div>
+<tr><td>Left Claw</td><td>700</td><td><div>
 <span><em>若</em>350</span>
 </div>
 ２ stagger(s) required (Must be Enraged)</td></tr>
@@ -133,7 +133,7 @@
 <span><em>若</em>1000</span>
 </div>
 </td></tr>
-<tr><td>尻尾先端</td><td>600</td><td><div>
+<tr><td>Tail Tip</td><td>600</td><td><div>
 <span><em>若</em>350</span>
 </div>
 ２ stagger(s) required (Must be Enraged)</td></tr>

--- a/mons/dura_ng.htm
+++ b/mons/dura_ng.htm
@@ -124,32 +124,32 @@
 <img id=icon src="../img/monsicons/dyuragaua.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>55</td><td>30</td><td>10</td><td>0</td><td>30</td><td>20</td><td>0</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>50</td><td>30</td><td>25</td><td>10</td><td>0</td><td>30</td><td>15</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>50</td><td>30</td><td>25</td><td>10</td><td>0</td><td>30</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>45</td><td>40</td><td>35</td><td>15</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>20</td><td>20</td><td>30</td><td>15</td><td>0</td><td>10</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>35</td><td>25</td><td>15</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
-<tr><td>尾</td><td>20</td><td>15</td><td>20</td><td>15</td><td>0</td><td>10</td><td>25</td><td>0</td><td>0</td></tr>
+<tr><td>Tail</td><td>20</td><td>15</td><td>20</td><td>15</td><td>0</td><td>10</td><td>25</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>55</td><td>45</td><td>35</td><td>10</td><td>0</td><td>15</td><td>30</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>60</td><td>35</td><td>15</td><td>0</td><td>25</td><td>25</td><td>0</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>55</td><td>35</td><td>30</td><td>15</td><td>0</td><td>20</td><td>20</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>55</td><td>35</td><td>30</td><td>15</td><td>0</td><td>20</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>45</td><td>40</td><td>50</td><td>10</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>20</td><td>20</td><td>45</td><td>10</td><td>0</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>35</td><td>40</td><td>10</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>尾</td><td>20</td><td>15</td><td>20</td><td>10</td><td>0</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
+<tr><td>Tail</td><td>20</td><td>15</td><td>20</td><td>10</td><td>0</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>60</td><td>50</td><td>40</td><td>15</td><td>0</td><td>10</td><td>35</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(回転攻撃時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(回転攻撃時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>60</td><td>30</td><td>10</td><td>0</td><td>30</td><td>20</td><td>0</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>55</td><td>35</td><td>25</td><td>10</td><td>0</td><td>30</td><td>15</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>55</td><td>35</td><td>25</td><td>10</td><td>0</td><td>30</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>45</td><td>40</td><td>35</td><td>15</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>25</td><td>20</td><td>30</td><td>15</td><td>0</td><td>10</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>35</td><td>25</td><td>15</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
-<tr><td>尾</td><td>20</td><td>15</td><td>20</td><td>15</td><td>0</td><td>10</td><td>25</td><td>0</td><td>0</td></tr>
+<tr><td>Tail</td><td>20</td><td>15</td><td>20</td><td>15</td><td>0</td><td>10</td><td>25</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>60</td><td>50</td><td>35</td><td>10</td><td>0</td><td>15</td><td>30</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -157,13 +157,13 @@
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>800</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
-<tr><td>右爪</td><td>1000</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
-<tr><td>左爪</td><td>1000</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
+<tr><td>Right Claw</td><td>1000</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
+<tr><td>Left Claw</td><td>1000</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Hind Leg</td><td>800</td><td></td></tr>
 <tr><td>Belly</td><td>1700</td><td></td></tr>
 <tr><td>Back</td><td>1500</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Tail</td><td>2500</td><td></td></tr>
-<tr><td>尻尾先端</td><td>900</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
+<tr><td>Tail Tip</td><td>900</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/dyuragaua.png" width="400"/>
 <script type="text/javascript" src="hover.js"></script>

--- a/mons/dura_nh.htm
+++ b/mons/dura_nh.htm
@@ -82,32 +82,32 @@
 <img id=icon src="../img/monsicons/dyuragaua.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>45</td><td>20</td><td>5</td><td>0</td><td>10</td><td>10</td><td>0</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>40</td><td>30</td><td>15</td><td>5</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>40</td><td>30</td><td>15</td><td>5</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>35</td><td>30</td><td>25</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>20</td><td>15</td><td>20</td><td>10</td><td>0</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>25</td><td>30</td><td>15</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>尾</td><td>15</td><td>10</td><td>15</td><td>10</td><td>0</td><td>5</td><td>20</td><td>0</td><td>0</td></tr>
+<tr><td>Tail</td><td>15</td><td>10</td><td>15</td><td>10</td><td>0</td><td>5</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>45</td><td>35</td><td>25</td><td>5</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>50</td><td>25</td><td>10</td><td>0</td><td>5</td><td>15</td><td>0</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>45</td><td>35</td><td>20</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>45</td><td>35</td><td>20</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>35</td><td>30</td><td>40</td><td>5</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>20</td><td>15</td><td>35</td><td>5</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>25</td><td>30</td><td>25</td><td>5</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>尾</td><td>15</td><td>10</td><td>15</td><td>5</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
+<tr><td>Tail</td><td>15</td><td>10</td><td>15</td><td>5</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>50</td><td>40</td><td>30</td><td>10</td><td>0</td><td>5</td><td>20</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(回転攻撃時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(回転攻撃時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>50</td><td>20</td><td>5</td><td>0</td><td>10</td><td>10</td><td>0</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>45</td><td>35</td><td>15</td><td>5</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>45</td><td>35</td><td>15</td><td>5</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>35</td><td>30</td><td>25</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>20</td><td>15</td><td>15</td><td>10</td><td>0</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>25</td><td>30</td><td>20</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>尾</td><td>15</td><td>10</td><td>15</td><td>10</td><td>0</td><td>5</td><td>20</td><td>0</td><td>0</td></tr>
+<tr><td>Tail</td><td>15</td><td>10</td><td>15</td><td>10</td><td>0</td><td>5</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>50</td><td>40</td><td>25</td><td>5</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -115,13 +115,13 @@
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>700</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
-<tr><td>右爪</td><td>800</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
-<tr><td>左爪</td><td>800</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
+<tr><td>Right Claw</td><td>800</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
+<tr><td>Left Claw</td><td>800</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Hind Leg</td><td>700</td><td></td></tr>
 <tr><td>Belly</td><td>1800</td><td></td></tr>
 <tr><td>Back</td><td>1200</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Tail</td><td>2400</td><td></td></tr>
-<tr><td>尻尾先端</td><td>700</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
+<tr><td>Tail Tip</td><td>700</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/dyuragaua.png" width="400"/>
 <script type="text/javascript" src="hover.js"></script>

--- a/mons/dura_nt.htm
+++ b/mons/dura_nt.htm
@@ -104,32 +104,32 @@
 <img id=icon src="../img/monsicons/dyuragaua.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>55</td><td>30</td><td>10</td><td>0</td><td>30</td><td>20</td><td>0</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>50</td><td>30</td><td>25</td><td>10</td><td>0</td><td>30</td><td>15</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>50</td><td>30</td><td>25</td><td>10</td><td>0</td><td>30</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>45</td><td>40</td><td>35</td><td>15</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>20</td><td>20</td><td>30</td><td>15</td><td>0</td><td>10</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>35</td><td>25</td><td>15</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
-<tr><td>尾</td><td>20</td><td>15</td><td>20</td><td>15</td><td>0</td><td>10</td><td>25</td><td>0</td><td>0</td></tr>
+<tr><td>Tail</td><td>20</td><td>15</td><td>20</td><td>15</td><td>0</td><td>10</td><td>25</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>55</td><td>45</td><td>35</td><td>10</td><td>0</td><td>15</td><td>30</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>60</td><td>35</td><td>15</td><td>0</td><td>25</td><td>25</td><td>0</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>55</td><td>35</td><td>30</td><td>15</td><td>0</td><td>20</td><td>20</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>55</td><td>35</td><td>30</td><td>15</td><td>0</td><td>20</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>45</td><td>40</td><td>50</td><td>10</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>20</td><td>20</td><td>45</td><td>10</td><td>0</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>35</td><td>40</td><td>10</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>尾</td><td>20</td><td>15</td><td>20</td><td>10</td><td>0</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
+<tr><td>Tail</td><td>20</td><td>15</td><td>20</td><td>10</td><td>0</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>60</td><td>50</td><td>40</td><td>15</td><td>0</td><td>10</td><td>35</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(回転攻撃時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(回転攻撃時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>60</td><td>30</td><td>10</td><td>0</td><td>30</td><td>20</td><td>0</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>55</td><td>35</td><td>25</td><td>10</td><td>0</td><td>30</td><td>15</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>55</td><td>35</td><td>25</td><td>10</td><td>0</td><td>30</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>45</td><td>40</td><td>35</td><td>15</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>25</td><td>20</td><td>30</td><td>15</td><td>0</td><td>10</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>35</td><td>25</td><td>15</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
-<tr><td>尾</td><td>20</td><td>15</td><td>20</td><td>15</td><td>0</td><td>10</td><td>25</td><td>0</td><td>0</td></tr>
+<tr><td>Tail</td><td>20</td><td>15</td><td>20</td><td>15</td><td>0</td><td>10</td><td>25</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>60</td><td>50</td><td>35</td><td>10</td><td>0</td><td>15</td><td>30</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -137,13 +137,13 @@
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>600</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
-<tr><td>右爪</td><td>700</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
-<tr><td>左爪</td><td>700</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
+<tr><td>Right Claw</td><td>700</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
+<tr><td>Left Claw</td><td>700</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Hind Leg</td><td>600</td><td></td></tr>
 <tr><td>Belly</td><td>1500</td><td></td></tr>
 <tr><td>Back</td><td>1000</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Tail</td><td>2000</td><td></td></tr>
-<tr><td>尻尾先端</td><td>600</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
+<tr><td>Tail Tip</td><td>600</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/dyuragaua.png" width="400"/>
 <script type="text/javascript" src="hover.js"></script>

--- a/mons/egura_n.htm
+++ b/mons/egura_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/egy.webp" width="300"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>50</td><td>65</td><td>55</td><td>0</td><td>20</td><td>5</td><td>25</td><td>15</td><td>100</td></tr>
 <tr><td>？？</td><td>60</td><td>45</td><td>45</td><td>0</td><td>15</td><td>5</td><td>15</td><td>20</td><td>0</td></tr>

--- a/mons/elze_ng.htm
+++ b/mons/elze_ng.htm
@@ -99,7 +99,7 @@
 <img id=icon src="../img/monsicons/elzelion.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>35</td><td>40</td><td>40</td><td>15</td><td>10</td><td>10</td><td>0</td><td>15</td><td>100</td></tr>
 <tr><td>？？</td><td>25</td><td>20</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
@@ -108,7 +108,7 @@
 <tr><td>？？</td><td>20</td><td>20</td><td>15</td><td>0</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>？？</td><td>20</td><td>20</td><td>15</td><td>15</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>？？</td><td>30</td><td>10</td><td>25</td><td>10</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>30</td><td>35</td><td>35</td><td>10</td><td>5</td><td>5</td><td>0</td><td>10</td><td>100</td></tr>
 <tr><td>？？</td><td>20</td><td>15</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>

--- a/mons/erupe_n.htm
+++ b/mons/erupe_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/erupe.webp" width="250"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>100</td><td>100</td><td>100</td><td>30</td><td>10</td><td>10</td><td>0</td><td>10</td><td>0</td></tr>
 </table>

--- a/mons/esp_n.htm
+++ b/mons/esp_n.htm
@@ -79,7 +79,7 @@
 <img id=icon src="../img/monsicons/espinas.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>20</td><td>40</td><td>0</td><td>10</td><td>5</td><td>10</td><td>30</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>25</td><td>0</td><td>10</td><td>5</td><td>10</td><td>15</td><td>0</td></tr>
@@ -88,7 +88,7 @@
 <tr><td>Tail</td><td>25</td><td>25</td><td>25</td><td>0</td><td>5</td><td>5</td><td>5</td><td>25</td><td>0</td></tr>
 <tr><td>Wing</td><td>10</td><td>25</td><td>10</td><td>0</td><td>5</td><td>5</td><td>10</td><td>15</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>45</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>70</td><td>40</td><td>30</td><td>0</td><td>10</td><td>5</td><td>15</td><td>40</td><td>100</td></tr>
 <tr><td>Neck</td><td>60</td><td>35</td><td>25</td><td>0</td><td>10</td><td>5</td><td>10</td><td>20</td><td>0</td></tr>
@@ -114,15 +114,15 @@
 <span><em>59</em>598</span>
 </div>
 １ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
-<tr><td>Left Foot</td><td>300</td><td><div>
+<tr><td>Left Leg</td><td>300</td><td><div>
 <span><em>11</em>399</span><span><em>12</em>407</span><span><em>17</em>447</span><span><em>若11</em>399</span><span><em>59</em>899</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>300</td><td><div>
+<tr><td>Right Leg</td><td>300</td><td><div>
 <span><em>11</em>399</span><span><em>12</em>407</span><span><em>17</em>447</span><span><em>若11</em>399</span><span><em>59</em>900</span>
 </div>
 </td></tr>
-<tr><td>首/背中</td><td>250</td><td><div>
+<tr><td>Neck/Back</td><td>250</td><td><div>
 <span><em>59</em>749</span>
 </div>
 ２ stagger(s) required (Must be Enraged)</td></tr>

--- a/mons/esp_ng.htm
+++ b/mons/esp_ng.htm
@@ -124,7 +124,7 @@
 <img id=icon src="../img/monsicons/espinas.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>20</td><td>35</td><td>0</td><td>10</td><td>5</td><td>10</td><td>30</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>25</td><td>0</td><td>10</td><td>5</td><td>10</td><td>15</td><td>0</td></tr>
@@ -133,7 +133,7 @@
 <tr><td>Tail</td><td>25</td><td>25</td><td>25</td><td>0</td><td>5</td><td>5</td><td>5</td><td>25</td><td>0</td></tr>
 <tr><td>Wing</td><td>10</td><td>25</td><td>10</td><td>0</td><td>5</td><td>5</td><td>10</td><td>15</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>40</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>40</td><td>30</td><td>0</td><td>10</td><td>5</td><td>15</td><td>40</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>35</td><td>25</td><td>0</td><td>10</td><td>5</td><td>10</td><td>20</td><td>0</td></tr>
@@ -150,9 +150,9 @@
 <tr><td>Torso</td><td>500</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Left Wing</td><td>400</td><td>１ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
 <tr><td>Right Wing</td><td>400</td><td>１ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
-<tr><td>Left Foot</td><td>450</td><td></td></tr>
-<tr><td>Right Foot</td><td>450</td><td></td></tr>
-<tr><td>首/背中</td><td>450</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
+<tr><td>Left Leg</td><td>450</td><td></td></tr>
+<tr><td>Right Leg</td><td>450</td><td></td></tr>
+<tr><td>Neck/Back</td><td>450</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Head</td><td>550</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Tail</td><td>450</td><td></td></tr>
 <tr><td>Tail Cut</td><td>800</td><td>Reach the required HP threshold and deal enough Cutting damage<br> (Must be Enraged)</td></tr>

--- a/mons/esp_nh.htm
+++ b/mons/esp_nh.htm
@@ -83,7 +83,7 @@
 <img id=icon src="../img/monsicons/espinas.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>20</td><td>30</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
@@ -92,7 +92,7 @@
 <tr><td>Tail</td><td>35</td><td>25</td><td>20</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>10</td><td>25</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>30</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>70</td><td>40</td><td>45</td><td>-5</td><td>10</td><td>15</td><td>5</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>60</td><td>35</td><td>10</td><td>10</td><td>-5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
@@ -109,9 +109,9 @@
 <tr><td>Torso</td><td>300</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Left Wing</td><td>200</td><td>１ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
 <tr><td>Right Wing</td><td>200</td><td>１ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
-<tr><td>Left Foot</td><td>300</td><td></td></tr>
-<tr><td>Right Foot</td><td>300</td><td></td></tr>
-<tr><td>首/背中</td><td>250</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
+<tr><td>Left Leg</td><td>300</td><td></td></tr>
+<tr><td>Right Leg</td><td>300</td><td></td></tr>
+<tr><td>Neck/Back</td><td>250</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Head</td><td>200</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Tail</td><td>300</td><td></td></tr>
 <tr><td>Tail Cut</td><td>400</td><td>Reach the required HP threshold and deal enough Cutting damage<br> (Must be Enraged)</td></tr>

--- a/mons/esp_ni.htm
+++ b/mons/esp_ni.htm
@@ -112,7 +112,7 @@
 <img id=icon src="../img/monsicons/zenith_espinas.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>20</td><td>10</td><td>0</td><td>10</td><td>5</td><td>10</td><td>15</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>15</td><td>15</td><td>0</td><td>10</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
@@ -121,7 +121,7 @@
 <tr><td>Tail</td><td>20</td><td>10</td><td>15</td><td>0</td><td>5</td><td>5</td><td>5</td><td>20</td><td>0</td></tr>
 <tr><td>Wing</td><td>10</td><td>10</td><td>10</td><td>0</td><td>5</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>5</td><td>10</td><td>5</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>35</td><td>25</td><td>0</td><td>10</td><td>5</td><td>15</td><td>15</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>15</td><td>15</td><td>0</td><td>10</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
@@ -138,9 +138,9 @@
 <tr><td>Torso</td><td>1200</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Left Wing</td><td>1000</td><td>１ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
 <tr><td>Right Wing</td><td>1000</td><td>１ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
-<tr><td>Left Foot</td><td>850</td><td></td></tr>
-<tr><td>Right Foot</td><td>850</td><td></td></tr>
-<tr><td>首/背中</td><td>700</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
+<tr><td>Left Leg</td><td>850</td><td></td></tr>
+<tr><td>Right Leg</td><td>850</td><td></td></tr>
+<tr><td>Neck/Back</td><td>700</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Head</td><td>5000</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Tail</td><td>750</td><td></td></tr>
 <tr><td>Tail Cut</td><td>2000</td><td>Reach the required HP threshold and deal enough Cutting damage<br> (Must be Enraged)</td></tr>

--- a/mons/esp_nt.htm
+++ b/mons/esp_nt.htm
@@ -104,7 +104,7 @@
 <img id=icon src="../img/monsicons/espinas.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>20</td><td>35</td><td>0</td><td>10</td><td>5</td><td>10</td><td>30</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>25</td><td>0</td><td>10</td><td>5</td><td>10</td><td>15</td><td>0</td></tr>
@@ -113,7 +113,7 @@
 <tr><td>Tail</td><td>25</td><td>25</td><td>25</td><td>0</td><td>5</td><td>5</td><td>5</td><td>25</td><td>0</td></tr>
 <tr><td>Wing</td><td>10</td><td>25</td><td>10</td><td>0</td><td>5</td><td>5</td><td>10</td><td>15</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>40</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>40</td><td>30</td><td>0</td><td>10</td><td>5</td><td>15</td><td>40</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>35</td><td>25</td><td>0</td><td>10</td><td>5</td><td>10</td><td>20</td><td>0</td></tr>
@@ -130,9 +130,9 @@
 <tr><td>Torso</td><td>300</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Left Wing</td><td>200</td><td>１ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
 <tr><td>Right Wing</td><td>200</td><td>１ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
-<tr><td>Left Foot</td><td>300</td><td></td></tr>
-<tr><td>Right Foot</td><td>300</td><td></td></tr>
-<tr><td>首/背中</td><td>250</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
+<tr><td>Left Leg</td><td>300</td><td></td></tr>
+<tr><td>Right Leg</td><td>300</td><td></td></tr>
+<tr><td>Neck/Back</td><td>250</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Head</td><td>200</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Tail</td><td>300</td><td></td></tr>
 <tr><td>Tail Cut</td><td>400</td><td>Reach the required HP threshold and deal enough Cutting damage<br> (Must be Enraged)</td></tr>

--- a/mons/espcya_n.htm
+++ b/mons/espcya_n.htm
@@ -77,7 +77,7 @@
 <img id=icon src="../img/monsicons/orangeespinas.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>20</td><td>40</td><td>10</td><td>30</td><td>10</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>25</td><td>10</td><td>15</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
@@ -86,7 +86,7 @@
 <tr><td>Tail</td><td>25</td><td>25</td><td>25</td><td>5</td><td>25</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>10</td><td>25</td><td>10</td><td>5</td><td>15</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>45</td><td>5</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>70</td><td>40</td><td>25</td><td>10</td><td>40</td><td>15</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>60</td><td>35</td><td>20</td><td>10</td><td>20</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
@@ -95,7 +95,7 @@
 <tr><td>Tail</td><td>35</td><td>30</td><td>20</td><td>5</td><td>30</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>40</td><td>35</td><td>20</td><td>5</td><td>20</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>35</td><td>5</td><td>10</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(溜め時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(溜め時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>70</td><td>40</td><td>20</td><td>10</td><td>40</td><td>15</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>60</td><td>35</td><td>15</td><td>10</td><td>20</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
@@ -112,15 +112,15 @@
 <tr><td>Torso</td><td>300</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Left Wing</td><td>200</td><td>１ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
 <tr><td>Right Wing</td><td>200</td><td>１ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
-<tr><td>Left Foot</td><td>300</td><td><div>
+<tr><td>Left Leg</td><td>300</td><td><div>
 <span><em>14</em>423</span><span><em>15</em>431</span><span><em>14若</em>423</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>300</td><td><div>
+<tr><td>Right Leg</td><td>300</td><td><div>
 <span><em>14</em>423</span><span><em>15</em>431</span><span><em>14若</em>423</span>
 </div>
 </td></tr>
-<tr><td>首/背中</td><td>250</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
+<tr><td>Neck/Back</td><td>250</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Head</td><td>200</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Tail</td><td>300</td><td></td></tr>
 <tr><td>Tail Cut</td><td>400</td><td><div>

--- a/mons/espcya_ng.htm
+++ b/mons/espcya_ng.htm
@@ -124,7 +124,7 @@
 <img id=icon src="../img/monsicons/orangeespinas.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>20</td><td>35</td><td>10</td><td>25</td><td>10</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>25</td><td>10</td><td>10</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
@@ -133,7 +133,7 @@
 <tr><td>Tail</td><td>25</td><td>25</td><td>25</td><td>5</td><td>15</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>10</td><td>25</td><td>10</td><td>5</td><td>10</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>40</td><td>5</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>40</td><td>30</td><td>10</td><td>35</td><td>15</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>35</td><td>25</td><td>10</td><td>15</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
@@ -142,7 +142,7 @@
 <tr><td>Tail</td><td>35</td><td>25</td><td>25</td><td>5</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>30</td><td>30</td><td>25</td><td>5</td><td>15</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>30</td><td>5</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(溜め時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(溜め時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>70</td><td>40</td><td>20</td><td>10</td><td>40</td><td>15</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>60</td><td>35</td><td>15</td><td>10</td><td>20</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
@@ -151,7 +151,7 @@
 <tr><td>Tail</td><td>35</td><td>30</td><td>15</td><td>5</td><td>30</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>40</td><td>35</td><td>15</td><td>5</td><td>20</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>30</td><td>5</td><td>10</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質()</th></tr>
+<tr class=l><th colspan=10>Hitzones()</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>20</td><td>35</td><td>10</td><td>25</td><td>10</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>25</td><td>10</td><td>10</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
@@ -160,7 +160,7 @@
 <tr><td>Tail</td><td>25</td><td>25</td><td>25</td><td>5</td><td>15</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>10</td><td>25</td><td>10</td><td>5</td><td>10</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>15</td><td>40</td><td>5</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質()</th></tr>
+<tr class=l><th colspan=10>Hitzones()</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>50</td><td>35</td><td>10</td><td>35</td><td>15</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>35</td><td>30</td><td>25</td><td>10</td><td>15</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
@@ -169,7 +169,7 @@
 <tr><td>Tail</td><td>35</td><td>25</td><td>25</td><td>5</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>30</td><td>35</td><td>25</td><td>5</td><td>15</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>10</td><td>30</td><td>5</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質()</th></tr>
+<tr class=l><th colspan=10>Hitzones()</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>75</td><td>75</td><td>60</td><td>10</td><td>40</td><td>15</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>65</td><td>60</td><td>55</td><td>10</td><td>20</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
@@ -186,9 +186,9 @@
 <tr><td>Torso</td><td>900</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Left Wing</td><td>450</td><td>１ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
 <tr><td>Right Wing</td><td>450</td><td>１ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
-<tr><td>Left Foot</td><td>650</td><td></td></tr>
-<tr><td>Right Foot</td><td>650</td><td></td></tr>
-<tr><td>首/背中</td><td>550</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
+<tr><td>Left Leg</td><td>650</td><td></td></tr>
+<tr><td>Right Leg</td><td>650</td><td></td></tr>
+<tr><td>Neck/Back</td><td>550</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Head</td><td>750</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Tail</td><td>550</td><td></td></tr>
 <tr><td>Tail Cut</td><td>800</td><td>Reach the required HP threshold and deal enough Cutting damage<br> (Must be Enraged)</td></tr>

--- a/mons/espcya_nh.htm
+++ b/mons/espcya_nh.htm
@@ -87,7 +87,7 @@
 <img id=icon src="../img/monsicons/orangeespinas.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>25</td><td>30</td><td>10</td><td>20</td><td>5</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
@@ -96,7 +96,7 @@
 <tr><td>Tail</td><td>25</td><td>20</td><td>30</td><td>5</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>10</td><td>15</td><td>10</td><td>0</td><td>10</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>40</td><td>0</td><td>0</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>55</td><td>45</td><td>30</td><td>10</td><td>20</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>45</td><td>35</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
@@ -105,7 +105,7 @@
 <tr><td>Tail</td><td>45</td><td>30</td><td>25</td><td>5</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>40</td><td>35</td><td>15</td><td>0</td><td>10</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>35</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(溜め時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(溜め時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>55</td><td>45</td><td>20</td><td>10</td><td>20</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>45</td><td>35</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
@@ -122,9 +122,9 @@
 <tr><td>Torso</td><td>320</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Left Wing</td><td>230</td><td>１ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
 <tr><td>Right Wing</td><td>230</td><td>１ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
-<tr><td>Left Foot</td><td>300</td><td></td></tr>
-<tr><td>Right Foot</td><td>300</td><td></td></tr>
-<tr><td>首/背中</td><td>300</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
+<tr><td>Left Leg</td><td>300</td><td></td></tr>
+<tr><td>Right Leg</td><td>300</td><td></td></tr>
+<tr><td>Neck/Back</td><td>300</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Head</td><td>300</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Tail</td><td>350</td><td></td></tr>
 <tr><td>Tail Cut</td><td>600</td><td>Reach the required HP threshold and deal enough Cutting damage<br> (Must be Enraged)</td></tr>

--- a/mons/espcya_nt.htm
+++ b/mons/espcya_nt.htm
@@ -104,7 +104,7 @@
 <img id=icon src="../img/monsicons/orangeespinas.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>20</td><td>40</td><td>10</td><td>30</td><td>10</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>25</td><td>10</td><td>15</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
@@ -113,7 +113,7 @@
 <tr><td>Tail</td><td>25</td><td>25</td><td>25</td><td>5</td><td>25</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>10</td><td>25</td><td>10</td><td>5</td><td>15</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>45</td><td>5</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>70</td><td>40</td><td>25</td><td>10</td><td>40</td><td>15</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>60</td><td>35</td><td>20</td><td>10</td><td>20</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
@@ -122,7 +122,7 @@
 <tr><td>Tail</td><td>35</td><td>30</td><td>20</td><td>5</td><td>30</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>40</td><td>35</td><td>20</td><td>5</td><td>20</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>35</td><td>5</td><td>10</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(溜め時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(溜め時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>70</td><td>40</td><td>20</td><td>10</td><td>40</td><td>15</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>60</td><td>35</td><td>15</td><td>10</td><td>20</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
@@ -139,9 +139,9 @@
 <tr><td>Torso</td><td>300</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Left Wing</td><td>200</td><td>１ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
 <tr><td>Right Wing</td><td>200</td><td>１ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
-<tr><td>Left Foot</td><td>300</td><td></td></tr>
-<tr><td>Right Foot</td><td>300</td><td></td></tr>
-<tr><td>首/背中</td><td>250</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
+<tr><td>Left Leg</td><td>300</td><td></td></tr>
+<tr><td>Right Leg</td><td>300</td><td></td></tr>
+<tr><td>Neck/Back</td><td>250</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Head</td><td>200</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Tail</td><td>300</td><td></td></tr>
 <tr><td>Tail Cut</td><td>400</td><td>Reach the required HP threshold and deal enough Cutting damage<br> (Must be Enraged)</td></tr>

--- a/mons/espsiro_n.htm
+++ b/mons/espsiro_n.htm
@@ -63,7 +63,7 @@
 <img id=icon src="../img/monsicons/whiteespinas.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>25</td><td>30</td><td>0</td><td>30</td><td>5</td><td>10</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>10</td><td>15</td><td>0</td><td>20</td><td>5</td><td>5</td><td>10</td><td>0</td></tr>
@@ -72,7 +72,7 @@
 <tr><td>Tail</td><td>25</td><td>20</td><td>15</td><td>0</td><td>5</td><td>5</td><td>25</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>10</td><td>15</td><td>10</td><td>0</td><td>10</td><td>5</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>35</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>60</td><td>20</td><td>0</td><td>40</td><td>5</td><td>15</td><td>15</td><td>100</td></tr>
 <tr><td>Neck</td><td>60</td><td>20</td><td>20</td><td>0</td><td>30</td><td>5</td><td>5</td><td>15</td><td>0</td></tr>
@@ -81,7 +81,7 @@
 <tr><td>Tail</td><td>40</td><td>20</td><td>15</td><td>0</td><td>5</td><td>5</td><td>40</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>35</td><td>30</td><td>15</td><td>0</td><td>10</td><td>5</td><td>25</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>30</td><td>25</td><td>25</td><td>0</td><td>5</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(溜め時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(溜め時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>60</td><td>70</td><td>30</td><td>0</td><td>15</td><td>5</td><td>15</td><td>40</td><td>10</td></tr>
 <tr><td>Neck</td><td>70</td><td>30</td><td>30</td><td>0</td><td>15</td><td>5</td><td>5</td><td>30</td><td>0</td></tr>
@@ -98,15 +98,15 @@
 <tr><td>Torso</td><td>500</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Left Wing</td><td>350</td><td>１ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
 <tr><td>Right Wing</td><td>350</td><td>１ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
-<tr><td>Left Foot</td><td>400</td><td><div>
+<tr><td>Left Leg</td><td>400</td><td><div>
 <span><em>12</em>542</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>400</td><td><div>
+<tr><td>Right Leg</td><td>400</td><td><div>
 <span><em>12</em>542</span>
 </div>
 </td></tr>
-<tr><td>首/背中</td><td>400</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
+<tr><td>Neck/Back</td><td>400</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Head</td><td>350</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Tail</td><td>300</td><td></td></tr>
 <tr><td>Tail Cut</td><td>400</td><td><div>

--- a/mons/espsiro_ng.htm
+++ b/mons/espsiro_ng.htm
@@ -104,7 +104,7 @@
 <img id=icon src="../img/monsicons/whiteespinas.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>25</td><td>25</td><td>0</td><td>30</td><td>5</td><td>10</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>10</td><td>15</td><td>0</td><td>20</td><td>5</td><td>5</td><td>10</td><td>0</td></tr>
@@ -113,7 +113,7 @@
 <tr><td>Tail</td><td>25</td><td>20</td><td>15</td><td>0</td><td>5</td><td>5</td><td>25</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>10</td><td>15</td><td>10</td><td>0</td><td>10</td><td>5</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>20</td><td>30</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>60</td><td>20</td><td>0</td><td>40</td><td>5</td><td>15</td><td>15</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>20</td><td>20</td><td>0</td><td>30</td><td>5</td><td>5</td><td>15</td><td>0</td></tr>
@@ -122,7 +122,7 @@
 <tr><td>Tail</td><td>40</td><td>20</td><td>15</td><td>0</td><td>5</td><td>5</td><td>40</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>25</td><td>5</td><td>0</td><td>10</td><td>5</td><td>25</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>30</td><td>25</td><td>25</td><td>0</td><td>5</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(溜め時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(溜め時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>70</td><td>30</td><td>0</td><td>30</td><td>5</td><td>10</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>60</td><td>30</td><td>30</td><td>0</td><td>20</td><td>5</td><td>5</td><td>10</td><td>0</td></tr>
@@ -139,9 +139,9 @@
 <tr><td>Torso</td><td>850</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Left Wing</td><td>700</td><td>１ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
 <tr><td>Right Wing</td><td>700</td><td>１ stagger(s) required<br>(Must be Enraged: Both must be broken for the reward)</td></tr>
-<tr><td>Left Foot</td><td>600</td><td></td></tr>
-<tr><td>Right Foot</td><td>600</td><td></td></tr>
-<tr><td>首/背中</td><td>750</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
+<tr><td>Left Leg</td><td>600</td><td></td></tr>
+<tr><td>Right Leg</td><td>600</td><td></td></tr>
+<tr><td>Neck/Back</td><td>750</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Head</td><td>950</td><td>２ stagger(s) required (Must be Enraged)</td></tr>
 <tr><td>Tail</td><td>450</td><td></td></tr>
 <tr><td>Tail Cut</td><td>800</td><td>Reach the required HP threshold and deal enough Cutting damage<br> (Must be Enraged)</td></tr>

--- a/mons/faru_ng.htm
+++ b/mons/faru_ng.htm
@@ -115,7 +115,7 @@
 <img id=icon src="../img/monsicons/farunokku.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>60</td><td>50</td><td>10</td><td>25</td><td>0</td><td>5</td><td>30</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>30</td><td>40</td><td>0</td><td>75</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
@@ -132,8 +132,8 @@
 <tr><td>Torso</td><td>500</td><td></td></tr>
 <tr><td>Left Wing</td><td>700</td><td></td></tr>
 <tr><td>Right Wing</td><td>600</td><td></td></tr>
-<tr><td>Left Foot</td><td>600</td><td></td></tr>
-<tr><td>Right Foot</td><td>600</td><td></td></tr>
+<tr><td>Left Leg</td><td>600</td><td></td></tr>
+<tr><td>Right Leg</td><td>600</td><td></td></tr>
 <tr><td>Neck</td><td>600</td><td></td></tr>
 <tr><td>Head</td><td>600</td><td>1st time breaks beak<br>2nd time breaks head</td></tr>
 <tr><td>Tail</td><td>1000</td><td></td></tr>

--- a/mons/folo_ng.htm
+++ b/mons/folo_ng.htm
@@ -102,7 +102,7 @@
 <img id=icon src="../img/monsicons/forokururu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>50</td><td>30</td><td>0</td><td>5</td><td>20</td><td>0</td><td>10</td><td>100</td></tr>
 <tr><td>Throat</td><td>50</td><td>40</td><td>40</td><td>0</td><td>5</td><td>15</td><td>0</td><td>10</td><td>10</td></tr>
@@ -120,8 +120,8 @@
 <tr><td>Torso</td><td>900</td><td></td></tr>
 <tr><td>Left Wing</td><td>1000</td><td>２ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>1000</td><td>２ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>700</td><td></td></tr>
-<tr><td>Right Foot</td><td>700</td><td></td></tr>
+<tr><td>Left Leg</td><td>700</td><td></td></tr>
+<tr><td>Right Leg</td><td>700</td><td></td></tr>
 <tr><td>Back</td><td>900</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>900</td><td></td></tr>
 <tr><td>Tail Cut</td><td>2200</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>

--- a/mons/folo_nh.htm
+++ b/mons/folo_nh.htm
@@ -75,7 +75,7 @@
 <img id=icon src="../img/monsicons/forokururu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>50</td><td>30</td><td>0</td><td>5</td><td>20</td><td>0</td><td>10</td><td>100</td></tr>
 <tr><td>Throat</td><td>50</td><td>40</td><td>40</td><td>0</td><td>5</td><td>15</td><td>0</td><td>10</td><td>10</td></tr>
@@ -93,8 +93,8 @@
 <tr><td>Torso</td><td>650</td><td></td></tr>
 <tr><td>Left Wing</td><td>750</td><td>２ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>750</td><td>２ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>550</td><td></td></tr>
-<tr><td>Right Foot</td><td>550</td><td></td></tr>
+<tr><td>Left Leg</td><td>550</td><td></td></tr>
+<tr><td>Right Leg</td><td>550</td><td></td></tr>
 <tr><td>Back</td><td>500</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>500</td><td></td></tr>
 <tr><td>Tail Cut</td><td>900</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>

--- a/mons/furu_n.htm
+++ b/mons/furu_n.htm
@@ -86,7 +86,7 @@
 <img id=icon src="../img/monsicons/khezu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>60</td><td>90</td><td>40</td><td>5</td><td>0</td><td>5</td><td>5</td><td>150</td></tr>
 <tr><td>Neck</td><td>60</td><td>50</td><td>70</td><td>30</td><td>5</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
@@ -103,11 +103,11 @@
 <tr><td>Torso</td><td>200</td><td>２ stagger(s) required (Break Head and Torso for rewards)</td></tr>
 <tr><td>Left Wing</td><td>120</td><td></td></tr>
 <tr><td>Right Wing</td><td>120</td><td></td></tr>
-<tr><td>Left Foot</td><td>130</td><td><div>
+<tr><td>Left Leg</td><td>130</td><td><div>
 <span><em>12</em>176</span><span><em>13</em>179</span><span><em>14</em>183</span><span><em>15</em>186</span><span><em>16</em>190</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>130</td><td><div>
+<tr><td>Right Leg</td><td>130</td><td><div>
 <span><em>12</em>176</span><span><em>13</em>179</span><span><em>14</em>183</span><span><em>15</em>186</span><span><em>16</em>190</span>
 </div>
 </td></tr>
@@ -119,7 +119,7 @@
 <table id=kou>
 <col span=2><col span=3 class=n><col>
 <tr class=l><th colspan=6>Attack Information</th></tr>
-<tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>首伸ばし噛み</td><td></td><td>55</td><td>40</td><td>10</td><td></td></tr>
+<tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>Neck伸ばし噛み</td><td></td><td>55</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>飛びつき噛み</td><td></td><td>60</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>飛びつき</td><td></td><td>65</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>右回転尻尾攻撃</td><td></td><td>50</td><td>30</td><td>20</td><td></td></tr>

--- a/mons/furu_ng.htm
+++ b/mons/furu_ng.htm
@@ -124,7 +124,7 @@
 <img id=icon src="../img/monsicons/khezu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>60</td><td>60</td><td>40</td><td>5</td><td>0</td><td>5</td><td>5</td><td>150</td></tr>
 <tr><td>Neck</td><td>55</td><td>45</td><td>50</td><td>30</td><td>5</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
@@ -141,8 +141,8 @@
 <tr><td>Torso</td><td>400</td><td>２ stagger(s) required (Break Head and Torso for rewards)</td></tr>
 <tr><td>Left Wing</td><td>350</td><td></td></tr>
 <tr><td>Right Wing</td><td>350</td><td></td></tr>
-<tr><td>Left Foot</td><td>300</td><td></td></tr>
-<tr><td>Right Foot</td><td>300</td><td></td></tr>
+<tr><td>Left Leg</td><td>300</td><td></td></tr>
+<tr><td>Right Leg</td><td>300</td><td></td></tr>
 <tr><td>Neck</td><td>300</td><td></td></tr>
 <tr><td>Head</td><td>450</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>250</td><td></td></tr>
@@ -151,7 +151,7 @@
 <table id=kou>
 <col span=2><col span=3 class=n><col>
 <tr class=l><th colspan=6>Attack Information</th></tr>
-<tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>首伸ばし噛み</td><td></td><td>55</td><td>40</td><td>10</td><td></td></tr>
+<tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>Neck伸ばし噛み</td><td></td><td>55</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>飛びつき噛み</td><td></td><td>60</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>飛びつき</td><td></td><td>65</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>右回転尻尾攻撃</td><td></td><td>50</td><td>30</td><td>20</td><td></td></tr>

--- a/mons/furu_nh.htm
+++ b/mons/furu_nh.htm
@@ -77,7 +77,7 @@
 <img id=icon src="../img/monsicons/khezu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>55</td><td>35</td><td>5</td><td>0</td><td>0</td><td>20</td><td>5</td><td>150</td></tr>
 <tr><td>Neck</td><td>40</td><td>35</td><td>65</td><td>5</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
@@ -94,8 +94,8 @@
 <tr><td>Torso</td><td>200</td><td>２ stagger(s) required (Break Head and Torso for rewards)</td></tr>
 <tr><td>Left Wing</td><td>120</td><td></td></tr>
 <tr><td>Right Wing</td><td>120</td><td></td></tr>
-<tr><td>Left Foot</td><td>130</td><td></td></tr>
-<tr><td>Right Foot</td><td>130</td><td></td></tr>
+<tr><td>Left Leg</td><td>130</td><td></td></tr>
+<tr><td>Right Leg</td><td>130</td><td></td></tr>
 <tr><td>Neck</td><td>140</td><td></td></tr>
 <tr><td>Head</td><td>200</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>90</td><td></td></tr>
@@ -104,7 +104,7 @@
 <table id=kou>
 <col span=2><col span=3 class=n><col>
 <tr class=l><th colspan=6>Attack Information</th></tr>
-<tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>首伸ばし噛み</td><td></td><td>55</td><td>40</td><td>10</td><td></td></tr>
+<tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>Neck伸ばし噛み</td><td></td><td>55</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>飛びつき噛み</td><td></td><td>60</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>飛びつき</td><td></td><td>65</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>右回転尻尾攻撃</td><td></td><td>50</td><td>30</td><td>20</td><td></td></tr>

--- a/mons/furu_ni.htm
+++ b/mons/furu_ni.htm
@@ -112,7 +112,7 @@
 <img id=icon src="../img/monsicons/zenith_khezu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>25</td><td>20</td><td>5</td><td>0</td><td>5</td><td>5</td><td>150</td></tr>
 <tr><td>Neck</td><td>35</td><td>20</td><td>35</td><td>30</td><td>5</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
@@ -129,8 +129,8 @@
 <tr><td>Torso</td><td>800</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>1800</td><td>？ stagger(s) required</td></tr>
 <tr><td>Right Wing</td><td>1800</td><td>？ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>1350</td><td>？ stagger(s) required</td></tr>
-<tr><td>Right Foot</td><td>1350</td><td>？ stagger(s) required</td></tr>
+<tr><td>Left Leg</td><td>1350</td><td>？ stagger(s) required</td></tr>
+<tr><td>Right Leg</td><td>1350</td><td>？ stagger(s) required</td></tr>
 <tr><td>Neck</td><td>1400</td><td></td></tr>
 <tr><td>Head</td><td>3800</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>1500</td><td></td></tr>
@@ -139,7 +139,7 @@
 <table id=kou>
 <col span=2><col span=3 class=n><col>
 <tr class=l><th colspan=6>Attack Information</th></tr>
-<tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>首伸ばし噛み</td><td></td><td>55</td><td>40</td><td>10</td><td></td></tr>
+<tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>Neck伸ばし噛み</td><td></td><td>55</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>飛びつき噛み</td><td></td><td>60</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>飛びつき</td><td></td><td>65</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>右回転尻尾攻撃</td><td></td><td>50</td><td>30</td><td>20</td><td></td></tr>

--- a/mons/furuaka_n.htm
+++ b/mons/furuaka_n.htm
@@ -68,7 +68,7 @@
 <img id=icon src="../img/monsicons/redkhezu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>50</td><td>70</td><td>5</td><td>40</td><td>0</td><td>5</td><td>5</td><td>200</td></tr>
 <tr><td>Neck</td><td>55</td><td>45</td><td>65</td><td>5</td><td>30</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
@@ -85,11 +85,11 @@
 <tr><td>Torso</td><td>200</td><td>２ stagger(s) required (Break Head and Torso for rewards)</td></tr>
 <tr><td>Left Wing</td><td>120</td><td></td></tr>
 <tr><td>Right Wing</td><td>120</td><td></td></tr>
-<tr><td>Left Foot</td><td>130</td><td><div>
+<tr><td>Left Leg</td><td>130</td><td><div>
 <span><em>12</em>176</span><span><em>13</em>179</span><span><em>14</em>183</span><span><em>15</em>186</span><span><em>16</em>190</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>130</td><td><div>
+<tr><td>Right Leg</td><td>130</td><td><div>
 <span><em>12</em>176</span><span><em>13</em>179</span><span><em>14</em>183</span><span><em>15</em>186</span><span><em>16</em>190</span>
 </div>
 </td></tr>
@@ -101,7 +101,7 @@
 <table id=kou>
 <col span=2><col span=3 class=n><col>
 <tr class=l><th colspan=6>Attack Information</th></tr>
-<tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>首伸ばし噛み</td><td></td><td>55</td><td>40</td><td>10</td><td></td></tr>
+<tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>Neck伸ばし噛み</td><td></td><td>55</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>飛びつき噛み</td><td></td><td>60</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>飛びつき</td><td></td><td>65</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>右回転尻尾攻撃</td><td></td><td>50</td><td>30</td><td>20</td><td></td></tr>

--- a/mons/furuaka_ng.htm
+++ b/mons/furuaka_ng.htm
@@ -104,7 +104,7 @@
 <img id=icon src="../img/monsicons/redkhezu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>50</td><td>45</td><td>5</td><td>35</td><td>0</td><td>0</td><td>5</td><td>200</td></tr>
 <tr><td>Neck</td><td>50</td><td>40</td><td>45</td><td>5</td><td>30</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
@@ -121,8 +121,8 @@
 <tr><td>Torso</td><td>600</td><td>２ stagger(s) required (Break Head and Torso for rewards)</td></tr>
 <tr><td>Left Wing</td><td>500</td><td></td></tr>
 <tr><td>Right Wing</td><td>500</td><td></td></tr>
-<tr><td>Left Foot</td><td>550</td><td></td></tr>
-<tr><td>Right Foot</td><td>550</td><td></td></tr>
+<tr><td>Left Leg</td><td>550</td><td></td></tr>
+<tr><td>Right Leg</td><td>550</td><td></td></tr>
 <tr><td>Neck</td><td>600</td><td></td></tr>
 <tr><td>Head</td><td>700</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>400</td><td></td></tr>
@@ -131,7 +131,7 @@
 <table id=kou>
 <col span=2><col span=3 class=n><col>
 <tr class=l><th colspan=6>Attack Information</th></tr>
-<tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>首伸ばし噛み</td><td></td><td>55</td><td>40</td><td>10</td><td></td></tr>
+<tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>Neck伸ばし噛み</td><td></td><td>55</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>飛びつき噛み</td><td></td><td>60</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>飛びつき</td><td></td><td>65</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>右回転尻尾攻撃</td><td></td><td>50</td><td>30</td><td>20</td><td></td></tr>

--- a/mons/furuaka_nh.htm
+++ b/mons/furuaka_nh.htm
@@ -93,7 +93,7 @@
 <img id=icon src="../img/monsicons/redkhezu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>55</td><td>40</td><td>5</td><td>30</td><td>0</td><td>5</td><td>5</td><td>200</td></tr>
 <tr><td>Neck</td><td>55</td><td>50</td><td>60</td><td>5</td><td>25</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
@@ -110,8 +110,8 @@
 <tr><td>Torso</td><td>350</td><td>２ stagger(s) required (Break Head and Torso for rewards)</td></tr>
 <tr><td>Left Wing</td><td>300</td><td></td></tr>
 <tr><td>Right Wing</td><td>300</td><td></td></tr>
-<tr><td>Left Foot</td><td>320</td><td></td></tr>
-<tr><td>Right Foot</td><td>320</td><td></td></tr>
+<tr><td>Left Leg</td><td>320</td><td></td></tr>
+<tr><td>Right Leg</td><td>320</td><td></td></tr>
 <tr><td>Neck</td><td>300</td><td></td></tr>
 <tr><td>Head</td><td>250</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>300</td><td></td></tr>
@@ -120,7 +120,7 @@
 <table id=kou>
 <col span=2><col span=3 class=n><col>
 <tr class=l><th colspan=6>Attack Information</th></tr>
-<tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>首伸ばし噛み</td><td></td><td>55</td><td>40</td><td>10</td><td></td></tr>
+<tr><th>Attack</th><th>Status</th><th>Attack</th><th>Power</th><th>Stun</th><th>Notes</th></tr><tr><td>Neck伸ばし噛み</td><td></td><td>55</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>飛びつき噛み</td><td></td><td>60</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>飛びつき</td><td></td><td>65</td><td>40</td><td>10</td><td></td></tr>
 <tr><td>右回転尻尾攻撃</td><td></td><td>50</td><td>30</td><td>20</td><td></td></tr>

--- a/mons/gabu_n.htm
+++ b/mons/gabu_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/remobra.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>90</td><td>80</td><td>70</td><td>10</td><td>30</td><td>0</td><td>35</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>40</td><td>40</td><td>10</td><td>25</td><td>5</td><td>20</td><td>10</td><td>0</td></tr>

--- a/mons/galba_ng.htm
+++ b/mons/galba_ng.htm
@@ -97,22 +97,22 @@
 <img id=icon src="../img/monsicons/garubadaora.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>25</td><td>0</td><td>0</td><td>15</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Belly</td><td>25</td><td>30</td><td>15</td><td>0</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>35</td><td>40</td><td>15</td><td>0</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>25</td><td>20</td><td>0</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>15</td><td>30</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>35</td><td>30</td><td>10</td><td>0</td><td>0</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質()</th></tr>
+<tr class=l><th colspan=10>Hitzones()</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>60</td><td>35</td><td>0</td><td>0</td><td>25</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Belly</td><td>40</td><td>45</td><td>15</td><td>0</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>50</td><td>15</td><td>20</td><td>0</td><td>0</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>40</td><td>25</td><td>0</td><td>0</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>35</td><td>15</td><td>0</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>35</td><td>15</td><td>0</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>15</td><td>35</td><td>15</td><td>0</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>60</td><td>35</td><td>15</td><td>0</td><td>0</td><td>30</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
@@ -123,8 +123,8 @@
 <tr><td>Head</td><td>850</td><td>２ stagger(s) required</td></tr>
 <tr><td>Torso</td><td>750</td><td></td></tr>
 <tr><td>Tail</td><td>750</td><td></td></tr>
-<tr><td>Left Foot</td><td>700</td><td></td></tr>
-<tr><td>Right Foot</td><td>700</td><td></td></tr>
+<tr><td>Left Leg</td><td>700</td><td></td></tr>
+<tr><td>Right Leg</td><td>700</td><td></td></tr>
 <tr><td>Wing</td><td>600</td><td>２ stagger(s) required</td></tr>
 <tr><td>-</td><td>800</td><td></td></tr>
 <tr><td>-</td><td>800</td><td></td></tr>

--- a/mons/galba_nh.htm
+++ b/mons/galba_nh.htm
@@ -75,22 +75,22 @@
 <img id=icon src="../img/monsicons/garubadaora.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>25</td><td>0</td><td>0</td><td>15</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Belly</td><td>25</td><td>30</td><td>15</td><td>0</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>35</td><td>40</td><td>15</td><td>0</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>25</td><td>20</td><td>0</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>20</td><td>20</td><td>10</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>15</td><td>30</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>35</td><td>30</td><td>10</td><td>0</td><td>0</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質()</th></tr>
+<tr class=l><th colspan=10>Hitzones()</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>60</td><td>35</td><td>0</td><td>0</td><td>25</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Belly</td><td>40</td><td>45</td><td>15</td><td>0</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>50</td><td>15</td><td>20</td><td>0</td><td>0</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>40</td><td>25</td><td>0</td><td>0</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>35</td><td>15</td><td>0</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>35</td><td>15</td><td>0</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>15</td><td>35</td><td>15</td><td>0</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>60</td><td>35</td><td>15</td><td>0</td><td>0</td><td>30</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
@@ -101,8 +101,8 @@
 <tr><td>Head</td><td>400</td><td>２ stagger(s) required</td></tr>
 <tr><td>Torso</td><td>600</td><td></td></tr>
 <tr><td>Tail</td><td>400</td><td></td></tr>
-<tr><td>Left Foot</td><td>450</td><td></td></tr>
-<tr><td>Right Foot</td><td>560</td><td></td></tr>
+<tr><td>Left Leg</td><td>450</td><td></td></tr>
+<tr><td>Right Leg</td><td>560</td><td></td></tr>
 <tr><td>Wing</td><td>400</td><td>２ stagger(s) required</td></tr>
 <tr><td>-</td><td>430</td><td></td></tr>
 <tr><td>-</td><td>420</td><td></td></tr>

--- a/mons/gami_n.htm
+++ b/mons/gami_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/hermitaur.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>70</td><td>90</td><td>65</td><td>5</td><td>5</td><td>30</td><td>0</td><td>40</td><td>200</td></tr>
 </table>

--- a/mons/gano_n.htm
+++ b/mons/gano_n.htm
@@ -73,7 +73,7 @@
 <img id=icon src="../img/monsicons/plesioth.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>30</td><td>60</td><td>25</td><td>0</td><td>25</td><td>5</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>60</td><td>50</td><td>100</td><td>30</td><td>0</td><td>30</td><td>5</td><td>5</td><td>0</td></tr>
@@ -90,11 +90,11 @@
 <tr><td>Torso</td><td>250</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>100</td><td></td></tr>
 <tr><td>Right Wing</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>250</td><td><div>
+<tr><td>Left Leg</td><td>250</td><td><div>
 <span><em>13</em>345</span><span><em>14</em>352</span><span><em>15</em>359</span><span><em>16</em>365</span><span><em>17</em>372</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>250</td><td><div>
+<tr><td>Right Leg</td><td>250</td><td><div>
 <span><em>13</em>345</span><span><em>14</em>352</span><span><em>15</em>359</span><span><em>16</em>365</span><span><em>17</em>372</span>
 </div>
 </td></tr>

--- a/mons/gano_ng.htm
+++ b/mons/gano_ng.htm
@@ -103,7 +103,7 @@
 <img id=icon src="../img/monsicons/plesioth.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>35</td><td>40</td><td>25</td><td>0</td><td>25</td><td>5</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>50</td><td>70</td><td>35</td><td>0</td><td>30</td><td>5</td><td>5</td><td>0</td></tr>
@@ -120,8 +120,8 @@
 <tr><td>Torso</td><td>800</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>500</td><td></td></tr>
 <tr><td>Right Wing</td><td>500</td><td></td></tr>
-<tr><td>Left Foot</td><td>450</td><td></td></tr>
-<tr><td>Right Foot</td><td>450</td><td></td></tr>
+<tr><td>Left Leg</td><td>450</td><td></td></tr>
+<tr><td>Right Leg</td><td>450</td><td></td></tr>
 <tr><td>Neck</td><td>900</td><td></td></tr>
 <tr><td>Head</td><td>750</td><td></td></tr>
 <tr><td>Tail</td><td>500</td><td></td></tr>

--- a/mons/gano_nh.htm
+++ b/mons/gano_nh.htm
@@ -76,7 +76,7 @@
 <img id=icon src="../img/monsicons/plesioth.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>30</td><td>30</td><td>15</td><td>0</td><td>5</td><td>5</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>65</td><td>20</td><td>20</td><td>10</td><td>-5</td><td>15</td><td>5</td><td>5</td><td>0</td></tr>
@@ -93,8 +93,8 @@
 <tr><td>Torso</td><td>250</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>100</td><td></td></tr>
 <tr><td>Right Wing</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>250</td><td></td></tr>
-<tr><td>Right Foot</td><td>250</td><td></td></tr>
+<tr><td>Left Leg</td><td>250</td><td></td></tr>
+<tr><td>Right Leg</td><td>250</td><td></td></tr>
 <tr><td>Neck</td><td>150</td><td></td></tr>
 <tr><td>Head</td><td>130</td><td></td></tr>
 <tr><td>Tail</td><td>180</td><td></td></tr>

--- a/mons/gano_ni.htm
+++ b/mons/gano_ni.htm
@@ -112,7 +112,7 @@
 <img id=icon src="../img/monsicons/zenith_plesioth.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>35</td><td>25</td><td>15</td><td>0</td><td>15</td><td>5</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>35</td><td>30</td><td>30</td><td>20</td><td>0</td><td>20</td><td>5</td><td>5</td><td>0</td></tr>
@@ -129,8 +129,8 @@
 <tr><td>Torso</td><td>1000</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>2000</td><td></td></tr>
 <tr><td>Right Wing</td><td>2000</td><td></td></tr>
-<tr><td>Left Foot</td><td>1000</td><td></td></tr>
-<tr><td>Right Foot</td><td>1000</td><td></td></tr>
+<tr><td>Left Leg</td><td>1000</td><td></td></tr>
+<tr><td>Right Leg</td><td>1000</td><td></td></tr>
 <tr><td>Neck</td><td>1200</td><td></td></tr>
 <tr><td>Head</td><td>4000</td><td></td></tr>
 <tr><td>Tail</td><td>1000</td><td></td></tr>

--- a/mons/ganomidori_n.htm
+++ b/mons/ganomidori_n.htm
@@ -72,7 +72,7 @@
 <img id=icon src="../img/monsicons/greenplesioth.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>30</td><td>60</td><td>5</td><td>0</td><td>20</td><td>5</td><td>25</td><td>100</td></tr>
 <tr><td>Neck</td><td>60</td><td>50</td><td>100</td><td>5</td><td>0</td><td>25</td><td>5</td><td>30</td><td>0</td></tr>
@@ -89,11 +89,11 @@
 <tr><td>Torso</td><td>250</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>100</td><td></td></tr>
 <tr><td>Right Wing</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>250</td><td><div>
+<tr><td>Left Leg</td><td>250</td><td><div>
 <span><em>13</em>345</span><span><em>14</em>352</span><span><em>15</em>359</span><span><em>16</em>365</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>250</td><td><div>
+<tr><td>Right Leg</td><td>250</td><td><div>
 <span><em>13</em>345</span><span><em>14</em>352</span><span><em>15</em>359</span><span><em>16</em>365</span>
 </div>
 </td></tr>

--- a/mons/ganomidori_ng.htm
+++ b/mons/ganomidori_ng.htm
@@ -103,7 +103,7 @@
 <img id=icon src="../img/monsicons/greenplesioth.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>35</td><td>40</td><td>5</td><td>0</td><td>10</td><td>5</td><td>15</td><td>100</td></tr>
 <tr><td>Neck</td><td>45</td><td>45</td><td>60</td><td>5</td><td>0</td><td>15</td><td>5</td><td>25</td><td>0</td></tr>
@@ -120,8 +120,8 @@
 <tr><td>Torso</td><td>800</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>600</td><td></td></tr>
 <tr><td>Right Wing</td><td>600</td><td></td></tr>
-<tr><td>Left Foot</td><td>650</td><td></td></tr>
-<tr><td>Right Foot</td><td>650</td><td></td></tr>
+<tr><td>Left Leg</td><td>650</td><td></td></tr>
+<tr><td>Right Leg</td><td>650</td><td></td></tr>
 <tr><td>Neck</td><td>500</td><td></td></tr>
 <tr><td>Head</td><td>700</td><td></td></tr>
 <tr><td>Tail</td><td>550</td><td></td></tr>

--- a/mons/ganomidori_nh.htm
+++ b/mons/ganomidori_nh.htm
@@ -93,7 +93,7 @@
 <img id=icon src="../img/monsicons/greenplesioth.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>35</td><td>30</td><td>5</td><td>0</td><td>5</td><td>5</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>40</td><td>70</td><td>5</td><td>0</td><td>5</td><td>0</td><td>30</td><td>0</td></tr>
@@ -110,8 +110,8 @@
 <tr><td>Torso</td><td>270</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>150</td><td></td></tr>
 <tr><td>Right Wing</td><td>150</td><td></td></tr>
-<tr><td>Left Foot</td><td>280</td><td></td></tr>
-<tr><td>Right Foot</td><td>280</td><td></td></tr>
+<tr><td>Left Leg</td><td>280</td><td></td></tr>
+<tr><td>Right Leg</td><td>280</td><td></td></tr>
 <tr><td>Neck</td><td>250</td><td></td></tr>
 <tr><td>Head</td><td>200</td><td></td></tr>
 <tr><td>Tail</td><td>220</td><td></td></tr>

--- a/mons/gare_n.htm
+++ b/mons/gare_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/cephalos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>70</td><td>80</td><td>80</td><td>30</td><td>10</td><td>40</td><td>0</td><td>10</td><td>90</td></tr>
 <tr><td>Neck</td><td>110</td><td>100</td><td>140</td><td>30</td><td>10</td><td>40</td><td>0</td><td>10</td><td>0</td></tr>
@@ -98,8 +98,8 @@
 <tr><td>Torso</td><td>150</td><td></td></tr>
 <tr><td>Left Wing</td><td>90</td><td></td></tr>
 <tr><td>Right Wing</td><td>90</td><td></td></tr>
-<tr><td>Left Foot</td><td>60</td><td></td></tr>
-<tr><td>Right Foot</td><td>60</td><td></td></tr>
+<tr><td>Left Leg</td><td>60</td><td></td></tr>
+<tr><td>Right Leg</td><td>60</td><td></td></tr>
 <tr><td>Neck</td><td>90</td><td></td></tr>
 <tr><td>Head</td><td>90</td><td></td></tr>
 <tr><td>Tail</td><td>90</td><td></td></tr>

--- a/mons/garuru_n.htm
+++ b/mons/garuru_n.htm
@@ -71,7 +71,7 @@
 <img id=icon src="../img/monsicons/yiangaruga.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>55</td><td>50</td><td>60</td><td>0</td><td>20</td><td>0</td><td>5</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>40</td><td>40</td><td>0</td><td>30</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
@@ -88,11 +88,11 @@
 <tr><td>Torso</td><td>160</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>150</td><td>２ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>150</td><td>２ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>180</td><td><div>
+<tr><td>Left Leg</td><td>180</td><td><div>
 <span><em>15</em>258</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>180</td><td><div>
+<tr><td>Right Leg</td><td>180</td><td><div>
 <span><em>15</em>258</span>
 </div>
 </td></tr>

--- a/mons/garuru_ng.htm
+++ b/mons/garuru_ng.htm
@@ -124,7 +124,7 @@
 <img id=icon src="../img/monsicons/yiangaruga.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>55</td><td>50</td><td>60</td><td>0</td><td>30</td><td>0</td><td>5</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>40</td><td>30</td><td>0</td><td>30</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
@@ -141,8 +141,8 @@
 <tr><td>Torso</td><td>460</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>350</td><td>２ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>350</td><td>２ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>480</td><td></td></tr>
-<tr><td>Right Foot</td><td>480</td><td></td></tr>
+<tr><td>Left Leg</td><td>480</td><td></td></tr>
+<tr><td>Right Leg</td><td>480</td><td></td></tr>
 <tr><td>Neck</td><td>450</td><td></td></tr>
 <tr><td>Head</td><td>600</td><td>２ stagger(s) required<br>３ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>650</td><td></td></tr>

--- a/mons/garuru_nh.htm
+++ b/mons/garuru_nh.htm
@@ -77,7 +77,7 @@
 <img id=icon src="../img/monsicons/yiangaruga.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>50</td><td>40</td><td>0</td><td>35</td><td>0</td><td>15</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>45</td><td>15</td><td>-5</td><td>0</td><td>20</td><td>0</td><td>0</td></tr>
@@ -94,8 +94,8 @@
 <tr><td>Torso</td><td>160</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>150</td><td>２ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>150</td><td>２ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>180</td><td></td></tr>
-<tr><td>Right Foot</td><td>180</td><td></td></tr>
+<tr><td>Left Leg</td><td>180</td><td></td></tr>
+<tr><td>Right Leg</td><td>180</td><td></td></tr>
 <tr><td>Neck</td><td>100</td><td></td></tr>
 <tr><td>Head</td><td>200</td><td>２ stagger(s) required<br>３ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>150</td><td></td></tr>

--- a/mons/garuru_nt.htm
+++ b/mons/garuru_nt.htm
@@ -104,7 +104,7 @@
 <img id=icon src="../img/monsicons/yiangaruga.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>55</td><td>50</td><td>60</td><td>0</td><td>30</td><td>0</td><td>5</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>40</td><td>30</td><td>0</td><td>30</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
@@ -121,8 +121,8 @@
 <tr><td>Torso</td><td>160</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>150</td><td>２ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>150</td><td>２ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>180</td><td></td></tr>
-<tr><td>Right Foot</td><td>180</td><td></td></tr>
+<tr><td>Left Leg</td><td>180</td><td></td></tr>
+<tr><td>Right Leg</td><td>180</td><td></td></tr>
 <tr><td>Neck</td><td>100</td><td></td></tr>
 <tr><td>Head</td><td>200</td><td>２ stagger(s) required<br>３ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>150</td><td></td></tr>

--- a/mons/gasra_ng.htm
+++ b/mons/gasra_ng.htm
@@ -103,20 +103,20 @@
 <img id=icon src="../img/monsicons/gasurabazura.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>35</td><td>20</td><td>0</td><td>0</td><td>30</td><td>0</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>15</td><td>25</td><td>0</td><td>0</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>40</td><td>25</td><td>30</td><td>0</td><td>0</td><td>45</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>40</td><td>25</td><td>30</td><td>0</td><td>0</td><td>45</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>15</td><td>30</td><td>15</td><td>0</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>20</td><td>20</td><td>15</td><td>0</td><td>0</td><td>25</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>15</td><td>20</td><td>20</td><td>0</td><td>0</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>10</td><td>40</td><td>0</td><td>0</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>45</td><td>30</td><td>0</td><td>0</td><td>15</td><td>0</td><td>5</td><td>120</td></tr>
 <tr><td>Neck</td><td>30</td><td>25</td><td>35</td><td>0</td><td>0</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>50</td><td>35</td><td>40</td><td>0</td><td>0</td><td>30</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>50</td><td>35</td><td>40</td><td>0</td><td>0</td><td>30</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>40</td><td>25</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>30</td><td>30</td><td>25</td><td>0</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>30</td><td>30</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
@@ -128,10 +128,10 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>800</td><td>？ stagger(s) required</td></tr>
 <tr><td>Back</td><td>850</td><td>？ stagger(s) required</td></tr>
-<tr><td>左前脚</td><td>880</td><td>？ stagger(s) required</td></tr>
-<tr><td>右前脚</td><td>880</td><td>？ stagger(s) required</td></tr>
-<tr><td>左後脚</td><td>1000</td><td></td></tr>
-<tr><td>右後脚</td><td>1000</td><td></td></tr>
+<tr><td>Left Foreleg</td><td>880</td><td>？ stagger(s) required</td></tr>
+<tr><td>Right Foreleg</td><td>880</td><td>？ stagger(s) required</td></tr>
+<tr><td>Left Hind Leg</td><td>1000</td><td></td></tr>
+<tr><td>Right Hind Leg</td><td>1000</td><td></td></tr>
 <tr><td>？？</td><td>800</td><td></td></tr>
 <tr><td>Tail</td><td>1000</td><td>１ stagger(s) required</td></tr>
 <tr><td>Tail Cut</td><td>1500</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>

--- a/mons/gasra_nh.htm
+++ b/mons/gasra_nh.htm
@@ -76,20 +76,20 @@
 <img id=icon src="../img/monsicons/gasurabazura.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>45</td><td>30</td><td>0</td><td>0</td><td>40</td><td>0</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>30</td><td>25</td><td>35</td><td>0</td><td>0</td><td>25</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>50</td><td>35</td><td>40</td><td>0</td><td>0</td><td>50</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>50</td><td>35</td><td>40</td><td>0</td><td>0</td><td>50</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>40</td><td>25</td><td>0</td><td>0</td><td>25</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>30</td><td>30</td><td>25</td><td>0</td><td>0</td><td>35</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>30</td><td>30</td><td>0</td><td>0</td><td>30</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>40</td><td>20</td><td>50</td><td>0</td><td>0</td><td>30</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>55</td><td>40</td><td>0</td><td>0</td><td>20</td><td>0</td><td>5</td><td>120</td></tr>
 <tr><td>Neck</td><td>40</td><td>35</td><td>45</td><td>0</td><td>0</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>60</td><td>45</td><td>50</td><td>0</td><td>0</td><td>30</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>60</td><td>45</td><td>50</td><td>0</td><td>0</td><td>30</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>35</td><td>50</td><td>35</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>40</td><td>40</td><td>35</td><td>0</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>40</td><td>40</td><td>0</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
@@ -101,10 +101,10 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>500</td><td>？ stagger(s) required</td></tr>
 <tr><td>Back</td><td>550</td><td>？ stagger(s) required</td></tr>
-<tr><td>左前脚</td><td>480</td><td>？ stagger(s) required</td></tr>
-<tr><td>右前脚</td><td>480</td><td>？ stagger(s) required</td></tr>
-<tr><td>左後脚</td><td>550</td><td></td></tr>
-<tr><td>右後脚</td><td>550</td><td></td></tr>
+<tr><td>Left Foreleg</td><td>480</td><td>？ stagger(s) required</td></tr>
+<tr><td>Right Foreleg</td><td>480</td><td>？ stagger(s) required</td></tr>
+<tr><td>Left Hind Leg</td><td>550</td><td></td></tr>
+<tr><td>Right Hind Leg</td><td>550</td><td></td></tr>
 <tr><td>？？</td><td>500</td><td></td></tr>
 <tr><td>Tail</td><td>600</td><td>１ stagger(s) required</td></tr>
 <tr><td>Tail Cut</td><td>1000</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>

--- a/mons/gasra_ni.htm
+++ b/mons/gasra_ni.htm
@@ -112,20 +112,20 @@
 <img id=icon src="../img/monsicons/zenith_gasurabazura.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>35</td><td>20</td><td>0</td><td>0</td><td>20</td><td>0</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>15</td><td>15</td><td>0</td><td>0</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>15</td><td>25</td><td>20</td><td>0</td><td>0</td><td>25</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>15</td><td>25</td><td>20</td><td>0</td><td>0</td><td>25</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>15</td><td>25</td><td>15</td><td>0</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>25</td><td>15</td><td>15</td><td>0</td><td>0</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>15</td><td>15</td><td>20</td><td>0</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>10</td><td>35</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>25</td><td>0</td><td>0</td><td>10</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>25</td><td>20</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>20</td><td>30</td><td>25</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>20</td><td>30</td><td>25</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>15</td><td>25</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>35</td><td>20</td><td>30</td><td>0</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>20</td><td>20</td><td>25</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
@@ -137,9 +137,9 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>1050</td><td>？ stagger(s) required</td></tr>
 <tr><td>Back</td><td>1050</td><td>？ stagger(s) required</td></tr>
-<tr><td>Fore Leg</td><td>5000</td><td>？ stagger(s) required</td></tr>
-<tr><td>左後脚</td><td>900</td><td></td></tr>
-<tr><td>右後脚</td><td>900</td><td></td></tr>
+<tr><td>Foreleg</td><td>5000</td><td>？ stagger(s) required</td></tr>
+<tr><td>Left Hind Leg</td><td>900</td><td></td></tr>
+<tr><td>Right Hind Leg</td><td>900</td><td></td></tr>
 <tr><td>？？</td><td>1400</td><td></td></tr>
 <tr><td>Tail</td><td>1000</td><td>１ stagger(s) required</td></tr>
 <tr><td>Tail Cut</td><td>2000</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>

--- a/mons/gau_n.htm
+++ b/mons/gau_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/anteka.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>100</td><td>90</td><td>90</td><td>100</td><td>10</td><td>10</td><td>10</td><td>5</td><td>100</td></tr>
 </table>

--- a/mons/gene_n.htm
+++ b/mons/gene_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/genprey.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>100</td><td>100</td><td>100</td><td>30</td><td>20</td><td>20</td><td>0</td><td>60</td><td>100</td></tr>
 </table>

--- a/mons/geryo_n.htm
+++ b/mons/geryo_n.htm
@@ -79,7 +79,7 @@
 <img id=icon src="../img/monsicons/gypceros.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>80</td><td>100</td><td>50</td><td>20</td><td>0</td><td>10</td><td>20</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>25</td><td>50</td><td>30</td><td>10</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
@@ -105,11 +105,11 @@
 <span><em>59</em>300</span>
 </div>
 </td></tr>
-<tr><td>Left Foot</td><td>120</td><td><div>
+<tr><td>Left Leg</td><td>120</td><td><div>
 <span><em>11</em>159</span><span><em>12</em>162</span><span><em>13</em>166</span><span><em>14</em>169</span><span><em>15</em>172</span><span><em>59</em>360</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>120</td><td><div>
+<tr><td>Right Leg</td><td>120</td><td><div>
 <span><em>11</em>159</span><span><em>12</em>162</span><span><em>13</em>166</span><span><em>14</em>169</span><span><em>15</em>172</span><span><em>59</em>360</span>
 </div>
 </td></tr>

--- a/mons/geryo_ng.htm
+++ b/mons/geryo_ng.htm
@@ -124,7 +124,7 @@
 <img id=icon src="../img/monsicons/gypceros.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>60</td><td>70</td><td>50</td><td>20</td><td>0</td><td>10</td><td>20</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>35</td><td>30</td><td>10</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
@@ -141,8 +141,8 @@
 <tr><td>Torso</td><td>350</td><td></td></tr>
 <tr><td>Left Wing</td><td>300</td><td></td></tr>
 <tr><td>Right Wing</td><td>300</td><td></td></tr>
-<tr><td>Left Foot</td><td>350</td><td></td></tr>
-<tr><td>Right Foot</td><td>350</td><td></td></tr>
+<tr><td>Left Leg</td><td>350</td><td></td></tr>
+<tr><td>Right Leg</td><td>350</td><td></td></tr>
 <tr><td>Neck</td><td>300</td><td></td></tr>
 <tr><td>Head</td><td>350</td><td>2nd time breaks his crest</td></tr>
 <tr><td>Tail</td><td>400</td><td></td></tr>

--- a/mons/geryo_nh.htm
+++ b/mons/geryo_nh.htm
@@ -82,7 +82,7 @@
 <img id=icon src="../img/monsicons/gypceros.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>45</td><td>30</td><td>0</td><td>5</td><td>0</td><td>0</td><td>10</td><td>150</td></tr>
 <tr><td>Neck</td><td>25</td><td>25</td><td>10</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
@@ -99,8 +99,8 @@
 <tr><td>Torso</td><td>150</td><td></td></tr>
 <tr><td>Left Wing</td><td>100</td><td></td></tr>
 <tr><td>Right Wing</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>120</td><td></td></tr>
-<tr><td>Right Foot</td><td>120</td><td></td></tr>
+<tr><td>Left Leg</td><td>120</td><td></td></tr>
+<tr><td>Right Leg</td><td>120</td><td></td></tr>
 <tr><td>Neck</td><td>80</td><td></td></tr>
 <tr><td>Head</td><td>130</td><td>2nd time breaks his crest</td></tr>
 <tr><td>Tail</td><td>80</td><td></td></tr>

--- a/mons/geryo_nt.htm
+++ b/mons/geryo_nt.htm
@@ -104,7 +104,7 @@
 <img id=icon src="../img/monsicons/gypceros.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>60</td><td>70</td><td>50</td><td>20</td><td>0</td><td>10</td><td>20</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>35</td><td>30</td><td>10</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
@@ -121,8 +121,8 @@
 <tr><td>Torso</td><td>150</td><td></td></tr>
 <tr><td>Left Wing</td><td>100</td><td></td></tr>
 <tr><td>Right Wing</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>120</td><td></td></tr>
-<tr><td>Right Foot</td><td>120</td><td></td></tr>
+<tr><td>Left Leg</td><td>120</td><td></td></tr>
+<tr><td>Right Leg</td><td>120</td><td></td></tr>
 <tr><td>Neck</td><td>80</td><td></td></tr>
 <tr><td>Head</td><td>130</td><td>2nd time breaks his crest</td></tr>
 <tr><td>Tail</td><td>80</td><td></td></tr>

--- a/mons/geryoao_n.htm
+++ b/mons/geryoao_n.htm
@@ -72,7 +72,7 @@
 <img id=icon src="../img/monsicons/purplegypceros.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>70</td><td>90</td><td>20</td><td>40</td><td>0</td><td>10</td><td>20</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>25</td><td>50</td><td>10</td><td>25</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
@@ -89,11 +89,11 @@
 <tr><td>Torso</td><td>150</td><td></td></tr>
 <tr><td>Left Wing</td><td>100</td><td></td></tr>
 <tr><td>Right Wing</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>120</td><td><div>
+<tr><td>Left Leg</td><td>120</td><td><div>
 <span><em>11</em>159</span><span><em>12</em>162</span><span><em>13</em>166</span><span><em>14</em>169</span><span><em>15</em>172</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>120</td><td><div>
+<tr><td>Right Leg</td><td>120</td><td><div>
 <span><em>11</em>159</span><span><em>12</em>162</span><span><em>13</em>166</span><span><em>14</em>169</span><span><em>15</em>172</span>
 </div>
 </td></tr>

--- a/mons/geryoao_ng.htm
+++ b/mons/geryoao_ng.htm
@@ -104,7 +104,7 @@
 <img id=icon src="../img/monsicons/purplegypceros.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>50</td><td>65</td><td>20</td><td>40</td><td>0</td><td>10</td><td>20</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>35</td><td>10</td><td>25</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
@@ -121,8 +121,8 @@
 <tr><td>Torso</td><td>350</td><td></td></tr>
 <tr><td>Left Wing</td><td>300</td><td></td></tr>
 <tr><td>Right Wing</td><td>300</td><td></td></tr>
-<tr><td>Left Foot</td><td>350</td><td></td></tr>
-<tr><td>Right Foot</td><td>350</td><td></td></tr>
+<tr><td>Left Leg</td><td>350</td><td></td></tr>
+<tr><td>Right Leg</td><td>350</td><td></td></tr>
 <tr><td>Neck</td><td>300</td><td></td></tr>
 <tr><td>Head</td><td>350</td><td>2nd time breaks his crest</td></tr>
 <tr><td>Tail</td><td>400</td><td></td></tr>

--- a/mons/geryoao_nh.htm
+++ b/mons/geryoao_nh.htm
@@ -93,7 +93,7 @@
 <img id=icon src="../img/monsicons/purplegypceros.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>50</td><td>50</td><td>10</td><td>30</td><td>0</td><td>10</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>30</td><td>25</td><td>40</td><td>10</td><td>25</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
@@ -110,8 +110,8 @@
 <tr><td>Torso</td><td>350</td><td></td></tr>
 <tr><td>Left Wing</td><td>320</td><td></td></tr>
 <tr><td>Right Wing</td><td>320</td><td></td></tr>
-<tr><td>Left Foot</td><td>360</td><td></td></tr>
-<tr><td>Right Foot</td><td>360</td><td></td></tr>
+<tr><td>Left Leg</td><td>360</td><td></td></tr>
+<tr><td>Right Leg</td><td>360</td><td></td></tr>
 <tr><td>Neck</td><td>320</td><td></td></tr>
 <tr><td>Head</td><td>250</td><td>2nd time breaks his crest</td></tr>
 <tr><td>Tail</td><td>300</td><td></td></tr>

--- a/mons/geryoao_nt.htm
+++ b/mons/geryoao_nt.htm
@@ -104,7 +104,7 @@
 <img id=icon src="../img/monsicons/purplegypceros.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>50</td><td>65</td><td>20</td><td>40</td><td>0</td><td>10</td><td>20</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>35</td><td>10</td><td>25</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
@@ -121,8 +121,8 @@
 <tr><td>Torso</td><td>150</td><td></td></tr>
 <tr><td>Left Wing</td><td>100</td><td></td></tr>
 <tr><td>Right Wing</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>120</td><td></td></tr>
-<tr><td>Right Foot</td><td>120</td><td></td></tr>
+<tr><td>Left Leg</td><td>120</td><td></td></tr>
+<tr><td>Right Leg</td><td>120</td><td></td></tr>
 <tr><td>Neck</td><td>80</td><td></td></tr>
 <tr><td>Head</td><td>130</td><td>2nd time breaks his crest</td></tr>
 <tr><td>Tail</td><td>80</td><td></td></tr>

--- a/mons/giano_n.htm
+++ b/mons/giano_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/giaprey.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>80</td><td>80</td><td>80</td><td>50</td><td>15</td><td>30</td><td>10</td><td>5</td><td>100</td></tr>
 </table>

--- a/mons/giao_ng.htm
+++ b/mons/giao_ng.htm
@@ -117,52 +117,52 @@
 <img id=icon src="../img/monsicons/giaorugu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>40</td><td>35</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td><td>100</td></tr>
-<tr><td>Right Foot</td><td>20</td><td>20</td><td>20</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>Left Foot</td><td>20</td><td>20</td><td>20</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>氷尾</td><td>20</td><td>25</td><td>15</td><td>100</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>20</td><td>20</td><td>20</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Left Leg</td><td>20</td><td>20</td><td>20</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Ice Tail</td><td>20</td><td>25</td><td>15</td><td>100</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>30</td><td>25</td><td>20</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>25</td><td>20</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>尾先端</td><td>50</td><td>45</td><td>35</td><td>20</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り1)</th></tr>
+<tr><td>Tail Tip</td><td>50</td><td>45</td><td>35</td><td>20</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(怒り1)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>40</td><td>35</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td><td>100</td></tr>
-<tr><td>Right Foot</td><td>25</td><td>25</td><td>25</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>Left Foot</td><td>20</td><td>20</td><td>20</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>氷尾</td><td>20</td><td>25</td><td>20</td><td>100</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>25</td><td>25</td><td>25</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Left Leg</td><td>20</td><td>20</td><td>20</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Ice Tail</td><td>20</td><td>25</td><td>20</td><td>100</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>30</td><td>25</td><td>20</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>25</td><td>20</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>尾先端</td><td>55</td><td>50</td><td>40</td><td>30</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り2)</th></tr>
+<tr><td>Tail Tip</td><td>55</td><td>50</td><td>40</td><td>30</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(怒り2)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>45</td><td>40</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td><td>100</td></tr>
-<tr><td>Right Foot</td><td>30</td><td>30</td><td>30</td><td>20</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>Left Foot</td><td>20</td><td>20</td><td>20</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>氷尾</td><td>20</td><td>25</td><td>20</td><td>100</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>30</td><td>30</td><td>30</td><td>20</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Left Leg</td><td>20</td><td>20</td><td>20</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Ice Tail</td><td>20</td><td>25</td><td>20</td><td>100</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>25</td><td>25</td><td>20</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>35</td><td>30</td><td>30</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>尾先端</td><td>60</td><td>55</td><td>45</td><td>40</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り3)</th></tr>
+<tr><td>Tail Tip</td><td>60</td><td>55</td><td>45</td><td>40</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(怒り3)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>45</td><td>40</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td><td>100</td></tr>
-<tr><td>Right Foot</td><td>40</td><td>40</td><td>40</td><td>25</td><td>0</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
-<tr><td>Left Foot</td><td>25</td><td>25</td><td>25</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>氷尾</td><td>25</td><td>30</td><td>20</td><td>100</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>40</td><td>40</td><td>40</td><td>25</td><td>0</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
+<tr><td>Left Leg</td><td>25</td><td>25</td><td>25</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Ice Tail</td><td>25</td><td>30</td><td>20</td><td>100</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>25</td><td>25</td><td>20</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>35</td><td>30</td><td>30</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>尾先端</td><td>80</td><td>75</td><td>60</td><td>50</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Tail Tip</td><td>80</td><td>75</td><td>60</td><td>50</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>800</td><td>１ stagger(s) required<br>２ stagger(s) required</td></tr>
-<tr><td>Right Foot</td><td>600</td><td></td></tr>
-<tr><td>Left Foot</td><td>500</td><td></td></tr>
-<tr><td>氷尾</td><td>150</td><td>１ stagger(s) required</td></tr>
-<tr><td>手</td><td>600</td><td></td></tr>
+<tr><td>Right Leg</td><td>600</td><td></td></tr>
+<tr><td>Left Leg</td><td>500</td><td></td></tr>
+<tr><td>Ice Tail</td><td>150</td><td>１ stagger(s) required</td></tr>
+<tr><td>Hand</td><td>600</td><td></td></tr>
 <tr><td>Torso</td><td>600</td><td></td></tr>
 <tr><td>？</td><td>600</td><td></td></tr>
 <tr><td>Tail</td><td>1000</td><td>１ stagger(s) required</td></tr>

--- a/mons/giao_ni.htm
+++ b/mons/giao_ni.htm
@@ -111,52 +111,52 @@
 <img id=icon src="../img/monsicons/zenith_giaorugu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>30</td><td>25</td><td>20</td><td>0</td><td>10</td><td>5</td><td>0</td><td>100</td></tr>
-<tr><td>Right Foot</td><td>15</td><td>15</td><td>10</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>Left Foot</td><td>15</td><td>15</td><td>10</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>氷尾</td><td>15</td><td>20</td><td>10</td><td>50</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>15</td><td>15</td><td>10</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Left Leg</td><td>15</td><td>15</td><td>10</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Ice Tail</td><td>15</td><td>20</td><td>10</td><td>50</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>25</td><td>20</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>20</td><td>15</td><td>20</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>尾先端</td><td>30</td><td>25</td><td>20</td><td>25</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り1)</th></tr>
+<tr><td>Tail Tip</td><td>30</td><td>25</td><td>20</td><td>25</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(怒り1)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>30</td><td>30</td><td>20</td><td>0</td><td>10</td><td>5</td><td>0</td><td>100</td></tr>
-<tr><td>Right Foot</td><td>15</td><td>15</td><td>10</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>Left Foot</td><td>15</td><td>15</td><td>10</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>氷尾</td><td>20</td><td>25</td><td>15</td><td>50</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>15</td><td>15</td><td>10</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Left Leg</td><td>15</td><td>15</td><td>10</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Ice Tail</td><td>20</td><td>25</td><td>15</td><td>50</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>25</td><td>30</td><td>25</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>25</td><td>20</td><td>25</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>尾先端</td><td>35</td><td>30</td><td>25</td><td>30</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り2)</th></tr>
+<tr><td>Tail Tip</td><td>35</td><td>30</td><td>25</td><td>30</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(怒り2)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>35</td><td>35</td><td>20</td><td>0</td><td>10</td><td>5</td><td>0</td><td>100</td></tr>
-<tr><td>Right Foot</td><td>15</td><td>20</td><td>10</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>Left Foot</td><td>15</td><td>20</td><td>10</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>氷尾</td><td>20</td><td>25</td><td>15</td><td>50</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>15</td><td>20</td><td>10</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Left Leg</td><td>15</td><td>20</td><td>10</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Ice Tail</td><td>20</td><td>25</td><td>15</td><td>50</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>25</td><td>30</td><td>25</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>25</td><td>20</td><td>30</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>尾先端</td><td>40</td><td>30</td><td>30</td><td>35</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り3)</th></tr>
+<tr><td>Tail Tip</td><td>40</td><td>30</td><td>30</td><td>35</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(怒り3)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>35</td><td>35</td><td>25</td><td>0</td><td>10</td><td>5</td><td>0</td><td>100</td></tr>
-<tr><td>Right Foot</td><td>15</td><td>20</td><td>10</td><td>15</td><td>0</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
-<tr><td>Left Foot</td><td>15</td><td>20</td><td>10</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>氷尾</td><td>20</td><td>25</td><td>15</td><td>50</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>15</td><td>20</td><td>10</td><td>15</td><td>0</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
+<tr><td>Left Leg</td><td>15</td><td>20</td><td>10</td><td>15</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Ice Tail</td><td>20</td><td>25</td><td>15</td><td>50</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>25</td><td>30</td><td>25</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>25</td><td>20</td><td>35</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>尾先端</td><td>45</td><td>30</td><td>30</td><td>40</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Tail Tip</td><td>45</td><td>30</td><td>30</td><td>40</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>1300</td><td>１ stagger(s) required<br>２ stagger(s) required</td></tr>
-<tr><td>Right Foot</td><td>600</td><td></td></tr>
-<tr><td>Left Foot</td><td>600</td><td></td></tr>
-<tr><td>氷尾</td><td>650</td><td>１ stagger(s) required</td></tr>
-<tr><td>手</td><td>700</td><td></td></tr>
+<tr><td>Right Leg</td><td>600</td><td></td></tr>
+<tr><td>Left Leg</td><td>600</td><td></td></tr>
+<tr><td>Ice Tail</td><td>650</td><td>１ stagger(s) required</td></tr>
+<tr><td>Hand</td><td>700</td><td></td></tr>
 <tr><td>Torso</td><td>900</td><td></td></tr>
 <tr><td>？</td><td>700</td><td></td></tr>
 <tr><td>Tail</td><td>5000</td><td>１ stagger(s) required</td></tr>

--- a/mons/glare_ng.htm
+++ b/mons/glare_ng.htm
@@ -97,7 +97,7 @@
 <img id=icon src="../img/monsicons/gureadomosu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>55</td><td>20</td><td>10</td><td>0</td><td>15</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>55</td><td>25</td><td>60</td><td>20</td><td>0</td><td>35</td><td>0</td><td>0</td><td>0</td></tr>
@@ -114,8 +114,8 @@
 <tr><td>Torso</td><td>1000</td><td>？ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>900</td><td>？ stagger(s) required</td></tr>
 <tr><td>Right Wing</td><td>900</td><td>？ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>800</td><td>？ stagger(s) required</td></tr>
-<tr><td>Right Foot</td><td>800</td><td>？ stagger(s) required</td></tr>
+<tr><td>Left Leg</td><td>800</td><td>？ stagger(s) required</td></tr>
+<tr><td>Right Leg</td><td>800</td><td>？ stagger(s) required</td></tr>
 <tr><td>Head</td><td>900</td><td>？ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>950</td><td>？ stagger(s) required</td></tr>
 <tr><td>-</td><td>2000</td><td></td></tr>

--- a/mons/glare_nh.htm
+++ b/mons/glare_nh.htm
@@ -75,7 +75,7 @@
 <img id=icon src="../img/monsicons/gureadomosu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>65</td><td>30</td><td>25</td><td>0</td><td>20</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>65</td><td>30</td><td>60</td><td>20</td><td>0</td><td>45</td><td>0</td><td>0</td><td>0</td></tr>
@@ -92,8 +92,8 @@
 <tr><td>Torso</td><td>700</td><td>？ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>450</td><td>？ stagger(s) required</td></tr>
 <tr><td>Right Wing</td><td>450</td><td>？ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>600</td><td>？ stagger(s) required</td></tr>
-<tr><td>Right Foot</td><td>600</td><td>？ stagger(s) required</td></tr>
+<tr><td>Left Leg</td><td>600</td><td>？ stagger(s) required</td></tr>
+<tr><td>Right Leg</td><td>600</td><td>？ stagger(s) required</td></tr>
 <tr><td>Head</td><td>650</td><td>？ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>750</td><td>？ stagger(s) required</td></tr>
 <tr><td>-</td><td>1000</td><td></td></tr>

--- a/mons/goa_ng.htm
+++ b/mons/goa_ng.htm
@@ -97,21 +97,21 @@
 <img id=icon src="../img/monsicons/goremagala.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>28</td><td>25</td><td>28</td><td>15</td><td>0</td><td>15</td><td>15</td><td>5</td><td>100</td></tr>
 <tr><td>Torso</td><td>19</td><td>19</td><td>17</td><td>5</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr><td>翼脚</td><td>21</td><td>21</td><td>25</td><td>10</td><td>0</td><td>15</td><td>10</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>15</td><td>15</td><td>15</td><td>5</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
+<tr><td>Wingleg</td><td>21</td><td>21</td><td>25</td><td>10</td><td>0</td><td>15</td><td>10</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>15</td><td>15</td><td>15</td><td>5</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>12</td><td>12</td><td>12</td><td>5</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>20</td><td>18</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>17</td><td>28</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(狂竜化)</th></tr>
+<tr class=l><th colspan=10>Hitzones(狂竜化)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>33</td><td>35</td><td>25</td><td>0</td><td>15</td><td>25</td><td>5</td><td>100</td></tr>
 <tr><td>Torso</td><td>19</td><td>19</td><td>17</td><td>5</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr><td>翼脚</td><td>21</td><td>21</td><td>25</td><td>15</td><td>0</td><td>15</td><td>10</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>15</td><td>15</td><td>15</td><td>5</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
+<tr><td>Wingleg</td><td>21</td><td>21</td><td>25</td><td>15</td><td>0</td><td>15</td><td>10</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>15</td><td>15</td><td>15</td><td>5</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>12</td><td>12</td><td>12</td><td>5</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>20</td><td>18</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>17</td><td>28</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>

--- a/mons/goa_nh.htm
+++ b/mons/goa_nh.htm
@@ -75,21 +75,21 @@
 <img id=icon src="../img/monsicons/goremagala.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>55</td><td>50</td><td>40</td><td>15</td><td>0</td><td>15</td><td>15</td><td>5</td><td>100</td></tr>
 <tr><td>Torso</td><td>25</td><td>25</td><td>25</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr><td>翼脚</td><td>30</td><td>30</td><td>30</td><td>25</td><td>0</td><td>15</td><td>10</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>35</td><td>35</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
+<tr><td>Wingleg</td><td>30</td><td>30</td><td>30</td><td>25</td><td>0</td><td>15</td><td>10</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>35</td><td>35</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>32</td><td>32</td><td>25</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>26</td><td>20</td><td>15</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>45</td><td>40</td><td>10</td><td>0</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(狂竜化)</th></tr>
+<tr class=l><th colspan=10>Hitzones(狂竜化)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>65</td><td>60</td><td>50</td><td>25</td><td>0</td><td>15</td><td>30</td><td>5</td><td>100</td></tr>
 <tr><td>Torso</td><td>25</td><td>25</td><td>25</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr><td>翼脚</td><td>30</td><td>30</td><td>30</td><td>30</td><td>0</td><td>15</td><td>10</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>35</td><td>35</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
+<tr><td>Wingleg</td><td>30</td><td>30</td><td>30</td><td>30</td><td>0</td><td>15</td><td>10</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>35</td><td>35</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>32</td><td>32</td><td>25</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>26</td><td>20</td><td>15</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>45</td><td>40</td><td>10</td><td>0</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>

--- a/mons/goglf_l_ng.htm
+++ b/mons/goglf_l_ng.htm
@@ -102,17 +102,17 @@
 <img id=icon src="../img/monsicons/raygougarf.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>45</td><td>35</td><td>20</td><td>0</td><td>0</td><td>0</td><td>10</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>40</td><td>25</td><td>10</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>40</td><td>25</td><td>10</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>40</td><td>35</td><td>20</td><td>15</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Torso</td><td>30</td><td>30</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>35</td><td>40</td><td>25</td><td>0</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>55</td><td>40</td><td>30</td><td>0</td><td>0</td><td>0</td><td>15</td><td>150</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>40</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>40</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>40</td><td>35</td><td>25</td><td>15</td><td>0</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>35</td><td>35</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>40</td><td>45</td><td>35</td><td>0</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
@@ -126,8 +126,8 @@
 <tr><td>Left Hind Leg</td><td>700</td><td></td></tr>
 <tr><td>Torso</td><td>600</td><td>1st time, back breaks</td></tr>
 <tr><td>Tail</td><td>2000</td><td>1st time, tail breaks</td></tr>
-<tr><td>Left Fore Leg</td><td>700</td><td></td></tr>
-<tr><td>Right Fore Leg</td><td>700</td><td></td></tr>
+<tr><td>Left Foreleg</td><td>700</td><td></td></tr>
+<tr><td>Right Foreleg</td><td>700</td><td></td></tr>
 <tr><td>Tail</td><td>2000</td><td></td></tr>
 </table>
 <img id=hitzones src="../img/monszones/raygougarf.png" width="400"/>

--- a/mons/goglf_l_nh.htm
+++ b/mons/goglf_l_nh.htm
@@ -75,17 +75,17 @@
 <img id=icon src="../img/monsicons/raygougarf.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>45</td><td>35</td><td>20</td><td>0</td><td>0</td><td>0</td><td>10</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>40</td><td>25</td><td>10</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>40</td><td>25</td><td>10</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>40</td><td>35</td><td>20</td><td>15</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Torso</td><td>30</td><td>30</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>35</td><td>40</td><td>25</td><td>0</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>55</td><td>40</td><td>30</td><td>0</td><td>0</td><td>0</td><td>15</td><td>150</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>40</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>40</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>40</td><td>35</td><td>25</td><td>15</td><td>0</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>35</td><td>35</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>40</td><td>45</td><td>35</td><td>0</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
@@ -99,8 +99,8 @@
 <tr><td>Left Hind Leg</td><td>500</td><td></td></tr>
 <tr><td>Torso</td><td>450</td><td>1st time, back breaks</td></tr>
 <tr><td>Tail</td><td>1100</td><td>1st time, tail breaks</td></tr>
-<tr><td>Left Fore Leg</td><td>500</td><td></td></tr>
-<tr><td>Right Fore Leg</td><td>500</td><td></td></tr>
+<tr><td>Left Foreleg</td><td>500</td><td></td></tr>
+<tr><td>Right Foreleg</td><td>500</td><td></td></tr>
 <tr><td>Tail</td><td>1100</td><td></td></tr>
 </table>
 <img id=hitzones src="../img/monszones/raygougarf.png" width="400"/>

--- a/mons/goglf_r_ng.htm
+++ b/mons/goglf_r_ng.htm
@@ -102,24 +102,24 @@
 <img id=icon src="../img/monsicons/lologougarf.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>35</td><td>0</td><td>15</td><td>0</td><td>0</td><td>10</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>30</td><td>15</td><td>0</td><td>10</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>30</td><td>15</td><td>0</td><td>10</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>25</td><td>20</td><td>0</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>15</td><td>0</td><td>10</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>25</td><td>0</td><td>20</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>45</td><td>40</td><td>0</td><td>35</td><td>0</td><td>0</td><td>15</td><td>150</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>35</td><td>20</td><td>0</td><td>20</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>35</td><td>20</td><td>0</td><td>20</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>35</td><td>30</td><td>25</td><td>0</td><td>25</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>15</td><td>0</td><td>20</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>40</td><td>35</td><td>0</td><td>25</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info(Both Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones(Both Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>65</td><td>60</td><td>0</td><td>35</td><td>0</td><td>0</td><td>15</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>40</td><td>45</td><td>35</td><td>0</td><td>20</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>40</td><td>45</td><td>35</td><td>0</td><td>20</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>45</td><td>40</td><td>35</td><td>0</td><td>25</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>40</td><td>40</td><td>20</td><td>0</td><td>20</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>45</td><td>55</td><td>0</td><td>30</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
@@ -133,8 +133,8 @@
 <tr><td>Left Hind Leg</td><td>700</td><td></td></tr>
 <tr><td>Torso</td><td>600</td><td>1st time, back breaks</td></tr>
 <tr><td>Tail</td><td>2000</td><td>1st time, tail breaks</td></tr>
-<tr><td>Left Fore Leg</td><td>700</td><td></td></tr>
-<tr><td>Right Fore Leg</td><td>700</td><td></td></tr>
+<tr><td>Left Foreleg</td><td>700</td><td></td></tr>
+<tr><td>Right Foreleg</td><td>700</td><td></td></tr>
 <tr><td>Tail</td><td>2000</td><td></td></tr>
 </table>
 <img id=hitzones src="../img/monszones/lologougarf.png" width="400"/>

--- a/mons/goglf_r_nh.htm
+++ b/mons/goglf_r_nh.htm
@@ -75,24 +75,24 @@
 <img id=icon src="../img/monsicons/lologougarf.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>35</td><td>0</td><td>15</td><td>0</td><td>0</td><td>10</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>30</td><td>15</td><td>0</td><td>10</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>30</td><td>15</td><td>0</td><td>10</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>25</td><td>20</td><td>0</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>15</td><td>0</td><td>10</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>25</td><td>0</td><td>20</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>45</td><td>40</td><td>0</td><td>35</td><td>0</td><td>0</td><td>15</td><td>150</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>35</td><td>20</td><td>0</td><td>20</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>35</td><td>20</td><td>0</td><td>20</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>35</td><td>30</td><td>25</td><td>0</td><td>25</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>15</td><td>0</td><td>20</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>40</td><td>35</td><td>0</td><td>25</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info(Both Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones(Both Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>65</td><td>60</td><td>0</td><td>35</td><td>0</td><td>0</td><td>15</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>40</td><td>45</td><td>35</td><td>0</td><td>20</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>40</td><td>45</td><td>35</td><td>0</td><td>20</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>45</td><td>40</td><td>35</td><td>0</td><td>25</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>40</td><td>40</td><td>20</td><td>0</td><td>20</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>45</td><td>55</td><td>0</td><td>30</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
@@ -106,8 +106,8 @@
 <tr><td>Left Hind Leg</td><td>500</td><td></td></tr>
 <tr><td>Torso</td><td>450</td><td>1st time, back breaks</td></tr>
 <tr><td>Tail</td><td>1100</td><td>1st time, tail breaks</td></tr>
-<tr><td>Left Fore Leg</td><td>500</td><td></td></tr>
-<tr><td>Right Fore Leg</td><td>500</td><td></td></tr>
+<tr><td>Left Foreleg</td><td>500</td><td></td></tr>
+<tr><td>Right Foreleg</td><td>500</td><td></td></tr>
 <tr><td>Tail</td><td>1100</td><td></td></tr>
 </table>
 <img id=hitzones src="../img/monszones/lologougarf.png" width="400"/>

--- a/mons/gogo_n.htm
+++ b/mons/gogo_n.htm
@@ -68,25 +68,25 @@
 <img id=icon src="../img/monsicons/gogomoa.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>70</td><td>80</td><td>60</td><td>10</td><td>5</td><td>10</td><td>0</td><td>15</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>60</td><td>60</td><td>40</td><td>10</td><td>5</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>Hind Leg</td><td>50</td><td>45</td><td>45</td><td>10</td><td>5</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Arm</td><td>60</td><td>60</td><td>40</td><td>10</td><td>5</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Leg</td><td>50</td><td>45</td><td>45</td><td>10</td><td>5</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Torso</td><td>40</td><td>45</td><td>50</td><td>10</td><td>5</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>70</td><td>60</td><td>80</td><td>15</td><td>5</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info(Counter： Dmg x4)</th></tr>
+<tr class=l><th colspan=10>Hitzones(Counter： Dmg x4)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>210</td><td>240</td><td>60</td><td>10</td><td>5</td><td>10</td><td>0</td><td>15</td><td>200</td></tr>
-<tr><td>Fore Leg</td><td>180</td><td>180</td><td>40</td><td>10</td><td>5</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>Hind Leg</td><td>150</td><td>135</td><td>45</td><td>10</td><td>5</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Arm</td><td>180</td><td>180</td><td>40</td><td>10</td><td>5</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Leg</td><td>150</td><td>135</td><td>45</td><td>10</td><td>5</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Torso</td><td>120</td><td>135</td><td>50</td><td>10</td><td>5</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>210</td><td>180</td><td>80</td><td>15</td><td>5</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info(Counter： Dmg x4 Aura)</th></tr>
+<tr class=l><th colspan=10>Hitzones(Counter： Dmg x4 Aura)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>245</td><td>250</td><td>60</td><td>10</td><td>5</td><td>10</td><td>0</td><td>15</td><td>200</td></tr>
-<tr><td>Fore Leg</td><td>210</td><td>210</td><td>40</td><td>10</td><td>5</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>Hind Leg</td><td>175</td><td>135</td><td>45</td><td>10</td><td>5</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Arm</td><td>210</td><td>210</td><td>40</td><td>10</td><td>5</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Leg</td><td>175</td><td>135</td><td>45</td><td>10</td><td>5</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Torso</td><td>140</td><td>135</td><td>50</td><td>10</td><td>5</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>245</td><td>195</td><td>80</td><td>15</td><td>5</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
 </table>
@@ -102,19 +102,19 @@
 <span><em>12</em>490</span>
 </div>
 </td></tr>
-<tr><td>Left Forearm</td><td>100</td><td><div>
+<tr><td>Left Arm</td><td>100</td><td><div>
 <span><em>12</em>350</span>
 </div>
 2nd time destroys left claw</td></tr>
-<tr><td>Right Forearm</td><td>100</td><td><div>
+<tr><td>Right Arm</td><td>100</td><td><div>
 <span><em>12</em>350</span>
 </div>
 2nd time destroys right claw</td></tr>
-<tr><td>Left Hind Leg</td><td>120</td><td><div>
+<tr><td>Left Leg</td><td>120</td><td><div>
 <span><em>12</em>420</span>
 </div>
 </td></tr>
-<tr><td>Right Hind Leg</td><td>120</td><td><div>
+<tr><td>Right Leg</td><td>120</td><td><div>
 <span><em>12</em>420</span>
 </div>
 </td></tr>

--- a/mons/gogo_ng.htm
+++ b/mons/gogo_ng.htm
@@ -106,25 +106,25 @@
 <img id=icon src="../img/monsicons/gogomoa.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>30</td><td>10</td><td>5</td><td>10</td><td>0</td><td>20</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>30</td><td>20</td><td>10</td><td>5</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>Hind Leg</td><td>25</td><td>20</td><td>20</td><td>10</td><td>5</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
+<tr><td>Arm</td><td>30</td><td>30</td><td>20</td><td>10</td><td>5</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
+<tr><td>Leg</td><td>25</td><td>20</td><td>20</td><td>10</td><td>5</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
 <tr><td>Torso</td><td>30</td><td>35</td><td>25</td><td>10</td><td>5</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>40</td><td>15</td><td>5</td><td>10</td><td>0</td><td>25</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info(Counter： Dmg x4)</th></tr>
+<tr class=l><th colspan=10>Hitzones(Counter： Dmg x4)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>105</td><td>120</td><td>30</td><td>10</td><td>5</td><td>10</td><td>0</td><td>20</td><td>200</td></tr>
-<tr><td>Fore Leg</td><td>90</td><td>90</td><td>20</td><td>10</td><td>5</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>Hind Leg</td><td>75</td><td>60</td><td>20</td><td>10</td><td>5</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
+<tr><td>Arm</td><td>90</td><td>90</td><td>20</td><td>10</td><td>5</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
+<tr><td>Leg</td><td>75</td><td>60</td><td>20</td><td>10</td><td>5</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
 <tr><td>Torso</td><td>90</td><td>105</td><td>25</td><td>10</td><td>5</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
 <tr><td>Tail</td><td>105</td><td>90</td><td>40</td><td>15</td><td>5</td><td>10</td><td>0</td><td>25</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info(Counter： Dmg x4 Aura)</th></tr>
+<tr class=l><th colspan=10>Hitzones(Counter： Dmg x4 Aura)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>140</td><td>140</td><td>30</td><td>10</td><td>5</td><td>10</td><td>0</td><td>20</td><td>200</td></tr>
-<tr><td>Fore Leg</td><td>105</td><td>105</td><td>20</td><td>10</td><td>5</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>Hind Leg</td><td>100</td><td>70</td><td>20</td><td>10</td><td>5</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
+<tr><td>Arm</td><td>105</td><td>105</td><td>20</td><td>10</td><td>5</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
+<tr><td>Leg</td><td>100</td><td>70</td><td>20</td><td>10</td><td>5</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
 <tr><td>Torso</td><td>105</td><td>140</td><td>25</td><td>10</td><td>5</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
 <tr><td>Tail</td><td>140</td><td>105</td><td>40</td><td>15</td><td>5</td><td>10</td><td>0</td><td>25</td><td>0</td></tr>
 </table>
@@ -134,10 +134,10 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>750</td><td>2nd time destroys head</td></tr>
 <tr><td>Torso</td><td>900</td><td></td></tr>
-<tr><td>Left Forearm</td><td>700</td><td>2nd time destroys left claw</td></tr>
-<tr><td>Right Forearm</td><td>700</td><td>2nd time destroys right claw</td></tr>
-<tr><td>Left Hind Leg</td><td>600</td><td></td></tr>
-<tr><td>Right Hind Leg</td><td>600</td><td></td></tr>
+<tr><td>Left Arm</td><td>700</td><td>2nd time destroys left claw</td></tr>
+<tr><td>Right Arm</td><td>700</td><td>2nd time destroys right claw</td></tr>
+<tr><td>Left Leg</td><td>600</td><td></td></tr>
+<tr><td>Right Leg</td><td>600</td><td></td></tr>
 <tr><td>Tail</td><td>1000</td><td>1st time destroys tail</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/gogomoa.png" width="400"/>

--- a/mons/gogo_nh.htm
+++ b/mons/gogo_nh.htm
@@ -84,25 +84,25 @@
 <img id=icon src="../img/monsicons/gogomoa.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>50</td><td>30</td><td>5</td><td>0</td><td>5</td><td>0</td><td>10</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>30</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>Hind Leg</td><td>25</td><td>35</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>35</td><td>30</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Leg</td><td>25</td><td>35</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>35</td><td>40</td><td>25</td><td>5</td><td>0</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>30</td><td>45</td><td>10</td><td>0</td><td>5</td><td>0</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info(Counter： Dmg x4)</th></tr>
+<tr class=l><th colspan=10>Hitzones(Counter： Dmg x4)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>120</td><td>150</td><td>30</td><td>5</td><td>0</td><td>5</td><td>0</td><td>10</td><td>200</td></tr>
-<tr><td>Fore Leg</td><td>105</td><td>90</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>Hind Leg</td><td>75</td><td>105</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>105</td><td>90</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Leg</td><td>75</td><td>105</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>105</td><td>120</td><td>25</td><td>5</td><td>0</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>120</td><td>90</td><td>45</td><td>10</td><td>0</td><td>5</td><td>0</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info(Counter： Dmg x4 Aura)</th></tr>
+<tr class=l><th colspan=10>Hitzones(Counter： Dmg x4 Aura)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>160</td><td>175</td><td>30</td><td>5</td><td>0</td><td>5</td><td>0</td><td>10</td><td>200</td></tr>
-<tr><td>Fore Leg</td><td>125</td><td>105</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>Hind Leg</td><td>90</td><td>125</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>125</td><td>105</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Leg</td><td>90</td><td>125</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>125</td><td>160</td><td>25</td><td>5</td><td>0</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>140</td><td>105</td><td>45</td><td>10</td><td>0</td><td>5</td><td>0</td><td>15</td><td>0</td></tr>
 </table>
@@ -112,10 +112,10 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>550</td><td>2nd time destroys head</td></tr>
 <tr><td>Torso</td><td>700</td><td></td></tr>
-<tr><td>Left Forearm</td><td>500</td><td>2nd time destroys left claw</td></tr>
-<tr><td>Right Forearm</td><td>500</td><td>2nd time destroys right claw</td></tr>
-<tr><td>Left Hind Leg</td><td>450</td><td></td></tr>
-<tr><td>Right Hind Leg</td><td>450</td><td></td></tr>
+<tr><td>Left Arm</td><td>500</td><td>2nd time destroys left claw</td></tr>
+<tr><td>Right Arm</td><td>500</td><td>2nd time destroys right claw</td></tr>
+<tr><td>Left Leg</td><td>450</td><td></td></tr>
+<tr><td>Right Leg</td><td>450</td><td></td></tr>
 <tr><td>Tail</td><td>800</td><td>1st time destroys tail</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/gogomoa.png" width="400"/>

--- a/mons/guan_ng.htm
+++ b/mons/guan_ng.htm
@@ -103,7 +103,7 @@
 <img id=icon src="../img/monsicons/guanzorumu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>25</td><td>40</td><td>35</td><td>0</td><td>20</td><td>5</td><td>25</td><td>15</td><td>100</td></tr>
 <tr><td>？？</td><td>30</td><td>25</td><td>20</td><td>0</td><td>15</td><td>5</td><td>15</td><td>20</td><td>0</td></tr>
@@ -112,7 +112,7 @@
 <tr><td>？？</td><td>15</td><td>25</td><td>10</td><td>0</td><td>10</td><td>5</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>15</td><td>15</td><td>10</td><td>0</td><td>15</td><td>5</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>40</td><td>30</td><td>35</td><td>10</td><td>0</td><td>25</td><td>20</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質()</th></tr>
+<tr class=l><th colspan=10>Hitzones()</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>25</td><td>40</td><td>30</td><td>0</td><td>25</td><td>5</td><td>25</td><td>20</td><td>100</td></tr>
 <tr><td>？？</td><td>25</td><td>20</td><td>20</td><td>0</td><td>20</td><td>5</td><td>15</td><td>25</td><td>0</td></tr>
@@ -121,7 +121,7 @@
 <tr><td>？？</td><td>15</td><td>25</td><td>10</td><td>0</td><td>10</td><td>5</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>15</td><td>15</td><td>10</td><td>0</td><td>15</td><td>5</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>40</td><td>30</td><td>35</td><td>10</td><td>0</td><td>25</td><td>20</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質()</th></tr>
+<tr class=l><th colspan=10>Hitzones()</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>20</td><td>35</td><td>30</td><td>0</td><td>15</td><td>10</td><td>30</td><td>10</td><td>100</td></tr>
 <tr><td>？？</td><td>25</td><td>20</td><td>15</td><td>0</td><td>10</td><td>10</td><td>20</td><td>15</td><td>0</td></tr>
@@ -130,7 +130,7 @@
 <tr><td>？？</td><td>10</td><td>20</td><td>5</td><td>0</td><td>5</td><td>10</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>？？</td><td>15</td><td>15</td><td>10</td><td>0</td><td>10</td><td>10</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>？？</td><td>40</td><td>30</td><td>35</td><td>10</td><td>0</td><td>25</td><td>20</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質()</th></tr>
+<tr class=l><th colspan=10>Hitzones()</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>20</td><td>35</td><td>25</td><td>0</td><td>15</td><td>10</td><td>35</td><td>10</td><td>100</td></tr>
 <tr><td>？？</td><td>25</td><td>20</td><td>15</td><td>0</td><td>10</td><td>15</td><td>25</td><td>15</td><td>0</td></tr>
@@ -139,7 +139,7 @@
 <tr><td>？？</td><td>10</td><td>20</td><td>5</td><td>0</td><td>5</td><td>10</td><td>25</td><td>5</td><td>0</td></tr>
 <tr><td>？？</td><td>10</td><td>10</td><td>10</td><td>0</td><td>10</td><td>10</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>？？</td><td>40</td><td>30</td><td>35</td><td>10</td><td>0</td><td>25</td><td>20</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(難関)</th></tr>
+<tr class=l><th colspan=10>Hitzones(難関)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>25</td><td>35</td><td>25</td><td>0</td><td>15</td><td>10</td><td>30</td><td>10</td><td>100</td></tr>
 <tr><td>？？</td><td>25</td><td>20</td><td>20</td><td>0</td><td>10</td><td>10</td><td>20</td><td>15</td><td>0</td></tr>
@@ -148,7 +148,7 @@
 <tr><td>？？</td><td>10</td><td>20</td><td>5</td><td>0</td><td>5</td><td>10</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>？？</td><td>15</td><td>15</td><td>15</td><td>0</td><td>10</td><td>10</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>？？</td><td>40</td><td>30</td><td>35</td><td>10</td><td>0</td><td>25</td><td>20</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(難関)</th></tr>
+<tr class=l><th colspan=10>Hitzones(難関)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>20</td><td>30</td><td>25</td><td>0</td><td>15</td><td>10</td><td>35</td><td>10</td><td>100</td></tr>
 <tr><td>？？</td><td>25</td><td>20</td><td>15</td><td>0</td><td>10</td><td>15</td><td>25</td><td>15</td><td>0</td></tr>

--- a/mons/guan_nh.htm
+++ b/mons/guan_nh.htm
@@ -75,7 +75,7 @@
 <img id=icon src="../img/monsicons/guanzorumu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>50</td><td>65</td><td>55</td><td>0</td><td>20</td><td>5</td><td>25</td><td>15</td><td>100</td></tr>
 <tr><td>？？</td><td>60</td><td>45</td><td>45</td><td>0</td><td>15</td><td>5</td><td>15</td><td>20</td><td>0</td></tr>
@@ -84,7 +84,7 @@
 <tr><td>？？</td><td>35</td><td>40</td><td>30</td><td>0</td><td>10</td><td>5</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>35</td><td>45</td><td>40</td><td>0</td><td>15</td><td>5</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>60</td><td>50</td><td>55</td><td>10</td><td>0</td><td>25</td><td>20</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質()</th></tr>
+<tr class=l><th colspan=10>Hitzones()</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>25</td><td>40</td><td>30</td><td>0</td><td>25</td><td>5</td><td>25</td><td>20</td><td>100</td></tr>
 <tr><td>？？</td><td>35</td><td>20</td><td>15</td><td>0</td><td>20</td><td>5</td><td>15</td><td>25</td><td>0</td></tr>
@@ -93,7 +93,7 @@
 <tr><td>？？</td><td>10</td><td>15</td><td>10</td><td>0</td><td>10</td><td>5</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>20</td><td>25</td><td>15</td><td>0</td><td>15</td><td>5</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>40</td><td>30</td><td>35</td><td>10</td><td>0</td><td>25</td><td>20</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質()</th></tr>
+<tr class=l><th colspan=10>Hitzones()</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>25</td><td>35</td><td>25</td><td>0</td><td>15</td><td>10</td><td>30</td><td>10</td><td>100</td></tr>
 <tr><td>？？</td><td>25</td><td>20</td><td>20</td><td>0</td><td>10</td><td>10</td><td>20</td><td>15</td><td>0</td></tr>
@@ -102,7 +102,7 @@
 <tr><td>？？</td><td>10</td><td>20</td><td>5</td><td>0</td><td>5</td><td>10</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>？？</td><td>15</td><td>15</td><td>15</td><td>0</td><td>10</td><td>10</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>？？</td><td>40</td><td>30</td><td>35</td><td>10</td><td>0</td><td>25</td><td>20</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質()</th></tr>
+<tr class=l><th colspan=10>Hitzones()</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>20</td><td>30</td><td>25</td><td>0</td><td>15</td><td>10</td><td>35</td><td>10</td><td>100</td></tr>
 <tr><td>？？</td><td>25</td><td>20</td><td>15</td><td>0</td><td>10</td><td>15</td><td>25</td><td>15</td><td>0</td></tr>

--- a/mons/gura_n.htm
+++ b/mons/gura_n.htm
@@ -74,7 +74,7 @@
 <img id=icon src="../img/monsicons/gravios.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>30</td><td>20</td><td>0</td><td>15</td><td>5</td><td>40</td><td>5</td><td>150</td></tr>
 <tr><td>Neck</td><td>30</td><td>30</td><td>20</td><td>0</td><td>30</td><td>5</td><td>20</td><td>10</td><td>0</td></tr>
@@ -83,7 +83,7 @@
 <tr><td>Tail</td><td>25</td><td>30</td><td>20</td><td>0</td><td>30</td><td>5</td><td>20</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>20</td><td>20</td><td>0</td><td>20</td><td>5</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>25</td><td>20</td><td>0</td><td>30</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(腹部破壊後)</th></tr>
+<tr class=l><th colspan=10>Hitzones(腹部破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>30</td><td>20</td><td>0</td><td>15</td><td>5</td><td>40</td><td>5</td><td>150</td></tr>
 <tr><td>Neck</td><td>30</td><td>30</td><td>20</td><td>0</td><td>30</td><td>5</td><td>20</td><td>10</td><td>0</td></tr>
@@ -100,11 +100,11 @@
 <tr><td>Torso</td><td>240</td><td></td></tr>
 <tr><td>Left Wing</td><td>120</td><td></td></tr>
 <tr><td>Right Wing</td><td>120</td><td></td></tr>
-<tr><td>Left Foot</td><td>160</td><td><div>
+<tr><td>Left Leg</td><td>160</td><td><div>
 <span><em>14</em>225</span><span><em>15</em>229</span><span><em>16</em>234</span><span><em>17</em>238</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>160</td><td><div>
+<tr><td>Right Leg</td><td>160</td><td><div>
 <span><em>14</em>225</span><span><em>15</em>229</span><span><em>16</em>234</span><span><em>17</em>238</span>
 </div>
 </td></tr>

--- a/mons/gura_ng.htm
+++ b/mons/gura_ng.htm
@@ -124,7 +124,7 @@
 <img id=icon src="../img/monsicons/gravios.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>40</td><td>30</td><td>0</td><td>20</td><td>5</td><td>40</td><td>5</td><td>150</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>20</td><td>0</td><td>30</td><td>5</td><td>20</td><td>10</td><td>0</td></tr>
@@ -133,7 +133,7 @@
 <tr><td>Tail</td><td>25</td><td>30</td><td>20</td><td>0</td><td>30</td><td>5</td><td>20</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>20</td><td>20</td><td>0</td><td>20</td><td>5</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>25</td><td>30</td><td>0</td><td>30</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(腹部破壊後)</th></tr>
+<tr class=l><th colspan=10>Hitzones(腹部破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>40</td><td>30</td><td>0</td><td>20</td><td>5</td><td>40</td><td>5</td><td>150</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>20</td><td>0</td><td>30</td><td>5</td><td>20</td><td>10</td><td>0</td></tr>
@@ -150,8 +150,8 @@
 <tr><td>Torso</td><td>400</td><td></td></tr>
 <tr><td>Left Wing</td><td>350</td><td></td></tr>
 <tr><td>Right Wing</td><td>350</td><td></td></tr>
-<tr><td>Left Foot</td><td>300</td><td></td></tr>
-<tr><td>Right Foot</td><td>300</td><td></td></tr>
+<tr><td>Left Leg</td><td>300</td><td></td></tr>
+<tr><td>Right Leg</td><td>300</td><td></td></tr>
 <tr><td>Head</td><td>350</td><td></td></tr>
 <tr><td>Belly</td><td>950</td><td>１ stagger(s) required<br>２ stagger(s) required to get the reward</td></tr>
 <tr><td>Tail</td><td>500</td><td></td></tr>

--- a/mons/gura_nh.htm
+++ b/mons/gura_nh.htm
@@ -77,7 +77,7 @@
 <img id=icon src="../img/monsicons/gravios.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>30</td><td>20</td><td>-10</td><td>15</td><td>5</td><td>5</td><td>5</td><td>150</td></tr>
 <tr><td>Neck</td><td>10</td><td>30</td><td>30</td><td>-10</td><td>20</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
@@ -86,7 +86,7 @@
 <tr><td>Tail</td><td>25</td><td>30</td><td>20</td><td>-10</td><td>15</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>10</td><td>20</td><td>-10</td><td>15</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>15</td><td>20</td><td>-5</td><td>10</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(腹部破壊後)</th></tr>
+<tr class=l><th colspan=10>Hitzones(腹部破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>30</td><td>20</td><td>-10</td><td>15</td><td>5</td><td>5</td><td>5</td><td>150</td></tr>
 <tr><td>Neck</td><td>10</td><td>30</td><td>30</td><td>-10</td><td>20</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
@@ -103,8 +103,8 @@
 <tr><td>Torso</td><td>240</td><td></td></tr>
 <tr><td>Left Wing</td><td>120</td><td></td></tr>
 <tr><td>Right Wing</td><td>120</td><td></td></tr>
-<tr><td>Left Foot</td><td>160</td><td></td></tr>
-<tr><td>Right Foot</td><td>160</td><td></td></tr>
+<tr><td>Left Leg</td><td>160</td><td></td></tr>
+<tr><td>Right Leg</td><td>160</td><td></td></tr>
 <tr><td>Head</td><td>120</td><td></td></tr>
 <tr><td>Belly</td><td>700</td><td>１ stagger(s) required<br>２ stagger(s) required to get the reward</td></tr>
 <tr><td>Tail</td><td>200</td><td></td></tr>

--- a/mons/gura_ni.htm
+++ b/mons/gura_ni.htm
@@ -112,7 +112,7 @@
 <img id=icon src="../img/monsicons/zenith_gravios.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>35</td><td>30</td><td>0</td><td>20</td><td>0</td><td>20</td><td>25</td><td>100</td></tr>
 <tr><td>Neck</td><td>30</td><td>10</td><td>15</td><td>0</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
@@ -121,7 +121,7 @@
 <tr><td>Tail</td><td>30</td><td>15</td><td>20</td><td>0</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>15</td><td>10</td><td>0</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>15</td><td>10</td><td>0</td><td>5</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(腹部破壊後)</th></tr>
+<tr class=l><th colspan=10>Hitzones(腹部破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>35</td><td>30</td><td>0</td><td>30</td><td>0</td><td>20</td><td>25</td><td>100</td></tr>
 <tr><td>Neck</td><td>30</td><td>10</td><td>15</td><td>0</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
@@ -130,7 +130,7 @@
 <tr><td>Tail</td><td>30</td><td>15</td><td>20</td><td>0</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>20</td><td>10</td><td>0</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>15</td><td>10</td><td>0</td><td>5</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(腹部破壊後)</th></tr>
+<tr class=l><th colspan=10>Hitzones(腹部破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>35</td><td>30</td><td>0</td><td>30</td><td>0</td><td>20</td><td>25</td><td>100</td></tr>
 <tr><td>Neck</td><td>30</td><td>10</td><td>15</td><td>0</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
@@ -139,7 +139,7 @@
 <tr><td>Tail</td><td>30</td><td>15</td><td>20</td><td>0</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>20</td><td>10</td><td>0</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>15</td><td>10</td><td>0</td><td>5</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(腹部破壊後)</th></tr>
+<tr class=l><th colspan=10>Hitzones(腹部破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>35</td><td>30</td><td>0</td><td>30</td><td>0</td><td>20</td><td>25</td><td>100</td></tr>
 <tr><td>Neck</td><td>30</td><td>10</td><td>15</td><td>0</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
@@ -155,8 +155,8 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Left Wing</td><td>1000</td><td></td></tr>
 <tr><td>Right Wing</td><td>1000</td><td></td></tr>
-<tr><td>Left Foot</td><td>600</td><td></td></tr>
-<tr><td>Right Foot</td><td>600</td><td></td></tr>
+<tr><td>Left Leg</td><td>600</td><td></td></tr>
+<tr><td>Right Leg</td><td>600</td><td></td></tr>
 <tr><td>Head</td><td>1400</td><td></td></tr>
 <tr><td>Belly</td><td>2500</td><td>１ stagger(s) required<br>２ stagger(s) required to get the reward</td></tr>
 <tr><td>Tail</td><td>700</td><td></td></tr>

--- a/mons/gura_nt.htm
+++ b/mons/gura_nt.htm
@@ -104,7 +104,7 @@
 <img id=icon src="../img/monsicons/gravios.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>40</td><td>30</td><td>0</td><td>20</td><td>5</td><td>40</td><td>5</td><td>150</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>20</td><td>0</td><td>30</td><td>5</td><td>20</td><td>10</td><td>0</td></tr>
@@ -113,7 +113,7 @@
 <tr><td>Tail</td><td>25</td><td>30</td><td>20</td><td>0</td><td>30</td><td>5</td><td>20</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>20</td><td>20</td><td>0</td><td>20</td><td>5</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>25</td><td>30</td><td>0</td><td>30</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(腹部破壊後)</th></tr>
+<tr class=l><th colspan=10>Hitzones(腹部破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>40</td><td>30</td><td>0</td><td>20</td><td>5</td><td>40</td><td>5</td><td>150</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>20</td><td>0</td><td>30</td><td>5</td><td>20</td><td>10</td><td>0</td></tr>
@@ -130,8 +130,8 @@
 <tr><td>Torso</td><td>240</td><td></td></tr>
 <tr><td>Left Wing</td><td>120</td><td></td></tr>
 <tr><td>Right Wing</td><td>120</td><td></td></tr>
-<tr><td>Left Foot</td><td>160</td><td></td></tr>
-<tr><td>Right Foot</td><td>160</td><td></td></tr>
+<tr><td>Left Leg</td><td>160</td><td></td></tr>
+<tr><td>Right Leg</td><td>160</td><td></td></tr>
 <tr><td>Head</td><td>120</td><td></td></tr>
 <tr><td>Belly</td><td>700</td><td>１ stagger(s) required<br>２ stagger(s) required to get the reward</td></tr>
 <tr><td>Tail</td><td>200</td><td></td></tr>

--- a/mons/gurakuro_n.htm
+++ b/mons/gurakuro_n.htm
@@ -73,7 +73,7 @@
 <img id=icon src="../img/monsicons/blackgravios.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>30</td><td>20</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>30</td><td>30</td><td>20</td><td>0</td><td>30</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
@@ -82,7 +82,7 @@
 <tr><td>Tail</td><td>25</td><td>30</td><td>20</td><td>0</td><td>30</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>20</td><td>20</td><td>0</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>25</td><td>20</td><td>0</td><td>30</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(腹部破壊後)</th></tr>
+<tr class=l><th colspan=10>Hitzones(腹部破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>30</td><td>20</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td><td>200</td></tr>
 <tr><td>Neck</td><td>30</td><td>30</td><td>20</td><td>0</td><td>30</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
@@ -99,11 +99,11 @@
 <tr><td>Torso</td><td>240</td><td></td></tr>
 <tr><td>Left Wing</td><td>120</td><td></td></tr>
 <tr><td>Right Wing</td><td>120</td><td></td></tr>
-<tr><td>Left Foot</td><td>160</td><td><div>
+<tr><td>Left Leg</td><td>160</td><td><div>
 <span><em>14</em>225</span><span><em>15</em>229</span><span><em>16</em>234</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>160</td><td><div>
+<tr><td>Right Leg</td><td>160</td><td><div>
 <span><em>14</em>225</span><span><em>15</em>229</span><span><em>16</em>234</span>
 </div>
 </td></tr>

--- a/mons/gurakuro_ng.htm
+++ b/mons/gurakuro_ng.htm
@@ -124,7 +124,7 @@
 <img id=icon src="../img/monsicons/blackgravios.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>30</td><td>20</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>30</td><td>30</td><td>20</td><td>0</td><td>30</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
@@ -133,7 +133,7 @@
 <tr><td>Tail</td><td>25</td><td>30</td><td>20</td><td>0</td><td>30</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>20</td><td>20</td><td>0</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>25</td><td>20</td><td>0</td><td>30</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(腹部破壊後)</th></tr>
+<tr class=l><th colspan=10>Hitzones(腹部破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>30</td><td>20</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td><td>200</td></tr>
 <tr><td>Neck</td><td>30</td><td>30</td><td>20</td><td>0</td><td>30</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
@@ -150,8 +150,8 @@
 <tr><td>Torso</td><td>510</td><td></td></tr>
 <tr><td>Left Wing</td><td>560</td><td></td></tr>
 <tr><td>Right Wing</td><td>560</td><td></td></tr>
-<tr><td>Left Foot</td><td>530</td><td></td></tr>
-<tr><td>Right Foot</td><td>530</td><td></td></tr>
+<tr><td>Left Leg</td><td>530</td><td></td></tr>
+<tr><td>Right Leg</td><td>530</td><td></td></tr>
 <tr><td>Head</td><td>450</td><td></td></tr>
 <tr><td>Belly</td><td>1000</td><td>１ stagger(s) required<br>２ stagger(s) required to get the reward</td></tr>
 <tr><td>Tail</td><td>500</td><td></td></tr>

--- a/mons/gurakuro_nh.htm
+++ b/mons/gurakuro_nh.htm
@@ -93,7 +93,7 @@
 <img id=icon src="../img/monsicons/blackgravios.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>30</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>40</td><td>30</td><td>0</td><td>30</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
@@ -102,7 +102,7 @@
 <tr><td>Tail</td><td>35</td><td>40</td><td>30</td><td>0</td><td>30</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>30</td><td>30</td><td>30</td><td>0</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>35</td><td>30</td><td>0</td><td>30</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(腹部破壊後)</th></tr>
+<tr class=l><th colspan=10>Hitzones(腹部破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>30</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td><td>200</td></tr>
 <tr><td>Neck</td><td>40</td><td>40</td><td>30</td><td>0</td><td>30</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
@@ -119,8 +119,8 @@
 <tr><td>Torso</td><td>300</td><td></td></tr>
 <tr><td>Left Wing</td><td>360</td><td></td></tr>
 <tr><td>Right Wing</td><td>360</td><td></td></tr>
-<tr><td>Left Foot</td><td>320</td><td></td></tr>
-<tr><td>Right Foot</td><td>320</td><td></td></tr>
+<tr><td>Left Leg</td><td>320</td><td></td></tr>
+<tr><td>Right Leg</td><td>320</td><td></td></tr>
 <tr><td>Head</td><td>360</td><td></td></tr>
 <tr><td>Belly</td><td>800</td><td>１ stagger(s) required<br>２ stagger(s) required to get the reward</td></tr>
 <tr><td>Tail</td><td>400</td><td></td></tr>

--- a/mons/guren_n.htm
+++ b/mons/guren_n.htm
@@ -72,7 +72,7 @@
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head/Neck</td><td>15</td><td>30</td><td>15</td><td>10</td><td>0</td><td>15</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Wing</td><td>20</td><td>25</td><td>20</td><td>10</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
-<tr><td>翼尾/先端</td><td>75</td><td>85</td><td>50</td><td>20</td><td>0</td><td>10</td><td>30</td><td>0</td><td>0</td></tr>
+<tr><td>Wing Tip/Tail Tip</td><td>75</td><td>85</td><td>50</td><td>20</td><td>0</td><td>10</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>40</td><td>20</td><td>25</td><td>0</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>45</td><td>40</td><td>30</td><td>0</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>55</td><td>60</td><td>20</td><td>10</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
@@ -81,7 +81,7 @@
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head/Neck</td><td>20</td><td>35</td><td>25</td><td>10</td><td>0</td><td>15</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Wing</td><td>25</td><td>30</td><td>20</td><td>10</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
-<tr><td>翼尾/先端</td><td>85</td><td>95</td><td>55</td><td>20</td><td>0</td><td>10</td><td>30</td><td>0</td><td>0</td></tr>
+<tr><td>Wing Tip/Tail Tip</td><td>85</td><td>95</td><td>55</td><td>20</td><td>0</td><td>10</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>45</td><td>25</td><td>30</td><td>0</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>50</td><td>45</td><td>35</td><td>0</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>60</td><td>65</td><td>25</td><td>10</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>

--- a/mons/guren_n.htm
+++ b/mons/guren_n.htm
@@ -68,18 +68,18 @@
 <img id=icon src="../img/monsicons/gurenzeburu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>頭首</td><td>15</td><td>30</td><td>15</td><td>10</td><td>0</td><td>15</td><td>0</td><td>0</td><td>100</td></tr>
+<tr><td>Head/Neck</td><td>15</td><td>30</td><td>15</td><td>10</td><td>0</td><td>15</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Wing</td><td>20</td><td>25</td><td>20</td><td>10</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>翼尾/先端</td><td>75</td><td>85</td><td>50</td><td>20</td><td>0</td><td>10</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>40</td><td>20</td><td>25</td><td>0</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>45</td><td>40</td><td>30</td><td>0</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>55</td><td>60</td><td>20</td><td>10</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>15</td><td>25</td><td>0</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>頭首</td><td>20</td><td>35</td><td>25</td><td>10</td><td>0</td><td>15</td><td>0</td><td>0</td><td>100</td></tr>
+<tr><td>Head/Neck</td><td>20</td><td>35</td><td>25</td><td>10</td><td>0</td><td>15</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Wing</td><td>25</td><td>30</td><td>20</td><td>10</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>翼尾/先端</td><td>85</td><td>95</td><td>55</td><td>20</td><td>0</td><td>10</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>45</td><td>25</td><td>30</td><td>0</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>

--- a/mons/guren_ng.htm
+++ b/mons/guren_ng.htm
@@ -103,18 +103,18 @@
 <img id=icon src="../img/monsicons/gurenzeburu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>頭首</td><td>15</td><td>30</td><td>15</td><td>10</td><td>0</td><td>35</td><td>0</td><td>0</td><td>100</td></tr>
+<tr><td>Head/Neck</td><td>15</td><td>30</td><td>15</td><td>10</td><td>0</td><td>35</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Wing</td><td>20</td><td>25</td><td>20</td><td>10</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>翼尾/先端</td><td>75</td><td>85</td><td>50</td><td>20</td><td>0</td><td>10</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>40</td><td>20</td><td>25</td><td>0</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>45</td><td>40</td><td>30</td><td>0</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>55</td><td>60</td><td>30</td><td>10</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>30</td><td>25</td><td>0</td><td>0</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>頭首</td><td>20</td><td>35</td><td>25</td><td>10</td><td>0</td><td>40</td><td>0</td><td>0</td><td>100</td></tr>
+<tr><td>Head/Neck</td><td>20</td><td>35</td><td>25</td><td>10</td><td>0</td><td>40</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Wing</td><td>25</td><td>30</td><td>20</td><td>10</td><td>0</td><td>10</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>翼尾/先端</td><td>85</td><td>95</td><td>55</td><td>20</td><td>0</td><td>10</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>45</td><td>25</td><td>30</td><td>0</td><td>0</td><td>10</td><td>20</td><td>0</td><td>0</td></tr>

--- a/mons/guren_ng.htm
+++ b/mons/guren_ng.htm
@@ -107,7 +107,7 @@
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head/Neck</td><td>15</td><td>30</td><td>15</td><td>10</td><td>0</td><td>35</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Wing</td><td>20</td><td>25</td><td>20</td><td>10</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
-<tr><td>翼尾/先端</td><td>75</td><td>85</td><td>50</td><td>20</td><td>0</td><td>10</td><td>30</td><td>0</td><td>0</td></tr>
+<tr><td>Wing Tip/Tail Tip</td><td>75</td><td>85</td><td>50</td><td>20</td><td>0</td><td>10</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>40</td><td>20</td><td>25</td><td>0</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>45</td><td>40</td><td>30</td><td>0</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>55</td><td>60</td><td>30</td><td>10</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
@@ -116,7 +116,7 @@
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head/Neck</td><td>20</td><td>35</td><td>25</td><td>10</td><td>0</td><td>40</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Wing</td><td>25</td><td>30</td><td>20</td><td>10</td><td>0</td><td>10</td><td>20</td><td>0</td><td>0</td></tr>
-<tr><td>翼尾/先端</td><td>85</td><td>95</td><td>55</td><td>20</td><td>0</td><td>10</td><td>30</td><td>0</td><td>0</td></tr>
+<tr><td>Wing Tip/Tail Tip</td><td>85</td><td>95</td><td>55</td><td>20</td><td>0</td><td>10</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>45</td><td>25</td><td>30</td><td>0</td><td>0</td><td>10</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>50</td><td>45</td><td>35</td><td>0</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>60</td><td>65</td><td>35</td><td>10</td><td>0</td><td>10</td><td>15</td><td>0</td><td>0</td></tr>

--- a/mons/guren_nh.htm
+++ b/mons/guren_nh.htm
@@ -81,18 +81,18 @@
 <img id=icon src="../img/monsicons/gurenzeburu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>頭首</td><td>10</td><td>25</td><td>15</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
+<tr><td>Head/Neck</td><td>10</td><td>25</td><td>15</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Wing</td><td>15</td><td>20</td><td>10</td><td>5</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>翼尾/先端</td><td>70</td><td>80</td><td>40</td><td>10</td><td>0</td><td>5</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>35</td><td>15</td><td>20</td><td>0</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>40</td><td>35</td><td>25</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>55</td><td>15</td><td>5</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>10</td><td>20</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>頭首</td><td>15</td><td>30</td><td>20</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
+<tr><td>Head/Neck</td><td>15</td><td>30</td><td>20</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Wing</td><td>20</td><td>25</td><td>15</td><td>5</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>翼尾/先端</td><td>80</td><td>90</td><td>45</td><td>10</td><td>0</td><td>5</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>40</td><td>20</td><td>25</td><td>0</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>

--- a/mons/guren_nh.htm
+++ b/mons/guren_nh.htm
@@ -85,7 +85,7 @@
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head/Neck</td><td>10</td><td>25</td><td>15</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Wing</td><td>15</td><td>20</td><td>10</td><td>5</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>翼尾/先端</td><td>70</td><td>80</td><td>40</td><td>10</td><td>0</td><td>5</td><td>20</td><td>0</td><td>0</td></tr>
+<tr><td>Wing Tip/Tail Tip</td><td>70</td><td>80</td><td>40</td><td>10</td><td>0</td><td>5</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>35</td><td>15</td><td>20</td><td>0</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>40</td><td>35</td><td>25</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>55</td><td>15</td><td>5</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
@@ -94,7 +94,7 @@
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head/Neck</td><td>15</td><td>30</td><td>20</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Wing</td><td>20</td><td>25</td><td>15</td><td>5</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>翼尾/先端</td><td>80</td><td>90</td><td>45</td><td>10</td><td>0</td><td>5</td><td>20</td><td>0</td><td>0</td></tr>
+<tr><td>Wing Tip/Tail Tip</td><td>80</td><td>90</td><td>45</td><td>10</td><td>0</td><td>5</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>40</td><td>20</td><td>25</td><td>0</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>45</td><td>40</td><td>30</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>55</td><td>60</td><td>20</td><td>5</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>

--- a/mons/hald_ng.htm
+++ b/mons/hald_ng.htm
@@ -122,24 +122,24 @@
 <img id=icon src="../img/monsicons/harudomerugu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>25</td><td>20</td><td>0</td><td>10</td><td>20</td><td>0</td><td>100</td></tr>
 <tr><td>Belly</td><td>25</td><td>25</td><td>15</td><td>15</td><td>0</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>20</td><td>10</td><td>15</td><td>0</td><td>10</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>25</td><td>20</td><td>20</td><td>0</td><td>10</td><td>25</td><td>0</td><td>0</td></tr>
-<tr><td>左前脚</td><td>35</td><td>35</td><td>25</td><td>25</td><td>0</td><td>5</td><td>30</td><td>0</td><td>0</td></tr>
+<tr><td>Left Foreleg</td><td>35</td><td>35</td><td>25</td><td>25</td><td>0</td><td>5</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>15</td><td>15</td><td>10</td><td>15</td><td>0</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
-<tr><td>右前脚</td><td>35</td><td>35</td><td>25</td><td>25</td><td>0</td><td>5</td><td>30</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(？？？)</th></tr>
+<tr><td>Right Foreleg</td><td>35</td><td>35</td><td>25</td><td>25</td><td>0</td><td>5</td><td>30</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(？？？)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>55</td><td>40</td><td>35</td><td>0</td><td>20</td><td>35</td><td>0</td><td>150</td></tr>
 <tr><td>Belly</td><td>40</td><td>40</td><td>30</td><td>30</td><td>0</td><td>15</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>40</td><td>35</td><td>25</td><td>30</td><td>0</td><td>20</td><td>35</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>40</td><td>35</td><td>35</td><td>0</td><td>20</td><td>40</td><td>0</td><td>0</td></tr>
-<tr><td>左前脚</td><td>50</td><td>50</td><td>40</td><td>40</td><td>0</td><td>15</td><td>45</td><td>0</td><td>0</td></tr>
+<tr><td>Left Foreleg</td><td>50</td><td>50</td><td>40</td><td>40</td><td>0</td><td>15</td><td>45</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>30</td><td>25</td><td>30</td><td>0</td><td>15</td><td>30</td><td>0</td><td>0</td></tr>
-<tr><td>右前脚</td><td>50</td><td>50</td><td>40</td><td>40</td><td>0</td><td>15</td><td>45</td><td>0</td><td>0</td></tr>
+<tr><td>Right Foreleg</td><td>50</td><td>50</td><td>40</td><td>40</td><td>0</td><td>15</td><td>45</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
@@ -148,8 +148,8 @@
 <tr><td>Head</td><td>1000</td><td>？ stagger(s) required</td></tr>
 <tr><td>Hind Leg</td><td>1100</td><td></td></tr>
 <tr><td>Tail</td><td>1200</td><td></td></tr>
-<tr><td>左前脚</td><td>850</td><td>？ stagger(s) required</td></tr>
-<tr><td>右前脚</td><td>850</td><td>？ stagger(s) required</td></tr>
+<tr><td>Left Foreleg</td><td>850</td><td>？ stagger(s) required</td></tr>
+<tr><td>Right Foreleg</td><td>850</td><td>？ stagger(s) required</td></tr>
 <tr><td>Wing</td><td>800</td><td>？ stagger(s) required</td></tr>
 <tr><td>Back</td><td>800</td><td></td></tr>
 <tr><td>Torso</td><td>900</td><td></td></tr>

--- a/mons/hald_nh.htm
+++ b/mons/hald_nh.htm
@@ -75,24 +75,24 @@
 <img id=icon src="../img/monsicons/harudomerugu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>25</td><td>20</td><td>0</td><td>10</td><td>20</td><td>0</td><td>100</td></tr>
 <tr><td>Belly</td><td>25</td><td>25</td><td>15</td><td>15</td><td>0</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>20</td><td>10</td><td>15</td><td>0</td><td>10</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>25</td><td>20</td><td>20</td><td>0</td><td>10</td><td>25</td><td>0</td><td>0</td></tr>
-<tr><td>左前脚</td><td>35</td><td>35</td><td>25</td><td>25</td><td>0</td><td>5</td><td>30</td><td>0</td><td>0</td></tr>
+<tr><td>Left Foreleg</td><td>35</td><td>35</td><td>25</td><td>25</td><td>0</td><td>5</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>15</td><td>15</td><td>10</td><td>15</td><td>0</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
-<tr><td>右前脚</td><td>35</td><td>35</td><td>25</td><td>25</td><td>0</td><td>5</td><td>30</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(？？？)</th></tr>
+<tr><td>Right Foreleg</td><td>35</td><td>35</td><td>25</td><td>25</td><td>0</td><td>5</td><td>30</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(？？？)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>55</td><td>40</td><td>35</td><td>0</td><td>20</td><td>35</td><td>0</td><td>150</td></tr>
 <tr><td>Belly</td><td>40</td><td>40</td><td>30</td><td>30</td><td>0</td><td>15</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>40</td><td>35</td><td>25</td><td>30</td><td>0</td><td>20</td><td>35</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>40</td><td>35</td><td>35</td><td>0</td><td>20</td><td>40</td><td>0</td><td>0</td></tr>
-<tr><td>左前脚</td><td>50</td><td>50</td><td>40</td><td>40</td><td>0</td><td>15</td><td>45</td><td>0</td><td>0</td></tr>
+<tr><td>Left Foreleg</td><td>50</td><td>50</td><td>40</td><td>40</td><td>0</td><td>15</td><td>45</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>30</td><td>25</td><td>30</td><td>0</td><td>15</td><td>30</td><td>0</td><td>0</td></tr>
-<tr><td>右前脚</td><td>50</td><td>50</td><td>40</td><td>40</td><td>0</td><td>15</td><td>45</td><td>0</td><td>0</td></tr>
+<tr><td>Right Foreleg</td><td>50</td><td>50</td><td>40</td><td>40</td><td>0</td><td>15</td><td>45</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
@@ -101,8 +101,8 @@
 <tr><td>Head</td><td>550</td><td>？ stagger(s) required</td></tr>
 <tr><td>Hind Leg</td><td>650</td><td></td></tr>
 <tr><td>Tail</td><td>700</td><td></td></tr>
-<tr><td>左前脚</td><td>500</td><td>？ stagger(s) required</td></tr>
-<tr><td>右前脚</td><td>500</td><td>？ stagger(s) required</td></tr>
+<tr><td>Left Foreleg</td><td>500</td><td>？ stagger(s) required</td></tr>
+<tr><td>Right Foreleg</td><td>500</td><td>？ stagger(s) required</td></tr>
 <tr><td>Wing</td><td>450</td><td>？ stagger(s) required</td></tr>
 <tr><td>Back</td><td>450</td><td></td></tr>
 <tr><td>Torso</td><td>550</td><td></td></tr>

--- a/mons/hald_ni.htm
+++ b/mons/hald_ni.htm
@@ -111,24 +111,24 @@
 <img id=icon src="../img/monsicons/zenith_harudomerugu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>35</td><td>25</td><td>20</td><td>0</td><td>10</td><td>25</td><td>0</td><td>100</td></tr>
 <tr><td>Belly</td><td>20</td><td>25</td><td>15</td><td>15</td><td>0</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>15</td><td>10</td><td>5</td><td>15</td><td>0</td><td>10</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>20</td><td>25</td><td>20</td><td>0</td><td>10</td><td>25</td><td>0</td><td>0</td></tr>
-<tr><td>左前脚</td><td>20</td><td>20</td><td>25</td><td>20</td><td>0</td><td>5</td><td>25</td><td>0</td><td>0</td></tr>
+<tr><td>Left Foreleg</td><td>20</td><td>20</td><td>25</td><td>20</td><td>0</td><td>5</td><td>25</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>15</td><td>15</td><td>10</td><td>15</td><td>0</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
-<tr><td>右前脚</td><td>20</td><td>20</td><td>25</td><td>20</td><td>0</td><td>5</td><td>25</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(？？？)</th></tr>
+<tr><td>Right Foreleg</td><td>20</td><td>20</td><td>25</td><td>20</td><td>0</td><td>5</td><td>25</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(？？？)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>45</td><td>40</td><td>25</td><td>0</td><td>20</td><td>30</td><td>0</td><td>150</td></tr>
 <tr><td>Belly</td><td>30</td><td>35</td><td>25</td><td>20</td><td>0</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>35</td><td>25</td><td>20</td><td>20</td><td>0</td><td>20</td><td>25</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>25</td><td>35</td><td>25</td><td>0</td><td>20</td><td>30</td><td>0</td><td>0</td></tr>
-<tr><td>左前脚</td><td>30</td><td>30</td><td>30</td><td>25</td><td>0</td><td>15</td><td>35</td><td>0</td><td>0</td></tr>
+<tr><td>Left Foreleg</td><td>30</td><td>30</td><td>30</td><td>25</td><td>0</td><td>15</td><td>35</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
-<tr><td>右前脚</td><td>30</td><td>30</td><td>30</td><td>25</td><td>0</td><td>15</td><td>35</td><td>0</td><td>0</td></tr>
+<tr><td>Right Foreleg</td><td>30</td><td>30</td><td>30</td><td>25</td><td>0</td><td>15</td><td>35</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
@@ -137,8 +137,8 @@
 <tr><td>Head</td><td>5000</td><td>？ stagger(s) required</td></tr>
 <tr><td>Hind Leg</td><td>1200</td><td></td></tr>
 <tr><td>Tail</td><td>1200</td><td></td></tr>
-<tr><td>左前脚</td><td>600</td><td>？ stagger(s) required (Only one break required for rewards)</td></tr>
-<tr><td>右前脚</td><td>600</td><td>？ stagger(s) required</td></tr>
+<tr><td>Left Foreleg</td><td>600</td><td>？ stagger(s) required (Only one break required for rewards)</td></tr>
+<tr><td>Right Foreleg</td><td>600</td><td>？ stagger(s) required</td></tr>
 <tr><td>Wing</td><td>700</td><td>？ stagger(s) required</td></tr>
 <tr><td>Back</td><td>1200</td><td></td></tr>
 <tr><td>Torso</td><td>1200</td><td></td></tr>

--- a/mons/hipu_n.htm
+++ b/mons/hipu_n.htm
@@ -80,7 +80,7 @@
 <img id=icon src="../img/monsicons/hypnoc.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>70</td><td>60</td><td>50</td><td>10</td><td>5</td><td>10</td><td>5</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>40</td><td>40</td><td>10</td><td>10</td><td>10</td><td>5</td><td>15</td><td>0</td></tr>
@@ -106,11 +106,11 @@
 <span><em>59</em>750</span>
 </div>
 </td></tr>
-<tr><td>Left Foot</td><td>400</td><td><div>
+<tr><td>Left Leg</td><td>400</td><td><div>
 <span><em>12</em>542</span><span><em>13</em>553</span><span><em>14</em>564</span><span><em>15</em>574</span><span><em>17</em>596</span><span><em>若6</em>350</span><span><em>59</em>1200</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>400</td><td><div>
+<tr><td>Right Leg</td><td>400</td><td><div>
 <span><em>12</em>542</span><span><em>13</em>553</span><span><em>14</em>564</span><span><em>15</em>574</span><span><em>17</em>596</span><span><em>若6</em>350</span><span><em>59</em>1200</span>
 </div>
 </td></tr>

--- a/mons/hipu_ng.htm
+++ b/mons/hipu_ng.htm
@@ -124,7 +124,7 @@
 <img id=icon src="../img/monsicons/hypnoc.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>45</td><td>40</td><td>10</td><td>5</td><td>10</td><td>5</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>30</td><td>35</td><td>10</td><td>10</td><td>10</td><td>5</td><td>15</td><td>0</td></tr>
@@ -141,8 +141,8 @@
 <tr><td>Torso</td><td>400</td><td></td></tr>
 <tr><td>Left Wing</td><td>450</td><td></td></tr>
 <tr><td>Right Wing</td><td>450</td><td></td></tr>
-<tr><td>Left Foot</td><td>600</td><td></td></tr>
-<tr><td>Right Foot</td><td>600</td><td></td></tr>
+<tr><td>Left Leg</td><td>600</td><td></td></tr>
+<tr><td>Right Leg</td><td>600</td><td></td></tr>
 <tr><td>Neck</td><td>350</td><td></td></tr>
 <tr><td>Head</td><td>400</td><td>2nd time breaks beak</td></tr>
 <tr><td>Tail</td><td>350</td><td></td></tr>

--- a/mons/hipu_nh.htm
+++ b/mons/hipu_nh.htm
@@ -78,7 +78,7 @@
 <img id=icon src="../img/monsicons/hypnoc.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>50</td><td>70</td><td>0</td><td>0</td><td>0</td><td>0</td><td>25</td><td>100</td></tr>
 <tr><td>Neck</td><td>25</td><td>55</td><td>30</td><td>25</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
@@ -95,8 +95,8 @@
 <tr><td>Torso</td><td>200</td><td></td></tr>
 <tr><td>Left Wing</td><td>250</td><td></td></tr>
 <tr><td>Right Wing</td><td>250</td><td></td></tr>
-<tr><td>Left Foot</td><td>400</td><td></td></tr>
-<tr><td>Right Foot</td><td>400</td><td></td></tr>
+<tr><td>Left Leg</td><td>400</td><td></td></tr>
+<tr><td>Right Leg</td><td>400</td><td></td></tr>
 <tr><td>Neck</td><td>150</td><td></td></tr>
 <tr><td>Head</td><td>200</td><td>2nd time breaks beak</td></tr>
 <tr><td>Tail</td><td>150</td><td></td></tr>

--- a/mons/hipu_ni.htm
+++ b/mons/hipu_ni.htm
@@ -112,7 +112,7 @@
 <img id=icon src="../img/monsicons/zenith_hypnoc.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>35</td><td>10</td><td>5</td><td>25</td><td>5</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>30</td><td>25</td><td>15</td><td>10</td><td>10</td><td>10</td><td>5</td><td>15</td><td>0</td></tr>
@@ -129,8 +129,8 @@
 <tr><td>Torso</td><td>1000</td><td></td></tr>
 <tr><td>Left Wing</td><td>1100</td><td></td></tr>
 <tr><td>Right Wing</td><td>1100</td><td></td></tr>
-<tr><td>Left Foot</td><td>1400</td><td></td></tr>
-<tr><td>Right Foot</td><td>1400</td><td></td></tr>
+<tr><td>Left Leg</td><td>1400</td><td></td></tr>
+<tr><td>Right Leg</td><td>1400</td><td></td></tr>
 <tr><td>Neck</td><td>900</td><td></td></tr>
 <tr><td>Head</td><td>5000</td><td>2nd time breaks beak</td></tr>
 <tr><td>Tail</td><td>900</td><td></td></tr>

--- a/mons/hipu_nt.htm
+++ b/mons/hipu_nt.htm
@@ -104,7 +104,7 @@
 <img id=icon src="../img/monsicons/hypnoc.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>45</td><td>40</td><td>10</td><td>5</td><td>10</td><td>5</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>30</td><td>35</td><td>10</td><td>10</td><td>10</td><td>5</td><td>15</td><td>0</td></tr>
@@ -121,8 +121,8 @@
 <tr><td>Torso</td><td>200</td><td></td></tr>
 <tr><td>Left Wing</td><td>250</td><td></td></tr>
 <tr><td>Right Wing</td><td>250</td><td></td></tr>
-<tr><td>Left Foot</td><td>400</td><td></td></tr>
-<tr><td>Right Foot</td><td>400</td><td></td></tr>
+<tr><td>Left Leg</td><td>400</td><td></td></tr>
+<tr><td>Right Leg</td><td>400</td><td></td></tr>
 <tr><td>Neck</td><td>150</td><td></td></tr>
 <tr><td>Head</td><td>200</td><td>2nd time breaks beak</td></tr>
 <tr><td>Tail</td><td>150</td><td></td></tr>

--- a/mons/hipuao_n.htm
+++ b/mons/hipuao_n.htm
@@ -73,7 +73,7 @@
 <img id=icon src="../img/monsicons/breedingseasonhypnoc.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>70</td><td>60</td><td>50</td><td>5</td><td>5</td><td>10</td><td>5</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>40</td><td>40</td><td>10</td><td>10</td><td>10</td><td>5</td><td>10</td><td>0</td></tr>
@@ -90,11 +90,11 @@
 <tr><td>Torso</td><td>200</td><td></td></tr>
 <tr><td>Left Wing</td><td>250</td><td></td></tr>
 <tr><td>Right Wing</td><td>250</td><td></td></tr>
-<tr><td>Left Foot</td><td>400</td><td><div>
+<tr><td>Left Leg</td><td>400</td><td><div>
 <span><em>11</em>532</span><span><em>14</em>564</span><span><em>15</em>574</span><span><em>17</em>596</span><span><em>11若</em>465</span><span><em>14若</em>493</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>400</td><td><div>
+<tr><td>Right Leg</td><td>400</td><td><div>
 <span><em>11</em>532</span><span><em>14</em>564</span><span><em>15</em>574</span><span><em>17</em>596</span><span><em>11若</em>465</span><span><em>14若</em>493</span>
 </div>
 </td></tr>

--- a/mons/hipuao_ng.htm
+++ b/mons/hipuao_ng.htm
@@ -104,7 +104,7 @@
 <img id=icon src="../img/monsicons/breedingseasonhypnoc.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>45</td><td>40</td><td>15</td><td>15</td><td>35</td><td>15</td><td>15</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>30</td><td>35</td><td>20</td><td>20</td><td>20</td><td>15</td><td>20</td><td>0</td></tr>
@@ -121,8 +121,8 @@
 <tr><td>Torso</td><td>500</td><td></td></tr>
 <tr><td>Left Wing</td><td>500</td><td></td></tr>
 <tr><td>Right Wing</td><td>500</td><td></td></tr>
-<tr><td>Left Foot</td><td>650</td><td></td></tr>
-<tr><td>Right Foot</td><td>650</td><td></td></tr>
+<tr><td>Left Leg</td><td>650</td><td></td></tr>
+<tr><td>Right Leg</td><td>650</td><td></td></tr>
 <tr><td>Neck</td><td>450</td><td></td></tr>
 <tr><td>Head</td><td>500</td><td>2nd time breaks beak</td></tr>
 <tr><td>Tail</td><td>450</td><td></td></tr>

--- a/mons/hipuao_nh.htm
+++ b/mons/hipuao_nh.htm
@@ -87,7 +87,7 @@
 <img id=icon src="../img/monsicons/breedingseasonhypnoc.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>60</td><td>35</td><td>0</td><td>0</td><td>25</td><td>5</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>45</td><td>55</td><td>15</td><td>15</td><td>-5</td><td>5</td><td>15</td><td>0</td></tr>
@@ -104,8 +104,8 @@
 <tr><td>Torso</td><td>300</td><td></td></tr>
 <tr><td>Left Wing</td><td>300</td><td></td></tr>
 <tr><td>Right Wing</td><td>300</td><td></td></tr>
-<tr><td>Left Foot</td><td>450</td><td></td></tr>
-<tr><td>Right Foot</td><td>450</td><td></td></tr>
+<tr><td>Left Leg</td><td>450</td><td></td></tr>
+<tr><td>Right Leg</td><td>450</td><td></td></tr>
 <tr><td>Neck</td><td>250</td><td></td></tr>
 <tr><td>Head</td><td>300</td><td>2nd time breaks beak</td></tr>
 <tr><td>Tail</td><td>250</td><td></td></tr>

--- a/mons/hipusiro_n.htm
+++ b/mons/hipusiro_n.htm
@@ -61,7 +61,7 @@
 <img id=icon src="../img/monsicons/whitehypnoc.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>50</td><td>30</td><td>5</td><td>0</td><td>0</td><td>0</td><td>15</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>40</td><td>15</td><td>10</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
@@ -78,11 +78,11 @@
 <tr><td>Torso</td><td>200</td><td></td></tr>
 <tr><td>Left Wing</td><td>250</td><td></td></tr>
 <tr><td>Right Wing</td><td>250</td><td></td></tr>
-<tr><td>Left Foot</td><td>450</td><td><div>
+<tr><td>Left Leg</td><td>450</td><td><div>
 <span><em>12</em>610</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>450</td><td><div>
+<tr><td>Right Leg</td><td>450</td><td><div>
 <span><em>12</em>610</span>
 </div>
 </td></tr>

--- a/mons/hipusiro_ng.htm
+++ b/mons/hipusiro_ng.htm
@@ -102,7 +102,7 @@
 <img id=icon src="../img/monsicons/whitehypnoc.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>30</td><td>5</td><td>0</td><td>0</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>30</td><td>15</td><td>10</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
@@ -119,8 +119,8 @@
 <tr><td>Torso</td><td>550</td><td></td></tr>
 <tr><td>Left Wing</td><td>600</td><td></td></tr>
 <tr><td>Right Wing</td><td>600</td><td></td></tr>
-<tr><td>Left Foot</td><td>750</td><td></td></tr>
-<tr><td>Right Foot</td><td>750</td><td></td></tr>
+<tr><td>Left Leg</td><td>750</td><td></td></tr>
+<tr><td>Right Leg</td><td>750</td><td></td></tr>
 <tr><td>Neck</td><td>500</td><td></td></tr>
 <tr><td>Head</td><td>550</td><td>2nd time breaks beak</td></tr>
 <tr><td>Tail</td><td>600</td><td></td></tr>

--- a/mons/hyuji_ng.htm
+++ b/mons/hyuji_ng.htm
@@ -117,22 +117,22 @@
 <img id=icon src="../img/monsicons/hyujikiki.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>55</td><td>40</td><td>40</td><td>15</td><td>25</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Torso</td><td>35</td><td>35</td><td>20</td><td>30</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>20</td><td>25</td><td>20</td><td>15</td><td>5</td><td>25</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>20</td><td>25</td><td>20</td><td>15</td><td>5</td><td>25</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>40</td><td>20</td><td>20</td><td>10</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>尾中間</td><td>40</td><td>30</td><td>25</td><td>25</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Tail Midsection</td><td>40</td><td>30</td><td>25</td><td>25</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>25</td><td>20</td><td>25</td><td>20</td><td>5</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>55</td><td>30</td><td>30</td><td>30</td><td>10</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(防御状態)</th></tr>
+<tr class=l><th colspan=10>Hitzones(防御状態)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>10</td><td>10</td><td>10</td><td>50</td><td>0</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>10</td><td>10</td><td>10</td><td>50</td><td>0</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>10</td><td>10</td><td>10</td><td>50</td><td>0</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>10</td><td>10</td><td>10</td><td>50</td><td>0</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>10</td><td>10</td><td>10</td><td>50</td><td>0</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>尾中間</td><td>10</td><td>10</td><td>10</td><td>50</td><td>0</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Tail Midsection</td><td>10</td><td>10</td><td>10</td><td>50</td><td>0</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>10</td><td>10</td><td>10</td><td>50</td><td>0</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>10</td><td>10</td><td>10</td><td>50</td><td>0</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
@@ -142,10 +142,10 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>500</td><td>２ stagger(s) required</td></tr>
 <tr><td>Torso</td><td>700</td><td>２ stagger(s) required</td></tr>
-<tr><td>右前脚</td><td>600</td><td>２ stagger(s) required</td></tr>
-<tr><td>左前脚</td><td>600</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Foreleg</td><td>600</td><td>２ stagger(s) required</td></tr>
+<tr><td>Left Foreleg</td><td>600</td><td>２ stagger(s) required</td></tr>
 <tr><td>Hind Leg</td><td>600</td><td></td></tr>
-<tr><td>尾</td><td>800</td><td></td></tr>
+<tr><td>Tail</td><td>800</td><td></td></tr>
 <tr><td>Tail Cut</td><td>1600</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/hyujikiki.png" width="400"/>

--- a/mons/hyuji_ni.htm
+++ b/mons/hyuji_ni.htm
@@ -111,22 +111,22 @@
 <img id=icon src="../img/monsicons/zenith_hyujikiki.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>35</td><td>30</td><td>15</td><td>25</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Torso</td><td>25</td><td>35</td><td>20</td><td>20</td><td>5</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>15</td><td>15</td><td>15</td><td>10</td><td>5</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>15</td><td>15</td><td>15</td><td>10</td><td>5</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>25</td><td>15</td><td>15</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>尾中間</td><td>35</td><td>20</td><td>25</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Tail Midsection</td><td>35</td><td>20</td><td>25</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>25</td><td>25</td><td>25</td><td>20</td><td>5</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>45</td><td>20</td><td>30</td><td>25</td><td>10</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(防御状態)</th></tr>
+<tr class=l><th colspan=10>Hitzones(防御状態)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>10</td><td>10</td><td>10</td><td>40</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>10</td><td>10</td><td>10</td><td>40</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>10</td><td>10</td><td>10</td><td>40</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>10</td><td>10</td><td>10</td><td>40</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>10</td><td>10</td><td>10</td><td>40</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>尾中間</td><td>10</td><td>10</td><td>10</td><td>40</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Tail Midsection</td><td>10</td><td>10</td><td>10</td><td>40</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>10</td><td>10</td><td>10</td><td>40</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>10</td><td>10</td><td>10</td><td>40</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
@@ -136,10 +136,10 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>1200</td><td>２ stagger(s) required</td></tr>
 <tr><td>Torso</td><td>5500</td><td>２ stagger(s) required</td></tr>
-<tr><td>右前脚</td><td>800</td><td>２ stagger(s) required</td></tr>
-<tr><td>左前脚</td><td>800</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Foreleg</td><td>800</td><td>２ stagger(s) required</td></tr>
+<tr><td>Left Foreleg</td><td>800</td><td>２ stagger(s) required</td></tr>
 <tr><td>Hind Leg</td><td>900</td><td></td></tr>
-<tr><td>尾</td><td>1300</td><td></td></tr>
+<tr><td>Tail</td><td>1300</td><td></td></tr>
 <tr><td>Tail Cut</td><td>2400</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/zenith_hyujikiki.png" width="400"/>

--- a/mons/ina_ng.htm
+++ b/mons/ina_ng.htm
@@ -102,23 +102,23 @@
 <img id=icon src="../img/monsicons/inagami.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>55</td><td>50</td><td>35</td><td>0</td><td>15</td><td>15</td><td>0</td><td>100</td></tr>
 <tr><td>Torso</td><td>15</td><td>25</td><td>10</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>右前脚</td><td>30</td><td>30</td><td>25</td><td>30</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>左前脚</td><td>30</td><td>30</td><td>25</td><td>30</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>右後脚</td><td>25</td><td>30</td><td>25</td><td>30</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>左後脚</td><td>25</td><td>30</td><td>25</td><td>30</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Right Foreleg</td><td>30</td><td>30</td><td>25</td><td>30</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Left Foreleg</td><td>30</td><td>30</td><td>25</td><td>30</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Right Hind Leg</td><td>25</td><td>30</td><td>25</td><td>30</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Left Hind Leg</td><td>25</td><td>30</td><td>25</td><td>30</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>55</td><td>45</td><td>55</td><td>40</td><td>0</td><td>20</td><td>15</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(泥着)</th></tr>
+<tr class=l><th colspan=10>Hitzones(泥着)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>35</td><td>30</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td><td>200</td></tr>
 <tr><td>Torso</td><td>15</td><td>20</td><td>10</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>右前脚</td><td>20</td><td>20</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左前脚</td><td>20</td><td>20</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>右後脚</td><td>20</td><td>20</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左後脚</td><td>20</td><td>20</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Foreleg</td><td>20</td><td>20</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Foreleg</td><td>20</td><td>20</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Hind Leg</td><td>20</td><td>20</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Hind Leg</td><td>20</td><td>20</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>35</td><td>15</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -127,10 +127,10 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>600</td><td></td></tr>
 <tr><td>Torso</td><td>900</td><td></td></tr>
-<tr><td>右手</td><td>550</td><td></td></tr>
-<tr><td>左手</td><td>550</td><td></td></tr>
-<tr><td>Right Foot</td><td>550</td><td></td></tr>
-<tr><td>Left Foot</td><td>550</td><td></td></tr>
+<tr><td>Right Hand</td><td>550</td><td></td></tr>
+<tr><td>Left Hand</td><td>550</td><td></td></tr>
+<tr><td>Right Leg</td><td>550</td><td></td></tr>
+<tr><td>Left Leg</td><td>550</td><td></td></tr>
 <tr><td>Tail</td><td>600</td><td>２ stagger(s) required</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/inagami.png" width="400"/>

--- a/mons/ina_nh.htm
+++ b/mons/ina_nh.htm
@@ -75,23 +75,23 @@
 <img id=icon src="../img/monsicons/inagami.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>55</td><td>50</td><td>35</td><td>0</td><td>15</td><td>15</td><td>0</td><td>100</td></tr>
 <tr><td>Torso</td><td>15</td><td>25</td><td>10</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>右前脚</td><td>30</td><td>30</td><td>25</td><td>30</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>左前脚</td><td>30</td><td>30</td><td>25</td><td>30</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>右後脚</td><td>25</td><td>30</td><td>25</td><td>30</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>左後脚</td><td>25</td><td>30</td><td>25</td><td>30</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Right Foreleg</td><td>30</td><td>30</td><td>25</td><td>30</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Left Foreleg</td><td>30</td><td>30</td><td>25</td><td>30</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Right Hind Leg</td><td>25</td><td>30</td><td>25</td><td>30</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Left Hind Leg</td><td>25</td><td>30</td><td>25</td><td>30</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>55</td><td>45</td><td>55</td><td>40</td><td>0</td><td>20</td><td>15</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(泥着)</th></tr>
+<tr class=l><th colspan=10>Hitzones(泥着)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>35</td><td>30</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td><td>200</td></tr>
 <tr><td>Torso</td><td>15</td><td>20</td><td>10</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>右前脚</td><td>20</td><td>20</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左前脚</td><td>20</td><td>20</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>右後脚</td><td>20</td><td>20</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>左後脚</td><td>20</td><td>20</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Foreleg</td><td>20</td><td>20</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Foreleg</td><td>20</td><td>20</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Right Hind Leg</td><td>20</td><td>20</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Left Hind Leg</td><td>20</td><td>20</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>35</td><td>15</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -100,10 +100,10 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>250</td><td></td></tr>
 <tr><td>Torso</td><td>550</td><td></td></tr>
-<tr><td>右手</td><td>300</td><td></td></tr>
-<tr><td>左手</td><td>300</td><td></td></tr>
-<tr><td>Right Foot</td><td>300</td><td></td></tr>
-<tr><td>Left Foot</td><td>300</td><td></td></tr>
+<tr><td>Right Hand</td><td>300</td><td></td></tr>
+<tr><td>Left Hand</td><td>300</td><td></td></tr>
+<tr><td>Right Leg</td><td>300</td><td></td></tr>
+<tr><td>Left Leg</td><td>300</td><td></td></tr>
 <tr><td>Tail</td><td>250</td><td>２ stagger(s) required</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/inagami.png" width="400"/>

--- a/mons/ina_ni.htm
+++ b/mons/ina_ni.htm
@@ -111,23 +111,23 @@
 <img id=icon src="../img/monsicons/zenith_inagami.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>45</td><td>35</td><td>30</td><td>0</td><td>15</td><td>15</td><td>0</td><td>100</td></tr>
 <tr><td>Torso</td><td>15</td><td>20</td><td>5</td><td>5</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>右前脚</td><td>20</td><td>25</td><td>20</td><td>15</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>左前脚</td><td>20</td><td>25</td><td>20</td><td>15</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>右後脚</td><td>25</td><td>20</td><td>20</td><td>15</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>左後脚</td><td>25</td><td>20</td><td>20</td><td>15</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Right Foreleg</td><td>20</td><td>25</td><td>20</td><td>15</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Left Foreleg</td><td>20</td><td>25</td><td>20</td><td>15</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Right Hind Leg</td><td>25</td><td>20</td><td>20</td><td>15</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Left Hind Leg</td><td>25</td><td>20</td><td>20</td><td>15</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>30</td><td>30</td><td>35</td><td>0</td><td>20</td><td>15</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(泥着)</th></tr>
+<tr class=l><th colspan=10>Hitzones(泥着)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>25</td><td>20</td><td>20</td><td>0</td><td>10</td><td>10</td><td>0</td><td>100</td></tr>
 <tr><td>Torso</td><td>15</td><td>20</td><td>5</td><td>5</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>右前脚</td><td>15</td><td>15</td><td>15</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>左前脚</td><td>15</td><td>15</td><td>15</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>右後脚</td><td>15</td><td>15</td><td>15</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>左後脚</td><td>15</td><td>15</td><td>15</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Right Foreleg</td><td>15</td><td>15</td><td>15</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Left Foreleg</td><td>15</td><td>15</td><td>15</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Right Hind Leg</td><td>15</td><td>15</td><td>15</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Left Hind Leg</td><td>15</td><td>15</td><td>15</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>20</td><td>15</td><td>15</td><td>25</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -136,10 +136,10 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>1000</td><td></td></tr>
 <tr><td>Torso</td><td>1500</td><td></td></tr>
-<tr><td>右手</td><td>650</td><td></td></tr>
-<tr><td>左手</td><td>650</td><td></td></tr>
-<tr><td>Right Foot</td><td>600</td><td></td></tr>
-<tr><td>Left Foot</td><td>600</td><td></td></tr>
+<tr><td>Right Hand</td><td>650</td><td></td></tr>
+<tr><td>Left Hand</td><td>650</td><td></td></tr>
+<tr><td>Right Leg</td><td>600</td><td></td></tr>
+<tr><td>Left Leg</td><td>600</td><td></td></tr>
 <tr><td>Tail</td><td>5000</td><td>２ stagger(s) required</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/zenith_inagami.png" width="400"/>

--- a/mons/ios_n.htm
+++ b/mons/ios_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/ioprey.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>90</td><td>90</td><td>90</td><td>20</td><td>30</td><td>50</td><td>0</td><td>20</td><td>100</td></tr>
 </table>

--- a/mons/iwa_n.htm
+++ b/mons/iwa_n.htm
@@ -78,7 +78,7 @@
 <img id=icon src="../img/monsicons/rock.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>1</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>5</td><td>100</td><td>0</td></tr>
 </table>

--- a/mons/joeK_ng.htm
+++ b/mons/joeK_ng.htm
@@ -99,21 +99,21 @@
 <img id=icon src="../img/monsicons/musou_deviljho.webp" width="450"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>頭部</td><td>20</td><td>22</td><td>18</td><td>20</td><td>20</td><td>30</td><td>20</td><td>20</td><td>100</td></tr>
-<tr><td>胸</td><td>41</td><td>41</td><td>39</td><td>15</td><td>15</td><td>25</td><td>15</td><td>15</td><td>0</td></tr>
+<tr><td>Head</td><td>20</td><td>22</td><td>18</td><td>20</td><td>20</td><td>30</td><td>20</td><td>20</td><td>100</td></tr>
+<tr><td>Chest</td><td>41</td><td>41</td><td>39</td><td>15</td><td>15</td><td>25</td><td>15</td><td>15</td><td>0</td></tr>
 <tr><td>Torso</td><td>15</td><td>15</td><td>15</td><td>20</td><td>20</td><td>30</td><td>20</td><td>20</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>18</td><td>18</td><td>21</td><td>15</td><td>15</td><td>25</td><td>15</td><td>15</td><td>0</td></tr>
-<tr><td>Hind Leg</td><td>20</td><td>20</td><td>14</td><td>20</td><td>20</td><td>30</td><td>20</td><td>20</td><td>0</td></tr>
+<tr><td>Hand</td><td>18</td><td>18</td><td>21</td><td>15</td><td>15</td><td>25</td><td>15</td><td>15</td><td>0</td></tr>
+<tr><td>Leg</td><td>20</td><td>20</td><td>14</td><td>20</td><td>20</td><td>30</td><td>20</td><td>20</td><td>0</td></tr>
 <tr><td>Tail</td><td>18</td><td>15</td><td>18</td><td>20</td><td>20</td><td>35</td><td>20</td><td>20</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>頭部</td><td>41</td><td>46</td><td>39</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>120</td></tr>
-<tr><td>胸</td><td>34</td><td>32</td><td>32</td><td>15</td><td>15</td><td>25</td><td>15</td><td>15</td><td>0</td></tr>
+<tr><td>Head</td><td>41</td><td>46</td><td>39</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>120</td></tr>
+<tr><td>Chest</td><td>34</td><td>32</td><td>32</td><td>15</td><td>15</td><td>25</td><td>15</td><td>15</td><td>0</td></tr>
 <tr><td>Torso</td><td>14</td><td>14</td><td>11</td><td>20</td><td>20</td><td>30</td><td>20</td><td>20</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>18</td><td>18</td><td>21</td><td>15</td><td>15</td><td>25</td><td>15</td><td>15</td><td>0</td></tr>
-<tr><td>Hind Leg</td><td>19</td><td>19</td><td>14</td><td>20</td><td>20</td><td>30</td><td>20</td><td>20</td><td>0</td></tr>
+<tr><td>Hand</td><td>18</td><td>18</td><td>21</td><td>15</td><td>15</td><td>25</td><td>15</td><td>15</td><td>0</td></tr>
+<tr><td>Leg</td><td>19</td><td>19</td><td>14</td><td>20</td><td>20</td><td>30</td><td>20</td><td>20</td><td>0</td></tr>
 <tr><td>Tail</td><td>17</td><td>15</td><td>18</td><td>20</td><td>20</td><td>35</td><td>20</td><td>20</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -123,9 +123,9 @@
 <tr><td>Head</td><td>1200</td><td>１ stagger(s) required<br>２ stagger(s) required</td></tr>
 <tr><td>Back</td><td>1100</td><td></td></tr>
 <tr><td>Neck</td><td>900</td><td></td></tr>
-<tr><td>Fore Leg</td><td>750</td><td></td></tr>
-<tr><td>左後足</td><td>1020</td><td></td></tr>
-<tr><td>右後足</td><td>1020</td><td></td></tr>
+<tr><td>Hand</td><td>750</td><td></td></tr>
+<tr><td>Left Leg</td><td>1020</td><td></td></tr>
+<tr><td>Right Leg</td><td>1020</td><td></td></tr>
 <tr><td>Belly</td><td>850</td><td></td></tr>
 <tr><td>Tail</td><td>1700</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>

--- a/mons/joe_ng.htm
+++ b/mons/joe_ng.htm
@@ -117,21 +117,21 @@
 <img id=icon src="../img/monsicons/deviljho.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>頭部</td><td>39</td><td>39</td><td>36</td><td>10</td><td>10</td><td>15</td><td>15</td><td>5</td><td>100</td></tr>
-<tr><td>胸</td><td>26</td><td>26</td><td>25</td><td>15</td><td>15</td><td>20</td><td>20</td><td>10</td><td>0</td></tr>
+<tr><td>Head</td><td>39</td><td>39</td><td>36</td><td>10</td><td>10</td><td>15</td><td>15</td><td>5</td><td>100</td></tr>
+<tr><td>Chest</td><td>26</td><td>26</td><td>25</td><td>15</td><td>15</td><td>20</td><td>20</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>18</td><td>18</td><td>18</td><td>5</td><td>5</td><td>20</td><td>20</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>21</td><td>21</td><td>21</td><td>10</td><td>10</td><td>15</td><td>15</td><td>5</td><td>0</td></tr>
-<tr><td>Hind Leg</td><td>30</td><td>27</td><td>25</td><td>5</td><td>5</td><td>10</td><td>10</td><td>5</td><td>0</td></tr>
+<tr><td>Hand</td><td>21</td><td>21</td><td>21</td><td>10</td><td>10</td><td>15</td><td>15</td><td>5</td><td>0</td></tr>
+<tr><td>Leg</td><td>30</td><td>27</td><td>25</td><td>5</td><td>5</td><td>10</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>22</td><td>21</td><td>5</td><td>5</td><td>20</td><td>20</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>頭部</td><td>21</td><td>24</td><td>21</td><td>15</td><td>15</td><td>20</td><td>20</td><td>10</td><td>120</td></tr>
-<tr><td>胸</td><td>46</td><td>46</td><td>36</td><td>10</td><td>10</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
+<tr><td>Head</td><td>21</td><td>24</td><td>21</td><td>15</td><td>15</td><td>20</td><td>20</td><td>10</td><td>120</td></tr>
+<tr><td>Chest</td><td>46</td><td>46</td><td>36</td><td>10</td><td>10</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
 <tr><td>Torso</td><td>15</td><td>15</td><td>14</td><td>5</td><td>5</td><td>25</td><td>25</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>19</td><td>19</td><td>21</td><td>15</td><td>15</td><td>20</td><td>20</td><td>10</td><td>0</td></tr>
-<tr><td>Hind Leg</td><td>25</td><td>22</td><td>18</td><td>10</td><td>10</td><td>15</td><td>15</td><td>5</td><td>0</td></tr>
+<tr><td>Hand</td><td>19</td><td>19</td><td>21</td><td>15</td><td>15</td><td>20</td><td>20</td><td>10</td><td>0</td></tr>
+<tr><td>Leg</td><td>25</td><td>22</td><td>18</td><td>10</td><td>10</td><td>15</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>27</td><td>25</td><td>21</td><td>5</td><td>5</td><td>20</td><td>20</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -141,9 +141,9 @@
 <tr><td>Head</td><td>1200</td><td>１ stagger(s) required<br>２ stagger(s) required</td></tr>
 <tr><td>Back</td><td>1100</td><td></td></tr>
 <tr><td>Neck</td><td>900</td><td></td></tr>
-<tr><td>Fore Leg</td><td>750</td><td></td></tr>
-<tr><td>左後足</td><td>1020</td><td></td></tr>
-<tr><td>右後足</td><td>1020</td><td></td></tr>
+<tr><td>Hand</td><td>750</td><td></td></tr>
+<tr><td>Left Leg</td><td>1020</td><td></td></tr>
+<tr><td>Right Leg</td><td>1020</td><td></td></tr>
 <tr><td>Belly</td><td>850</td><td></td></tr>
 <tr><td>Tail</td><td>1700</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>

--- a/mons/joe_nh.htm
+++ b/mons/joe_nh.htm
@@ -76,21 +76,21 @@
 <img id=icon src="../img/monsicons/deviljho.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>頭部</td><td>52</td><td>52</td><td>48</td><td>10</td><td>10</td><td>15</td><td>15</td><td>5</td><td>100</td></tr>
-<tr><td>胸</td><td>37</td><td>37</td><td>35</td><td>15</td><td>15</td><td>20</td><td>20</td><td>10</td><td>0</td></tr>
+<tr><td>Head</td><td>52</td><td>52</td><td>48</td><td>10</td><td>10</td><td>15</td><td>15</td><td>5</td><td>100</td></tr>
+<tr><td>Chest</td><td>37</td><td>37</td><td>35</td><td>15</td><td>15</td><td>20</td><td>20</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>25</td><td>25</td><td>25</td><td>5</td><td>5</td><td>20</td><td>20</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>30</td><td>30</td><td>10</td><td>10</td><td>15</td><td>15</td><td>5</td><td>0</td></tr>
-<tr><td>Hind Leg</td><td>43</td><td>38</td><td>35</td><td>5</td><td>5</td><td>10</td><td>10</td><td>5</td><td>0</td></tr>
+<tr><td>Hand</td><td>30</td><td>30</td><td>30</td><td>10</td><td>10</td><td>15</td><td>15</td><td>5</td><td>0</td></tr>
+<tr><td>Leg</td><td>43</td><td>38</td><td>35</td><td>5</td><td>5</td><td>10</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>32</td><td>30</td><td>5</td><td>5</td><td>20</td><td>20</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>頭部</td><td>30</td><td>34</td><td>30</td><td>15</td><td>15</td><td>20</td><td>20</td><td>10</td><td>120</td></tr>
-<tr><td>胸</td><td>61</td><td>61</td><td>48</td><td>10</td><td>10</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
+<tr><td>Head</td><td>30</td><td>34</td><td>30</td><td>15</td><td>15</td><td>20</td><td>20</td><td>10</td><td>120</td></tr>
+<tr><td>Chest</td><td>61</td><td>61</td><td>48</td><td>10</td><td>10</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
 <tr><td>Torso</td><td>22</td><td>22</td><td>20</td><td>5</td><td>5</td><td>25</td><td>25</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>27</td><td>27</td><td>30</td><td>15</td><td>15</td><td>20</td><td>20</td><td>10</td><td>0</td></tr>
-<tr><td>Hind Leg</td><td>35</td><td>32</td><td>25</td><td>10</td><td>10</td><td>15</td><td>15</td><td>5</td><td>0</td></tr>
+<tr><td>Hand</td><td>27</td><td>27</td><td>30</td><td>15</td><td>15</td><td>20</td><td>20</td><td>10</td><td>0</td></tr>
+<tr><td>Leg</td><td>35</td><td>32</td><td>25</td><td>10</td><td>10</td><td>15</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>38</td><td>35</td><td>30</td><td>5</td><td>5</td><td>20</td><td>20</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -100,9 +100,9 @@
 <tr><td>Head</td><td>875</td><td>１ stagger(s) required<br>２ stagger(s) required</td></tr>
 <tr><td>Back</td><td>700</td><td></td></tr>
 <tr><td>Neck</td><td>500</td><td></td></tr>
-<tr><td>Fore Leg</td><td>375</td><td></td></tr>
-<tr><td>左後足</td><td>550</td><td></td></tr>
-<tr><td>右後足</td><td>550</td><td></td></tr>
+<tr><td>Hand</td><td>375</td><td></td></tr>
+<tr><td>Left Leg</td><td>550</td><td></td></tr>
+<tr><td>Right Leg</td><td>550</td><td></td></tr>
 <tr><td>Belly</td><td>450</td><td></td></tr>
 <tr><td>Tail</td><td>900</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>

--- a/mons/kanta_n.htm
+++ b/mons/kanta_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/hornetaur.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>100</td><td>120</td><td>100</td><td>100</td><td>20</td><td>60</td><td>0</td><td>100</td><td>0</td></tr>
 </table>

--- a/mons/keoa_ng.htm
+++ b/mons/keoa_ng.htm
@@ -97,7 +97,7 @@
 <img id=icon src="../img/monsicons/keoaruboru.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>30</td><td>45</td><td>35</td><td>0</td><td>20</td><td>0</td><td>30</td><td>20</td><td>100</td></tr>
 <tr><td>？？</td><td>15</td><td>20</td><td>30</td><td>0</td><td>10</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
@@ -106,7 +106,7 @@
 <tr><td>？？</td><td>35</td><td>35</td><td>25</td><td>0</td><td>15</td><td>0</td><td>10</td><td>20</td><td>0</td></tr>
 <tr><td>？？</td><td>40</td><td>15</td><td>20</td><td>0</td><td>15</td><td>0</td><td>10</td><td>20</td><td>0</td></tr>
 <tr><td>？？</td><td>35</td><td>35</td><td>35</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質()</th></tr>
+<tr class=l><th colspan=10>Hitzones()</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>65</td><td>60</td><td>50</td><td>25</td><td>0</td><td>15</td><td>30</td><td>5</td><td>100</td></tr>
 <tr><td>？？</td><td>25</td><td>25</td><td>25</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>

--- a/mons/kerubi_n.htm
+++ b/mons/kerubi_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/kelbi.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>140</td><td>140</td><td>150</td><td>100</td><td>100</td><td>100</td><td>10</td><td>100</td><td>100</td></tr>
 </table>

--- a/mons/kirin_n.htm
+++ b/mons/kirin_n.htm
@@ -68,11 +68,11 @@
 <img id=icon src="../img/monsicons/kirin.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>40</td><td>60</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
 <tr><td>Torso</td><td>20</td><td>25</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>角</td><td>90</td><td>100</td><td>80</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Horn</td><td>90</td><td>100</td><td>80</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>

--- a/mons/kirin_ng.htm
+++ b/mons/kirin_ng.htm
@@ -123,11 +123,11 @@
 <img id=icon src="../img/monsicons/kirin.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>35</td><td>30</td><td>5</td><td>5</td><td>0</td><td>5</td><td>5</td><td>100</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>15</td><td>10</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
-<tr><td>角</td><td>60</td><td>50</td><td>50</td><td>20</td><td>20</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
+<tr><td>Horn</td><td>60</td><td>50</td><td>50</td><td>20</td><td>20</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>

--- a/mons/kirin_nh.htm
+++ b/mons/kirin_nh.htm
@@ -81,11 +81,11 @@
 <img id=icon src="../img/monsicons/kirin.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>30</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>150</td></tr>
 <tr><td>Torso</td><td>20</td><td>25</td><td>10</td><td>-15</td><td>-15</td><td>-15</td><td>-15</td><td>-15</td><td>0</td></tr>
-<tr><td>角</td><td>70</td><td>60</td><td>50</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>0</td></tr>
+<tr><td>Horn</td><td>70</td><td>60</td><td>50</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>

--- a/mons/koko_n.htm
+++ b/mons/koko_n.htm
@@ -81,7 +81,7 @@
 <!--<img id=icon src="../img/monsicons/koko.webp" width="400"/> -->
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>80</td><td>80</td><td>80</td><td>20</td><td>5</td><td>10</td><td>0</td><td>30</td><td>100</td></tr>
 </table>

--- a/mons/konga_n.htm
+++ b/mons/konga_n.htm
@@ -81,10 +81,10 @@
 <img id=icon src="../img/monsicons/conga.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>60</td><td>70</td><td>60</td><td>25</td><td>10</td><td>10</td><td>0</td><td>15</td><td>50</td></tr>
-<tr><td>Fore Leg</td><td>45</td><td>40</td><td>45</td><td>25</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>45</td><td>40</td><td>45</td><td>25</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>45</td><td>40</td><td>45</td><td>25</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Torso</td><td>40</td><td>40</td><td>50</td><td>25</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>40</td><td>35</td><td>25</td><td>10</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
@@ -94,8 +94,8 @@
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>20</td><td></td></tr>
-<tr><td>Right Foot</td><td>25</td><td></td></tr>
-<tr><td>Left Foot</td><td>20</td><td></td></tr>
+<tr><td>Right Leg</td><td>25</td><td></td></tr>
+<tr><td>Left Leg</td><td>20</td><td></td></tr>
 <tr><td>Torso</td><td>25</td><td></td></tr>
 <tr><td>Tail</td><td>15</td><td></td></tr>
 </table>

--- a/mons/kukku_n.htm
+++ b/mons/kukku_n.htm
@@ -72,7 +72,7 @@
 <img id=icon src="../img/monsicons/yiankut-ku.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>80</td><td>100</td><td>10</td><td>30</td><td>30</td><td>0</td><td>40</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>60</td><td>50</td><td>10</td><td>80</td><td>50</td><td>20</td><td>50</td><td>0</td></tr>
@@ -89,11 +89,11 @@
 <tr><td>Torso</td><td>130</td><td></td></tr>
 <tr><td>Left Wing</td><td>100</td><td></td></tr>
 <tr><td>Right Wing</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>100</td><td><div>
+<tr><td>Left Leg</td><td>100</td><td><div>
 <span><em>11</em>133</span><span><em>12</em>135</span><span><em>13</em>138</span><span><em>14</em>141</span><span><em>15</em>143</span><span><em>17</em>149</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>100</td><td><div>
+<tr><td>Right Leg</td><td>100</td><td><div>
 <span><em>11</em>133</span><span><em>12</em>135</span><span><em>13</em>138</span><span><em>14</em>141</span><span><em>15</em>143</span><span><em>17</em>149</span>
 </div>
 </td></tr>

--- a/mons/kukku_ng.htm
+++ b/mons/kukku_ng.htm
@@ -124,7 +124,7 @@
 <img id=icon src="../img/monsicons/yiankut-ku.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>60</td><td>80</td><td>5</td><td>20</td><td>20</td><td>0</td><td>30</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>50</td><td>40</td><td>5</td><td>70</td><td>40</td><td>10</td><td>40</td><td>0</td></tr>
@@ -141,8 +141,8 @@
 <tr><td>Torso</td><td>330</td><td></td></tr>
 <tr><td>Left Wing</td><td>300</td><td></td></tr>
 <tr><td>Right Wing</td><td>300</td><td></td></tr>
-<tr><td>Left Foot</td><td>300</td><td></td></tr>
-<tr><td>Right Foot</td><td>300</td><td></td></tr>
+<tr><td>Left Leg</td><td>300</td><td></td></tr>
+<tr><td>Right Leg</td><td>300</td><td></td></tr>
 <tr><td>Neck</td><td>300</td><td></td></tr>
 <tr><td>Head</td><td>280</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>280</td><td></td></tr>

--- a/mons/kukku_nh.htm
+++ b/mons/kukku_nh.htm
@@ -83,7 +83,7 @@
 <img id=icon src="../img/monsicons/yiankut-ku.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>55</td><td>60</td><td>10</td><td>-5</td><td>5</td><td>0</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>45</td><td>30</td><td>30</td><td>10</td><td>50</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
@@ -100,8 +100,8 @@
 <tr><td>Torso</td><td>130</td><td></td></tr>
 <tr><td>Left Wing</td><td>100</td><td></td></tr>
 <tr><td>Right Wing</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>100</td><td></td></tr>
-<tr><td>Right Foot</td><td>100</td><td></td></tr>
+<tr><td>Left Leg</td><td>100</td><td></td></tr>
+<tr><td>Right Leg</td><td>100</td><td></td></tr>
 <tr><td>Neck</td><td>100</td><td></td></tr>
 <tr><td>Head</td><td>80</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>80</td><td></td></tr>

--- a/mons/kukkuao_n.htm
+++ b/mons/kukkuao_n.htm
@@ -71,7 +71,7 @@
 <img id=icon src="../img/monsicons/blueyiankut-ku.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>70</td><td>90</td><td>5</td><td>5</td><td>25</td><td>0</td><td>45</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>50</td><td>50</td><td>5</td><td>10</td><td>40</td><td>20</td><td>55</td><td>0</td></tr>
@@ -88,11 +88,11 @@
 <tr><td>Torso</td><td>130</td><td></td></tr>
 <tr><td>Left Wing</td><td>100</td><td></td></tr>
 <tr><td>Right Wing</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>100</td><td><div>
+<tr><td>Left Leg</td><td>100</td><td><div>
 <span><em>11</em>133</span><span><em>12</em>135</span><span><em>13</em>138</span><span><em>14</em>141</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>100</td><td><div>
+<tr><td>Right Leg</td><td>100</td><td><div>
 <span><em>11</em>133</span><span><em>12</em>135</span><span><em>13</em>138</span><span><em>14</em>141</span>
 </div>
 </td></tr>

--- a/mons/kukkuao_ng.htm
+++ b/mons/kukkuao_ng.htm
@@ -124,7 +124,7 @@
 <img id=icon src="../img/monsicons/blueyiankut-ku.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>50</td><td>60</td><td>5</td><td>5</td><td>25</td><td>0</td><td>45</td><td>100</td></tr>
 <tr><td>Neck</td><td>30</td><td>35</td><td>35</td><td>5</td><td>10</td><td>40</td><td>20</td><td>55</td><td>0</td></tr>
@@ -141,8 +141,8 @@
 <tr><td>Torso</td><td>450</td><td></td></tr>
 <tr><td>Left Wing</td><td>420</td><td></td></tr>
 <tr><td>Right Wing</td><td>420</td><td></td></tr>
-<tr><td>Left Foot</td><td>420</td><td></td></tr>
-<tr><td>Right Foot</td><td>420</td><td></td></tr>
+<tr><td>Left Leg</td><td>420</td><td></td></tr>
+<tr><td>Right Leg</td><td>420</td><td></td></tr>
 <tr><td>Neck</td><td>420</td><td></td></tr>
 <tr><td>Head</td><td>350</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>400</td><td></td></tr>

--- a/mons/kukkuao_nh.htm
+++ b/mons/kukkuao_nh.htm
@@ -93,7 +93,7 @@
 <img id=icon src="../img/monsicons/blueyiankut-ku.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>60</td><td>60</td><td>5</td><td>5</td><td>15</td><td>0</td><td>40</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>45</td><td>50</td><td>5</td><td>10</td><td>30</td><td>20</td><td>45</td><td>0</td></tr>
@@ -110,8 +110,8 @@
 <tr><td>Torso</td><td>320</td><td></td></tr>
 <tr><td>Left Wing</td><td>280</td><td></td></tr>
 <tr><td>Right Wing</td><td>280</td><td></td></tr>
-<tr><td>Left Foot</td><td>280</td><td></td></tr>
-<tr><td>Right Foot</td><td>280</td><td></td></tr>
+<tr><td>Left Leg</td><td>280</td><td></td></tr>
+<tr><td>Right Leg</td><td>280</td><td></td></tr>
 <tr><td>Neck</td><td>280</td><td></td></tr>
 <tr><td>Head</td><td>240</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>240</td><td></td></tr>

--- a/mons/kusha_n.htm
+++ b/mons/kusha_n.htm
@@ -75,22 +75,22 @@
 <img id=icon src="../img/monsicons/kushaladaora.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>60</td><td>30</td><td>10</td><td>5</td><td>20</td><td>35</td><td>0</td><td>100</td></tr>
 <tr><td>Belly</td><td>35</td><td>50</td><td>25</td><td>10</td><td>5</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>25</td><td>30</td><td>10</td><td>5</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>40</td><td>10</td><td>5</td><td>30</td><td>35</td><td>0</td><td>10</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>25</td><td>20</td><td>10</td><td>5</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>25</td><td>20</td><td>10</td><td>5</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>35</td><td>25</td><td>10</td><td>5</td><td>15</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>15</td><td>20</td><td>10</td><td>5</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(風纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(風纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>55</td><td>30</td><td>10</td><td>5</td><td>25</td><td>45</td><td>0</td><td>100</td></tr>
 <tr><td>Belly</td><td>25</td><td>40</td><td>25</td><td>5</td><td>0</td><td>20</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>25</td><td>20</td><td>5</td><td>0</td><td>20</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>40</td><td>5</td><td>0</td><td>30</td><td>40</td><td>0</td><td>10</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>25</td><td>20</td><td>5</td><td>0</td><td>20</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>25</td><td>20</td><td>5</td><td>0</td><td>20</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>35</td><td>25</td><td>5</td><td>0</td><td>20</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>15</td><td>20</td><td>5</td><td>0</td><td>20</td><td>10</td><td>0</td><td>0</td></tr>
 </table>
@@ -101,11 +101,11 @@
 <tr><td>Head</td><td>150</td><td>２ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying</td></tr>
 <tr><td>Torso</td><td>100</td><td></td></tr>
 <tr><td>Tail</td><td>180</td><td></td></tr>
-<tr><td>Left Foot</td><td>180</td><td><div>
+<tr><td>Left Leg</td><td>180</td><td><div>
 <span><em>13</em>248</span><span><em>14</em>253</span><span><em>15</em>258</span><span><em>16</em>263</span><span><em>17</em>268</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>180</td><td><div>
+<tr><td>Right Leg</td><td>180</td><td><div>
 <span><em>13</em>248</span><span><em>14</em>253</span><span><em>15</em>258</span><span><em>16</em>263</span><span><em>17</em>268</span>
 </div>
 </td></tr>

--- a/mons/kusha_ng.htm
+++ b/mons/kusha_ng.htm
@@ -104,22 +104,22 @@
 <img id=icon src="../img/monsicons/kushaladaora.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>40</td><td>35</td><td>0</td><td>0</td><td>20</td><td>25</td><td>0</td><td>100</td></tr>
 <tr><td>Belly</td><td>30</td><td>25</td><td>15</td><td>10</td><td>5</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>15</td><td>15</td><td>25</td><td>10</td><td>5</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>40</td><td>0</td><td>0</td><td>20</td><td>30</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>25</td><td>20</td><td>10</td><td>5</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>25</td><td>20</td><td>10</td><td>5</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>25</td><td>25</td><td>10</td><td>5</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>15</td><td>28</td><td>15</td><td>0</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(風纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(風纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>35</td><td>35</td><td>0</td><td>0</td><td>25</td><td>30</td><td>0</td><td>100</td></tr>
 <tr><td>Belly</td><td>25</td><td>25</td><td>15</td><td>5</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>15</td><td>15</td><td>20</td><td>5</td><td>0</td><td>20</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>30</td><td>35</td><td>0</td><td>0</td><td>25</td><td>35</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>20</td><td>19</td><td>10</td><td>5</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>20</td><td>19</td><td>10</td><td>5</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>21</td><td>15</td><td>5</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>15</td><td>25</td><td>25</td><td>0</td><td>0</td><td>20</td><td>10</td><td>0</td><td>0</td></tr>
 </table>
@@ -130,8 +130,8 @@
 <tr><td>Head</td><td>700</td><td>２ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying</td></tr>
 <tr><td>Torso</td><td>1400</td><td></td></tr>
 <tr><td>Tail</td><td>900</td><td></td></tr>
-<tr><td>Left Foot</td><td>1000</td><td></td></tr>
-<tr><td>Right Foot</td><td>1000</td><td></td></tr>
+<tr><td>Left Leg</td><td>1000</td><td></td></tr>
+<tr><td>Right Leg</td><td>1000</td><td></td></tr>
 <tr><td>Wing</td><td>600</td><td>２ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying</td></tr>
 <tr><td>-</td><td>700</td><td></td></tr>
 <tr><td>-</td><td>600</td><td></td></tr>

--- a/mons/kusha_nh.htm
+++ b/mons/kusha_nh.htm
@@ -82,22 +82,22 @@
 <img id=icon src="../img/monsicons/kushaladaora.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>55</td><td>25</td><td>0</td><td>0</td><td>20</td><td>35</td><td>0</td><td>100</td></tr>
 <tr><td>Belly</td><td>30</td><td>45</td><td>20</td><td>10</td><td>5</td><td>-10</td><td>-15</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>25</td><td>25</td><td>10</td><td>5</td><td>-10</td><td>-15</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>25</td><td>35</td><td>0</td><td>0</td><td>30</td><td>35</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>20</td><td>20</td><td>10</td><td>5</td><td>-10</td><td>-15</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>20</td><td>20</td><td>10</td><td>5</td><td>-10</td><td>-15</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>30</td><td>25</td><td>10</td><td>5</td><td>-10</td><td>-15</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>15</td><td>20</td><td>0</td><td>0</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(風纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(風纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>20</td><td>0</td><td>0</td><td>20</td><td>25</td><td>0</td><td>100</td></tr>
 <tr><td>Belly</td><td>25</td><td>25</td><td>15</td><td>5</td><td>0</td><td>-15</td><td>-20</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>10</td><td>15</td><td>20</td><td>5</td><td>0</td><td>-15</td><td>-20</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>20</td><td>30</td><td>0</td><td>0</td><td>30</td><td>25</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>20</td><td>15</td><td>10</td><td>5</td><td>0</td><td>-15</td><td>-20</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>20</td><td>15</td><td>10</td><td>5</td><td>0</td><td>-15</td><td>-20</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>25</td><td>15</td><td>5</td><td>0</td><td>-15</td><td>-20</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>15</td><td>10</td><td>15</td><td>0</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
 </table>
@@ -108,8 +108,8 @@
 <tr><td>Head</td><td>400</td><td>２ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying</td></tr>
 <tr><td>Torso</td><td>700</td><td></td></tr>
 <tr><td>Tail</td><td>180</td><td></td></tr>
-<tr><td>Left Foot</td><td>230</td><td></td></tr>
-<tr><td>Right Foot</td><td>230</td><td></td></tr>
+<tr><td>Left Leg</td><td>230</td><td></td></tr>
+<tr><td>Right Leg</td><td>230</td><td></td></tr>
 <tr><td>Wing</td><td>270</td><td>２ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying</td></tr>
 <tr><td>-</td><td>250</td><td></td></tr>
 <tr><td>-</td><td>190</td><td></td></tr>

--- a/mons/kushasabi_n.htm
+++ b/mons/kushasabi_n.htm
@@ -67,22 +67,22 @@
 <img id=icon src="../img/monsicons/rustedkushaladaora.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>60</td><td>30</td><td>10</td><td>5</td><td>20</td><td>35</td><td>0</td><td>100</td></tr>
 <tr><td>Belly</td><td>35</td><td>50</td><td>25</td><td>10</td><td>5</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>25</td><td>30</td><td>10</td><td>5</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>40</td><td>10</td><td>5</td><td>30</td><td>35</td><td>0</td><td>10</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>25</td><td>20</td><td>10</td><td>5</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>25</td><td>20</td><td>10</td><td>5</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>35</td><td>25</td><td>10</td><td>5</td><td>15</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>15</td><td>20</td><td>10</td><td>5</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(風纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(風纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>55</td><td>30</td><td>10</td><td>5</td><td>25</td><td>45</td><td>0</td><td>100</td></tr>
 <tr><td>Belly</td><td>25</td><td>40</td><td>25</td><td>5</td><td>0</td><td>20</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>25</td><td>20</td><td>5</td><td>0</td><td>20</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>40</td><td>5</td><td>0</td><td>30</td><td>40</td><td>0</td><td>10</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>25</td><td>20</td><td>5</td><td>0</td><td>20</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>25</td><td>20</td><td>5</td><td>0</td><td>20</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>35</td><td>25</td><td>5</td><td>0</td><td>20</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>15</td><td>20</td><td>5</td><td>0</td><td>20</td><td>10</td><td>0</td><td>0</td></tr>
 </table>
@@ -93,11 +93,11 @@
 <tr><td>Head</td><td>220</td><td>２ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying</td></tr>
 <tr><td>Torso</td><td>100</td><td></td></tr>
 <tr><td>Tail</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>180</td><td><div>
+<tr><td>Left Leg</td><td>180</td><td><div>
 <span><em>15</em>258</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>180</td><td><div>
+<tr><td>Right Leg</td><td>180</td><td><div>
 <span><em>15</em>258</span>
 </div>
 </td></tr>

--- a/mons/kushasabi_nh.htm
+++ b/mons/kushasabi_nh.htm
@@ -82,22 +82,22 @@
 <img id=icon src="../img/monsicons/rustedkushaladaora.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>55</td><td>25</td><td>0</td><td>0</td><td>20</td><td>35</td><td>0</td><td>100</td></tr>
 <tr><td>Belly</td><td>30</td><td>45</td><td>20</td><td>10</td><td>5</td><td>-10</td><td>-15</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>25</td><td>25</td><td>10</td><td>5</td><td>-10</td><td>-15</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>25</td><td>35</td><td>0</td><td>0</td><td>30</td><td>35</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>20</td><td>20</td><td>10</td><td>5</td><td>-10</td><td>-15</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>20</td><td>20</td><td>10</td><td>5</td><td>-10</td><td>-15</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>30</td><td>25</td><td>10</td><td>5</td><td>-10</td><td>-15</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>15</td><td>20</td><td>0</td><td>0</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(風纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(風纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>20</td><td>0</td><td>0</td><td>20</td><td>25</td><td>0</td><td>100</td></tr>
 <tr><td>Belly</td><td>25</td><td>25</td><td>15</td><td>5</td><td>0</td><td>-15</td><td>-20</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>10</td><td>15</td><td>20</td><td>5</td><td>0</td><td>-15</td><td>-20</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>20</td><td>30</td><td>0</td><td>0</td><td>30</td><td>25</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>20</td><td>15</td><td>10</td><td>5</td><td>0</td><td>-15</td><td>-20</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>20</td><td>15</td><td>10</td><td>5</td><td>0</td><td>-15</td><td>-20</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>25</td><td>15</td><td>5</td><td>0</td><td>-15</td><td>-20</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>15</td><td>10</td><td>15</td><td>0</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
 </table>
@@ -108,8 +108,8 @@
 <tr><td>Head</td><td>400</td><td>２ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying</td></tr>
 <tr><td>Torso</td><td>700</td><td></td></tr>
 <tr><td>Tail</td><td>180</td><td></td></tr>
-<tr><td>Left Foot</td><td>230</td><td></td></tr>
-<tr><td>Right Foot</td><td>230</td><td></td></tr>
+<tr><td>Left Leg</td><td>230</td><td></td></tr>
+<tr><td>Right Leg</td><td>230</td><td></td></tr>
 <tr><td>Wing</td><td>270</td><td>２ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying</td></tr>
 <tr><td>-</td><td>250</td><td></td></tr>
 <tr><td>-</td><td>190</td><td></td></tr>

--- a/mons/lappy_n.htm
+++ b/mons/lappy_n.htm
@@ -78,7 +78,7 @@
 <!--<img id=icon src="../img/monsicons/rappy.webp" width="400"/>-->
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>100</td><td>100</td><td>100</td><td>50</td><td>50</td><td>50</td><td>10</td><td>50</td><td>100</td></tr>
 </table>

--- a/mons/lavieG_ng.htm
+++ b/mons/lavieG_ng.htm
@@ -7,7 +7,7 @@
 </head><body>
 <div id=monsname>Berserk Raviente[GR]</div><div id=tophosoku><a href="lavieG_h.htm">Carves</a></div>
 <div id=hosoku>
-<span><em>Roar</em>特大</span><span><em>Wind Pres.</em>Dragon</span><span><em>Tremor</em>強</span><span><em>Pitfall T.</em>×</span><span><em>Shock T.</em>×</span><span><em>Flash</em>×</span><span><em>Sonic</em>×</span><span><em>Meat</em>×</span><span><em>Dung</em>×</span><span><em>特殊</em><a style="margin:0" href="lavie-memo.htm">肉質変化</a></span>
+<span><em>Roar</em>特大</span><span><em>Wind Pres.</em>Dragon</span><span><em>Tremor</em>強</span><span><em>Pitfall T.</em>×</span><span><em>Shock T.</em>×</span><span><em>Flash</em>×</span><span><em>Sonic</em>×</span><span><em>Meat</em>×</span><span><em>Dung</em>×</span><span><em>特殊</em><a style="margin:0" href="lavie-memo.htm">Hitzones変化</a></span>
 </div>
 <table id=izyo>
 <col class=c1><col class=c2><col class=c3><col class=c4><col class=c5>
@@ -98,108 +98,108 @@
 <img id=icon src="../img/monsicons/berserkraviente.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>牙</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td></tr>
+<tr><td>Fang</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td></tr>
 <tr><td>Head</td><td>50</td><td>50</td><td>40</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>10</td></tr>
 <tr><td>Throat</td><td>60</td><td>10</td><td>40</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>0</td></tr>
 <tr><td>Belly</td><td>50</td><td>50</td><td>30</td><td>30</td><td>30</td><td>30</td><td>30</td><td>30</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>35</td><td>50</td><td>35</td><td>35</td><td>35</td><td>35</td><td>35</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>40</td><td>30</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>0</td></tr>
 <tr><td>Tail</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(蓄積耐性|怒り)</th></tr>
+<tr class=l><th colspan=10>Hitzones(蓄積耐性|怒り)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>牙</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>5</td><td>5</td><td>5</td><td>10</td></tr>
+<tr><td>Fang</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>5</td><td>5</td><td>5</td><td>10</td></tr>
 <tr><td>Head</td><td>40</td><td>40</td><td>30</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>10</td></tr>
 <tr><td>Throat</td><td>50</td><td>10</td><td>30</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
 <tr><td>Belly</td><td>40</td><td>40</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>25</td><td>40</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>30</td><td>25</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(蓄積耐性|怒り)</th></tr>
+<tr class=l><th colspan=10>Hitzones(蓄積耐性|怒り)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>牙</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td></tr>
+<tr><td>Fang</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td></tr>
 <tr><td>Head</td><td>50</td><td>50</td><td>40</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>10</td></tr>
 <tr><td>Throat</td><td>60</td><td>10</td><td>40</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>0</td></tr>
 <tr><td>Belly</td><td>50</td><td>50</td><td>30</td><td>30</td><td>30</td><td>30</td><td>30</td><td>30</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>35</td><td>50</td><td>35</td><td>35</td><td>35</td><td>35</td><td>35</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>40</td><td>30</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>0</td></tr>
 <tr><td>Tail</td><td>80</td><td>80</td><td>80</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(蓄積耐性|怒り)</th></tr>
+<tr class=l><th colspan=10>Hitzones(蓄積耐性|怒り)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>牙</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>5</td><td>5</td><td>5</td><td>10</td></tr>
+<tr><td>Fang</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>5</td><td>5</td><td>5</td><td>10</td></tr>
 <tr><td>Head</td><td>40</td><td>40</td><td>30</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>10</td></tr>
 <tr><td>Throat</td><td>50</td><td>10</td><td>30</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
 <tr><td>Belly</td><td>40</td><td>40</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>25</td><td>40</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>30</td><td>25</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>60</td><td>60</td><td>60</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(蓄積耐性|怒り)</th></tr>
+<tr class=l><th colspan=10>Hitzones(蓄積耐性|怒り)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>牙</td><td>80</td><td>80</td><td>80</td><td>30</td><td>30</td><td>30</td><td>30</td><td>30</td><td>100</td></tr>
+<tr><td>Fang</td><td>80</td><td>80</td><td>80</td><td>30</td><td>30</td><td>30</td><td>30</td><td>30</td><td>100</td></tr>
 <tr><td>Head</td><td>70</td><td>70</td><td>60</td><td>30</td><td>30</td><td>30</td><td>30</td><td>30</td><td>100</td></tr>
 <tr><td>Throat</td><td>60</td><td>10</td><td>40</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>0</td></tr>
 <tr><td>Belly</td><td>50</td><td>50</td><td>30</td><td>30</td><td>30</td><td>30</td><td>30</td><td>30</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>35</td><td>50</td><td>35</td><td>35</td><td>35</td><td>35</td><td>35</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>40</td><td>30</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>0</td></tr>
 <tr><td>Tail</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(蓄積耐性|怒り)</th></tr>
+<tr class=l><th colspan=10>Hitzones(蓄積耐性|怒り)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>牙</td><td>70</td><td>70</td><td>70</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>100</td></tr>
+<tr><td>Fang</td><td>70</td><td>70</td><td>70</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>100</td></tr>
 <tr><td>Head</td><td>60</td><td>60</td><td>50</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>100</td></tr>
 <tr><td>Throat</td><td>50</td><td>10</td><td>30</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
 <tr><td>Belly</td><td>40</td><td>40</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>25</td><td>40</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>30</td><td>25</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(極)</th></tr>
+<tr class=l><th colspan=10>Hitzones(極)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>牙</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td></tr>
+<tr><td>Fang</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td></tr>
 <tr><td>Head</td><td>35</td><td>35</td><td>30</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>10</td></tr>
 <tr><td>Throat</td><td>40</td><td>10</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>0</td></tr>
 <tr><td>Belly</td><td>35</td><td>35</td><td>20</td><td>30</td><td>30</td><td>30</td><td>30</td><td>30</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>25</td><td>35</td><td>35</td><td>35</td><td>35</td><td>35</td><td>35</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>25</td><td>20</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>0</td></tr>
 <tr><td>Tail</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(極蓄積耐性|怒り)</th></tr>
+<tr class=l><th colspan=10>Hitzones(極蓄積耐性|怒り)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>牙</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>5</td><td>5</td><td>5</td><td>10</td></tr>
+<tr><td>Fang</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>5</td><td>5</td><td>5</td><td>10</td></tr>
 <tr><td>Head</td><td>25</td><td>25</td><td>20</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>10</td></tr>
 <tr><td>Throat</td><td>30</td><td>10</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
 <tr><td>Belly</td><td>25</td><td>25</td><td>10</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
 <tr><td>Back</td><td>10</td><td>15</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>0</td></tr>
 <tr><td>Tail</td><td>15</td><td>15</td><td>10</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(極蓄積耐性|怒り)</th></tr>
+<tr class=l><th colspan=10>Hitzones(極蓄積耐性|怒り)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>牙</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td></tr>
+<tr><td>Fang</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td></tr>
 <tr><td>Head</td><td>35</td><td>35</td><td>30</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>10</td></tr>
 <tr><td>Throat</td><td>40</td><td>10</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>0</td></tr>
 <tr><td>Belly</td><td>35</td><td>35</td><td>20</td><td>30</td><td>30</td><td>30</td><td>30</td><td>30</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>25</td><td>35</td><td>35</td><td>35</td><td>35</td><td>35</td><td>35</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>25</td><td>20</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>0</td></tr>
 <tr><td>Tail</td><td>60</td><td>60</td><td>60</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(極蓄積耐性|怒り)</th></tr>
+<tr class=l><th colspan=10>Hitzones(極蓄積耐性|怒り)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>牙</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>5</td><td>5</td><td>5</td><td>10</td></tr>
+<tr><td>Fang</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>5</td><td>5</td><td>5</td><td>10</td></tr>
 <tr><td>Head</td><td>25</td><td>25</td><td>20</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>10</td></tr>
 <tr><td>Throat</td><td>30</td><td>10</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
 <tr><td>Belly</td><td>25</td><td>25</td><td>10</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
 <tr><td>Back</td><td>10</td><td>15</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>0</td></tr>
 <tr><td>Tail</td><td>15</td><td>15</td><td>10</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>45</td><td>45</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(極蓄積耐性|怒り)</th></tr>
+<tr class=l><th colspan=10>Hitzones(極蓄積耐性|怒り)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>牙</td><td>45</td><td>45</td><td>45</td><td>30</td><td>30</td><td>30</td><td>30</td><td>30</td><td>100</td></tr>
+<tr><td>Fang</td><td>45</td><td>45</td><td>45</td><td>30</td><td>30</td><td>30</td><td>30</td><td>30</td><td>100</td></tr>
 <tr><td>Head</td><td>35</td><td>45</td><td>30</td><td>30</td><td>30</td><td>30</td><td>30</td><td>30</td><td>100</td></tr>
 <tr><td>Throat</td><td>40</td><td>10</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>0</td></tr>
 <tr><td>Belly</td><td>35</td><td>35</td><td>20</td><td>30</td><td>30</td><td>30</td><td>30</td><td>30</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>25</td><td>30</td><td>35</td><td>35</td><td>35</td><td>35</td><td>35</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>25</td><td>20</td><td>25</td><td>25</td><td>25</td><td>25</td><td>25</td><td>0</td></tr>
 <tr><td>Tail</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(極蓄積耐性|怒り)</th></tr>
+<tr class=l><th colspan=10>Hitzones(極蓄積耐性|怒り)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>牙</td><td>30</td><td>30</td><td>30</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>100</td></tr>
+<tr><td>Fang</td><td>30</td><td>30</td><td>30</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>100</td></tr>
 <tr><td>Head</td><td>25</td><td>25</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>100</td></tr>
 <tr><td>Throat</td><td>30</td><td>10</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
 <tr><td>Belly</td><td>25</td><td>25</td><td>10</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
@@ -211,7 +211,7 @@
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
-<tr><td>牙</td><td>1500</td><td></td></tr>
+<tr><td>Fang</td><td>1500</td><td></td></tr>
 <tr><td>Head</td><td>1000</td><td></td></tr>
 <tr><td>Throat</td><td>2000</td><td></td></tr>
 <tr><td>Belly</td><td>3000</td><td></td></tr>
@@ -220,12 +220,12 @@
 <tr><td></td><td>2500</td><td></td></tr>
 <tr><td></td><td>2500</td><td></td></tr>
 <tr class=l><th colspan=3>特殊部位破壊</th></tr>
-<tr><td>牙</td><td></td><td></td></tr>
+<tr><td>Fang</td><td></td><td></td></tr>
 <tr><td>Head</td><td></td><td></td></tr>
 <tr><td>Throat</td><td></td><td></td></tr>
 <tr><td>Tail</td><td></td><td></td></tr>
-<tr><td>背中1</td><td></td><td></td></tr>
-<tr><td>背中2</td><td></td><td></td></tr>
+<tr><td>Back 1</td><td></td><td></td></tr>
+<tr><td>Back 2</td><td></td><td></td></tr>
 </table>
 <script type="text/javascript" src="hover.js"></script>
 </body></html>

--- a/mons/lavie_n.htm
+++ b/mons/lavie_n.htm
@@ -7,7 +7,7 @@
 </head><body>
 <div id=monsname>Raviente</div><div id=tophosoku><a href="lavie_nh.htm">Violent</a>／<a href="lavie_h.htm">Carves</a></div>
 <div id=hosoku>
-<span><em>Roar</em>特大</span><span><em>Wind Pres.</em>Dragon</span><span><em>Tremor</em>強</span><span><em>Pitfall T.</em>×</span><span><em>Shock T.</em>×</span><span><em>Flash</em>×</span><span><em>Sonic</em>×</span><span><em>Meat</em>×</span><span><em>Dung</em>×</span><span><em>特殊</em><a style="margin:0" href="lavie-memo.htm">肉質変化</a></span>
+<span><em>Roar</em>特大</span><span><em>Wind Pres.</em>Dragon</span><span><em>Tremor</em>強</span><span><em>Pitfall T.</em>×</span><span><em>Shock T.</em>×</span><span><em>Flash</em>×</span><span><em>Sonic</em>×</span><span><em>Meat</em>×</span><span><em>Dung</em>×</span><span><em>特殊</em><a style="margin:0" href="lavie-memo.htm">Hitzones変化</a></span>
 </div>
 <table id=izyo>
 <col class=c1><col class=c2><col class=c3><col class=c4><col class=c5>
@@ -52,18 +52,18 @@
 <img id=icon src="../img/monsicons/raviente.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>牙</td><td>60</td><td>60</td><td>60</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>10</td></tr>
+<tr><td>Fang</td><td>60</td><td>60</td><td>60</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>10</td></tr>
 <tr><td>Head</td><td>50</td><td>50</td><td>40</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>10</td></tr>
 <tr><td>Throat</td><td>60</td><td>10</td><td>40</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
 <tr><td>Belly</td><td>50</td><td>50</td><td>30</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>35</td><td>50</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>40</td><td>30</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>40</td><td>30</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(蓄積耐性|怒り)</th></tr>
+<tr class=l><th colspan=10>Hitzones(蓄積耐性|怒り)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>牙</td><td>50</td><td>50</td><td>50</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>10</td></tr>
+<tr><td>Fang</td><td>50</td><td>50</td><td>50</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>10</td></tr>
 <tr><td>Head</td><td>40</td><td>40</td><td>30</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>10</td></tr>
 <tr><td>Throat</td><td>50</td><td>10</td><td>30</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
 <tr><td>Belly</td><td>40</td><td>40</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
@@ -75,19 +75,19 @@
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
-<tr><td>牙</td><td>1000</td><td></td></tr>
+<tr><td>Fang</td><td>1000</td><td></td></tr>
 <tr><td>Head</td><td>1000</td><td>３ stagger(s) required</td></tr>
 <tr><td>Throat</td><td>2000</td><td></td></tr>
 <tr><td>Belly</td><td>3000</td><td></td></tr>
 <tr><td>Back</td><td>2000</td><td>３ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>4000</td><td>３ stagger(s) required</td></tr>
 <tr class=l><th colspan=3>特殊部位破壊</th></tr>
-<tr><td>牙</td><td>16000<br>25600<br>33600</td><td>Deal enough damage<br>Break with Partbreak Support (up to 3 times)</td></tr>
+<tr><td>Fang</td><td>16000<br>25600<br>33600</td><td>Deal enough damage<br>Break with Partbreak Support (up to 3 times)</td></tr>
 <tr><td>Head</td><td>32000<br>51200<br>67200</td><td>Deal enough damage<br>Break with Partbreak Support (up to 3 times)</td></tr>
 <tr><td>Throat</td><td>67200</td><td>Deal enough damage<br>Break with Partbreak support</td></tr>
 <tr><td>Tail</td><td>67200</td><td>Deal enough damage<br>Break with Partbreak support</td></tr>
-<tr><td>背中1</td><td>204800</td><td>Deal enough damage<br>Break with Partbreak support</td></tr>
-<tr><td>背中2</td><td>16000</td><td>Deal enough damage<br>Break with Partbreak support</td></tr>
+<tr><td>Back 1</td><td>204800</td><td>Deal enough damage<br>Break with Partbreak support</td></tr>
+<tr><td>Back 2</td><td>16000</td><td>Deal enough damage<br>Break with Partbreak support</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/raviente.png" width="400"/>
 <table id=kou>

--- a/mons/lavie_nh.htm
+++ b/mons/lavie_nh.htm
@@ -7,7 +7,7 @@
 </head><body>
 <div id=monsname>Violent Raviente</div><div id=tophosoku><a href="lavie_n.htm">Normal</a>／<a href="lavie_h.htm">Carves</a></div>
 <div id=hosoku>
-<span><em>Roar</em>特大</span><span><em>Wind Pres.</em>Dragon</span><span><em>Tremor</em>強</span><span><em>Pitfall T.</em>×</span><span><em>Shock T.</em>×</span><span><em>Flash</em>×</span><span><em>Sonic</em>×</span><span><em>Meat</em>×</span><span><em>Dung</em>×</span><span><em>特殊</em><a style="margin:0" href="lavie-memo.htm">肉質変化</a></span>
+<span><em>Roar</em>特大</span><span><em>Wind Pres.</em>Dragon</span><span><em>Tremor</em>強</span><span><em>Pitfall T.</em>×</span><span><em>Shock T.</em>×</span><span><em>Flash</em>×</span><span><em>Sonic</em>×</span><span><em>Meat</em>×</span><span><em>Dung</em>×</span><span><em>特殊</em><a style="margin:0" href="lavie-memo.htm">Hitzones変化</a></span>
 </div>
 <table id=izyo>
 <col class=c1><col class=c2><col class=c3><col class=c4><col class=c5>
@@ -52,18 +52,18 @@
 <img id=icon src="../img/monsicons/violentraviente.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>牙</td><td>60</td><td>60</td><td>60</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>10</td></tr>
+<tr><td>Fang</td><td>60</td><td>60</td><td>60</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>10</td></tr>
 <tr><td>Head</td><td>50</td><td>50</td><td>40</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>10</td></tr>
 <tr><td>Throat</td><td>60</td><td>10</td><td>40</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
 <tr><td>Belly</td><td>50</td><td>50</td><td>30</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>35</td><td>50</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>40</td><td>30</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>40</td><td>30</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(蓄積耐性|怒り)</th></tr>
+<tr class=l><th colspan=10>Hitzones(蓄積耐性|怒り)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>牙</td><td>50</td><td>50</td><td>50</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>10</td></tr>
+<tr><td>Fang</td><td>50</td><td>50</td><td>50</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>10</td></tr>
 <tr><td>Head</td><td>40</td><td>40</td><td>30</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>10</td></tr>
 <tr><td>Throat</td><td>50</td><td>10</td><td>30</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
 <tr><td>Belly</td><td>40</td><td>40</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
@@ -75,19 +75,19 @@
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
-<tr><td>牙</td><td>1000</td><td></td></tr>
+<tr><td>Fang</td><td>1000</td><td></td></tr>
 <tr><td>Head</td><td>1000</td><td>３ stagger(s) required</td></tr>
 <tr><td>Throat</td><td>2000</td><td></td></tr>
 <tr><td>Belly</td><td>3000</td><td></td></tr>
 <tr><td>Back</td><td>2000</td><td>３ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>4000</td><td>３ stagger(s) required</td></tr>
 <tr class=l><th colspan=3>特殊部位破壊</th></tr>
-<tr><td>牙</td><td>16000<br>25600<br>33600</td><td>Deal enough damage<br>Break with Partbreak Support (up to 3 times)</td></tr>
+<tr><td>Fang</td><td>16000<br>25600<br>33600</td><td>Deal enough damage<br>Break with Partbreak Support (up to 3 times)</td></tr>
 <tr><td>Head</td><td>32000<br>51200<br>67200</td><td>Deal enough damage<br>Break with Partbreak Support (up to 3 times)</td></tr>
 <tr><td>Throat</td><td>67200</td><td>Deal enough damage<br>Break with Partbreak support</td></tr>
 <tr><td>Tail</td><td>67200</td><td>Deal enough damage<br>Break with Partbreak support</td></tr>
-<tr><td>背中1</td><td>204800</td><td>Deal enough damage<br>Break with Partbreak support</td></tr>
-<tr><td>背中2</td><td>16000</td><td>Deal enough damage<br>Break with Partbreak support</td></tr>
+<tr><td>Back 1</td><td>204800</td><td>Deal enough damage<br>Break with Partbreak support</td></tr>
+<tr><td>Back 2</td><td>16000</td><td>Deal enough damage<br>Break with Partbreak support</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/raviente.png" width="400"/>
 <table id=kou>

--- a/mons/levy_ng.htm
+++ b/mons/levy_ng.htm
@@ -117,22 +117,22 @@
 <img id=icon src="../img/monsicons/rebidiora.webp" width="300"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>60</td><td>40</td><td>0</td><td>35</td><td>0</td><td>15</td><td>15</td><td>100</td></tr>
 <tr><td>Belly</td><td>25</td><td>30</td><td>35</td><td>0</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>25</td><td>35</td><td>0</td><td>10</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>55</td><td>35</td><td>45</td><td>0</td><td>10</td><td>0</td><td>35</td><td>15</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>30</td><td>30</td><td>0</td><td>15</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>30</td><td>30</td><td>0</td><td>15</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>35</td><td>45</td><td>30</td><td>0</td><td>5</td><td>0</td><td>30</td><td>15</td><td>0</td></tr>
 <tr><td>Wing</td><td>45</td><td>35</td><td>35</td><td>0</td><td>30</td><td>0</td><td>15</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(磁力纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(磁力纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>60</td><td>40</td><td>0</td><td>35</td><td>0</td><td>15</td><td>15</td><td>100</td></tr>
 <tr><td>Belly</td><td>25</td><td>30</td><td>35</td><td>0</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>25</td><td>35</td><td>0</td><td>10</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>55</td><td>35</td><td>45</td><td>0</td><td>10</td><td>0</td><td>35</td><td>15</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>30</td><td>30</td><td>0</td><td>15</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>30</td><td>30</td><td>0</td><td>15</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>35</td><td>45</td><td>30</td><td>0</td><td>5</td><td>0</td><td>30</td><td>15</td><td>0</td></tr>
 <tr><td>Wing</td><td>45</td><td>35</td><td>35</td><td>0</td><td>30</td><td>0</td><td>15</td><td>10</td><td>0</td></tr>
 </table>
@@ -143,8 +143,8 @@
 <tr><td>Head</td><td>700</td><td>２ stagger(s) required for first partbreak stage<br>４ stagger(s) required for complete partbreak</td></tr>
 <tr><td>Torso</td><td>500</td><td></td></tr>
 <tr><td>Tail</td><td>800</td><td></td></tr>
-<tr><td>Left Foot</td><td>600</td><td></td></tr>
-<tr><td>Right Foot</td><td>600</td><td></td></tr>
+<tr><td>Left Leg</td><td>600</td><td></td></tr>
+<tr><td>Right Leg</td><td>600</td><td></td></tr>
 <tr><td>Wing</td><td>800</td><td>２ stagger(s) required for first partbreak stage<br>４ stagger(s) required for complete partbreak</td></tr>
 <tr><td>-</td><td>250</td><td></td></tr>
 <tr><td>-</td><td>190</td><td></td></tr>

--- a/mons/mera_ng.htm
+++ b/mons/mera_ng.htm
@@ -97,7 +97,7 @@
 <img id=icon src="../img/monsicons/meraginasu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>50</td><td>20</td><td>10</td><td>5</td><td>20</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>10</td><td>10</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
@@ -106,7 +106,7 @@
 <tr><td>Tail</td><td>50</td><td>30</td><td>25</td><td>10</td><td>5</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>15</td><td>20</td><td>10</td><td>10</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>25</td><td>20</td><td>10</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>50</td><td>25</td><td>15</td><td>5</td><td>20</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>25</td><td>25</td><td>15</td><td>15</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
@@ -115,7 +115,7 @@
 <tr><td>Tail</td><td>50</td><td>35</td><td>30</td><td>10</td><td>5</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>25</td><td>15</td><td>15</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>30</td><td>20</td><td>10</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(探査？)</th></tr>
+<tr class=l><th colspan=10>Hitzones(探査？)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>60</td><td>30</td><td>15</td><td>5</td><td>20</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>30</td><td>30</td><td>15</td><td>15</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
@@ -132,9 +132,9 @@
 <tr><td>Torso</td><td>800</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>500</td><td>１ stagger(s) required<br> (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>500</td><td>１ stagger(s) required<br> (Only one break required for rewards)</td></tr>
-<tr><td>Left Foot</td><td>1200</td><td></td></tr>
-<tr><td>Right Foot</td><td>1200</td><td></td></tr>
-<tr><td>首/背中</td><td>500</td><td>２ stagger(s) required</td></tr>
+<tr><td>Left Leg</td><td>1200</td><td></td></tr>
+<tr><td>Right Leg</td><td>1200</td><td></td></tr>
+<tr><td>Neck/Back</td><td>500</td><td>２ stagger(s) required</td></tr>
 <tr><td>Head</td><td>800</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>700</td><td>２ stagger(s) required</td></tr>
 </table>

--- a/mons/mera_nh.htm
+++ b/mons/mera_nh.htm
@@ -75,7 +75,7 @@
 <img id=icon src="../img/monsicons/meraginasu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>50</td><td>25</td><td>10</td><td>5</td><td>20</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>25</td><td>15</td><td>10</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
@@ -84,7 +84,7 @@
 <tr><td>Tail</td><td>50</td><td>20</td><td>25</td><td>10</td><td>5</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>20</td><td>15</td><td>10</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>25</td><td>10</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>50</td><td>30</td><td>15</td><td>5</td><td>20</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>25</td><td>30</td><td>20</td><td>15</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
@@ -93,7 +93,7 @@
 <tr><td>Tail</td><td>50</td><td>30</td><td>30</td><td>10</td><td>5</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>25</td><td>20</td><td>15</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>30</td><td>25</td><td>10</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(探査？)</th></tr>
+<tr class=l><th colspan=10>Hitzones(探査？)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>60</td><td>40</td><td>15</td><td>5</td><td>20</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>30</td><td>35</td><td>20</td><td>15</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
@@ -110,9 +110,9 @@
 <tr><td>Torso</td><td>650</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>500</td><td>１ stagger(s) required<br> (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>500</td><td>１ stagger(s) required<br> (Only one break required for rewards)</td></tr>
-<tr><td>Left Foot</td><td>650</td><td></td></tr>
-<tr><td>Right Foot</td><td>650</td><td></td></tr>
-<tr><td>首/背中</td><td>450</td><td>２ stagger(s) required</td></tr>
+<tr><td>Left Leg</td><td>650</td><td></td></tr>
+<tr><td>Right Leg</td><td>650</td><td></td></tr>
+<tr><td>Neck/Back</td><td>450</td><td>２ stagger(s) required</td></tr>
 <tr><td>Head</td><td>500</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>500</td><td>２ stagger(s) required</td></tr>
 </table>

--- a/mons/merura_n.htm
+++ b/mons/merura_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/Melynx.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>110</td><td>100</td><td>100</td><td>100</td><td>100</td><td>100</td><td>10</td><td>100</td><td>100</td></tr>
 </table>

--- a/mons/mi-ru_ng.htm
+++ b/mons/mi-ru_ng.htm
@@ -92,77 +92,77 @@
 <img id=icon src="../img/monsicons/miru.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>30</td><td>25</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>30</td><td>25</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>30</td><td>25</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>30</td><td>30</td><td>25</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>30</td><td>25</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>尾</td><td>30</td><td>30</td><td>25</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Tail</td><td>30</td><td>30</td><td>25</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>40</td><td>35</td><td>40</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(碧状態)</th></tr>
+<tr class=l><th colspan=10>Hitzones(碧状態)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>40</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>50</td><td>50</td><td>45</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>50</td><td>50</td><td>45</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>30</td><td>25</td><td>0</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>25</td><td>25</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>30</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>30</td><td>25</td><td>0</td><td>0</td><td>30</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>尾</td><td>30</td><td>30</td><td>25</td><td>0</td><td>0</td><td>0</td><td>30</td><td>0</td><td>0</td></tr>
+<tr><td>Tail</td><td>30</td><td>30</td><td>25</td><td>0</td><td>0</td><td>0</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>40</td><td>30</td><td>40</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(紅状態)</th></tr>
+<tr class=l><th colspan=10>Hitzones(紅状態)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>40</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>25</td><td>15</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>25</td><td>15</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>50</td><td>50</td><td>45</td><td>0</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>30</td><td>30</td><td>25</td><td>0</td><td>0</td><td>0</td><td>0</td><td>30</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>30</td><td>25</td><td>0</td><td>0</td><td>30</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>尾</td><td>30</td><td>30</td><td>25</td><td>0</td><td>0</td><td>0</td><td>30</td><td>0</td><td>0</td></tr>
+<tr><td>Tail</td><td>30</td><td>30</td><td>25</td><td>0</td><td>0</td><td>0</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>40</td><td>30</td><td>40</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(結晶状態)</th></tr>
+<tr class=l><th colspan=10>Hitzones(結晶状態)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>40</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>30</td><td>25</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>30</td><td>25</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>30</td><td>25</td><td>0</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>30</td><td>30</td><td>25</td><td>0</td><td>0</td><td>0</td><td>0</td><td>30</td><td>0</td></tr>
 <tr><td>Back</td><td>50</td><td>50</td><td>45</td><td>0</td><td>0</td><td>30</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>尾</td><td>25</td><td>25</td><td>15</td><td>0</td><td>0</td><td>0</td><td>30</td><td>0</td><td>0</td></tr>
+<tr><td>Tail</td><td>25</td><td>25</td><td>15</td><td>0</td><td>0</td><td>0</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>40</td><td>35</td><td>40</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(蒼状態)</th></tr>
+<tr class=l><th colspan=10>Hitzones(蒼状態)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>40</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>30</td><td>25</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>30</td><td>25</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>30</td><td>25</td><td>0</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>30</td><td>30</td><td>25</td><td>0</td><td>0</td><td>0</td><td>0</td><td>30</td><td>0</td></tr>
 <tr><td>Back</td><td>25</td><td>25</td><td>15</td><td>0</td><td>0</td><td>30</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>尾</td><td>50</td><td>50</td><td>45</td><td>0</td><td>0</td><td>0</td><td>30</td><td>0</td><td>0</td></tr>
+<tr><td>Tail</td><td>50</td><td>50</td><td>45</td><td>0</td><td>0</td><td>0</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>40</td><td>30</td><td>40</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(白状態)</th></tr>
+<tr class=l><th colspan=10>Hitzones(白状態)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>40</td><td>40</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>50</td><td>25</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>50</td><td>25</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>35</td><td>35</td><td>30</td><td>0</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>30</td><td>30</td><td>45</td><td>0</td><td>0</td><td>0</td><td>0</td><td>30</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>30</td><td>25</td><td>0</td><td>0</td><td>30</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>尾</td><td>50</td><td>35</td><td>30</td><td>0</td><td>0</td><td>0</td><td>30</td><td>0</td><td>0</td></tr>
+<tr><td>Tail</td><td>50</td><td>35</td><td>30</td><td>0</td><td>0</td><td>0</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>40</td><td>25</td><td>40</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(弾跳ね返し時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(弾跳ね返し時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>30</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>30</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>30</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>30</td><td>30</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>30</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>尾</td><td>30</td><td>30</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Tail</td><td>30</td><td>30</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>40</td><td>35</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質()</th></tr>
+<tr class=l><th colspan=10>Hitzones()</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>30</td><td>25</td><td>5</td><td>5</td><td>5</td><td>5</td><td>5</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>35</td><td>15</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>35</td><td>15</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>20</td><td>20</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>20</td><td>15</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>25</td><td>15</td><td>0</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>尾</td><td>35</td><td>20</td><td>20</td><td>0</td><td>0</td><td>0</td><td>15</td><td>0</td><td>0</td></tr>
+<tr><td>Tail</td><td>35</td><td>20</td><td>20</td><td>0</td><td>0</td><td>0</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>30</td><td>10</td><td>35</td><td>5</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -170,13 +170,13 @@
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>1200</td><td>２ stagger(s) required</td></tr>
-<tr><td>右爪</td><td>800</td><td>２ stagger(s) required</td></tr>
-<tr><td>左爪</td><td>800</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Claw</td><td>800</td><td>２ stagger(s) required</td></tr>
+<tr><td>Left Claw</td><td>800</td><td>２ stagger(s) required</td></tr>
 <tr><td>Hind Leg</td><td>1000</td><td></td></tr>
 <tr><td>Belly</td><td>2000</td><td></td></tr>
 <tr><td>Back</td><td>1400</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>2000</td><td></td></tr>
-<tr><td>尻尾先端</td><td>1200</td><td>２ stagger(s) required</td></tr>
+<tr><td>Tail Tip</td><td>1200</td><td>２ stagger(s) required</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/miru.png" width="400"/>
 <script type="text/javascript" src="hover.js"></script>

--- a/mons/mido_ng.htm
+++ b/mons/mido_ng.htm
@@ -117,21 +117,21 @@
 <img id=icon src="../img/monsicons/midogaron.webp" width="300"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>40</td><td>0</td><td>30</td><td>5</td><td>0</td><td>40</td><td>100</td></tr>
 <tr><td>Back</td><td>45</td><td>40</td><td>40</td><td>0</td><td>15</td><td>5</td><td>0</td><td>25</td><td>0</td></tr>
 <tr><td>Body</td><td>30</td><td>25</td><td>20</td><td>0</td><td>20</td><td>5</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>30</td><td>20</td><td>0</td><td>15</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>30</td><td>0</td><td>10</td><td>5</td><td>0</td><td>20</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>50</td><td>45</td><td>0</td><td>35</td><td>5</td><td>0</td><td>50</td><td>100</td></tr>
 <tr><td>Back</td><td>45</td><td>40</td><td>40</td><td>0</td><td>20</td><td>5</td><td>0</td><td>30</td><td>0</td></tr>
 <tr><td>Body</td><td>35</td><td>30</td><td>25</td><td>0</td><td>25</td><td>5</td><td>0</td><td>20</td><td>0</td></tr>
 <tr><td>Leg</td><td>30</td><td>35</td><td>25</td><td>0</td><td>20</td><td>5</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>35</td><td>35</td><td>0</td><td>15</td><td>5</td><td>0</td><td>25</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info(Roaring State)</th></tr>
+<tr class=l><th colspan=10>Hitzones(Roaring State)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>5</td><td>0</td><td>30</td><td>5</td><td>0</td><td>40</td><td>100</td></tr>
 <tr><td>Back</td><td>45</td><td>40</td><td>5</td><td>0</td><td>15</td><td>5</td><td>0</td><td>25</td><td>0</td></tr>
@@ -146,7 +146,7 @@
 <tr><td>Head</td><td>700</td><td>3rd time, head break</td></tr>
 <tr><td>Back</td><td>600</td><td>3rd time, back break</td></tr>
 <tr><td>Torso</td><td>700</td><td></td></tr>
-<tr><td>Fore Leg</td><td>800</td><td></td></tr>
+<tr><td>Foreleg</td><td>800</td><td></td></tr>
 <tr><td>Hind Leg</td><td>800</td><td></td></tr>
 <tr><td>Tail</td><td>600</td><td>3rd time, tail break</td></tr>
 </table>

--- a/mons/mido_ni.htm
+++ b/mons/mido_ni.htm
@@ -111,21 +111,21 @@
 <img id=icon src="../img/monsicons/zenith_midogaron.webp" width="300"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>30</td><td>30</td><td>0</td><td>20</td><td>5</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Back</td><td>20</td><td>15</td><td>30</td><td>0</td><td>15</td><td>5</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Body</td><td>15</td><td>20</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>25</td><td>0</td><td>20</td><td>5</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>20</td><td>20</td><td>0</td><td>10</td><td>5</td><td>0</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>35</td><td>30</td><td>0</td><td>20</td><td>5</td><td>0</td><td>25</td><td>100</td></tr>
 <tr><td>Back</td><td>25</td><td>20</td><td>35</td><td>0</td><td>15</td><td>5</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Body</td><td>10</td><td>15</td><td>5</td><td>0</td><td>10</td><td>5</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>30</td><td>30</td><td>25</td><td>0</td><td>25</td><td>5</td><td>0</td><td>20</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>20</td><td>20</td><td>0</td><td>10</td><td>5</td><td>0</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info(Roaring State)</th></tr>
+<tr class=l><th colspan=10>Hitzones(Roaring State)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>30</td><td>5</td><td>0</td><td>20</td><td>5</td><td>0</td><td>25</td><td>100</td></tr>
 <tr><td>Back</td><td>25</td><td>20</td><td>5</td><td>0</td><td>15</td><td>5</td><td>0</td><td>15</td><td>0</td></tr>
@@ -142,7 +142,7 @@
 <tr><td>Head</td><td>600</td><td>3rd time, head break</td></tr>
 <tr><td>Back</td><td>350</td><td>3rd time, back break</td></tr>
 <tr><td>Torso</td><td>1500</td><td></td></tr>
-<tr><td>Fore Leg</td><td>2600</td><td></td></tr>
+<tr><td>Foreleg</td><td>2600</td><td></td></tr>
 <tr><td>Hind Leg</td><td>2600</td><td></td></tr>
 <tr><td>Tail</td><td>450</td><td>3rd time, tail break</td></tr>
 </table>

--- a/mons/mira_n.htm
+++ b/mons/mira_n.htm
@@ -54,26 +54,26 @@
 <img id=icon src="../img/monsicons/fatalis.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>顔</td><td>80</td><td>75</td><td>45</td><td>15</td><td>5</td><td>5</td><td>40</td><td>10</td><td>100</td></tr>
+<tr><td>Face</td><td>80</td><td>75</td><td>45</td><td>15</td><td>5</td><td>5</td><td>40</td><td>10</td><td>100</td></tr>
 <tr><td>Head</td><td>50</td><td>55</td><td>30</td><td>15</td><td>5</td><td>5</td><td>30</td><td>10</td><td>0</td></tr>
-<tr><td>背中/尻尾</td><td>30</td><td>30</td><td>30</td><td>15</td><td>5</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
+<tr><td>Back/Tail</td><td>30</td><td>30</td><td>30</td><td>15</td><td>5</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Neck</td><td>30</td><td>35</td><td>35</td><td>15</td><td>5</td><td>5</td><td>30</td><td>10</td><td>0</td></tr>
-<tr><td>胸</td><td>40</td><td>40</td><td>35</td><td>15</td><td>5</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
+<tr><td>Chest</td><td>40</td><td>40</td><td>35</td><td>15</td><td>5</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>30</td><td>25</td><td>35</td><td>15</td><td>5</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
-<tr><td>腹/脚</td><td>35</td><td>35</td><td>30</td><td>15</td><td>5</td><td>5</td><td>20</td><td>10</td><td>0</td></tr>
+<tr><td>Belly/Leg</td><td>35</td><td>35</td><td>30</td><td>15</td><td>5</td><td>5</td><td>20</td><td>10</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
-<tr><td>胸</td><td>300</td><td>１ stagger(s) required</td></tr>
+<tr><td>Chest</td><td>300</td><td>１ stagger(s) required</td></tr>
 <tr><td>Back</td><td>180</td><td></td></tr>
 <tr><td>Leg</td><td>200</td><td></td></tr>
 <tr><td>Belly</td><td>200</td><td></td></tr>
 <tr><td>Head</td><td>250</td><td></td></tr>
-<tr><td>顔</td><td>500</td><td>１ stagger(s) required to break Horn<br>２ stagger(s) required<br>３ stagger(s) required</td></tr>
+<tr><td>Face</td><td>500</td><td>１ stagger(s) required to break Horn<br>２ stagger(s) required<br>３ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>180</td><td></td></tr>
 <tr><td>Wing</td><td>240</td><td>１０ stagger(s) required</td></tr>
 </table>

--- a/mons/mira_ng.htm
+++ b/mons/mira_ng.htm
@@ -99,53 +99,53 @@
 <img id=icon src="../img/monsicons/fatalis.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>顔</td><td>45</td><td>50</td><td>60</td><td>0</td><td>0</td><td>0</td><td>30</td><td>10</td><td>100</td></tr>
+<tr><td>Face</td><td>45</td><td>50</td><td>60</td><td>0</td><td>0</td><td>0</td><td>30</td><td>10</td><td>100</td></tr>
 <tr><td>Head</td><td>30</td><td>35</td><td>20</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>背中/尻尾</td><td>20</td><td>50</td><td>15</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Back/Tail</td><td>20</td><td>50</td><td>15</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Neck</td><td>20</td><td>30</td><td>15</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>胸</td><td>60</td><td>25</td><td>35</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
+<tr><td>Chest</td><td>60</td><td>25</td><td>35</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>30</td><td>30</td><td>40</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>腹/脚</td><td>20</td><td>40</td><td>20</td><td>0</td><td>30</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(蒼炎纏)</th></tr>
+<tr><td>Belly/Leg</td><td>20</td><td>40</td><td>20</td><td>0</td><td>30</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(蒼炎纏)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>顔</td><td>55</td><td>60</td><td>70</td><td>0</td><td>0</td><td>0</td><td>30</td><td>10</td><td>100</td></tr>
+<tr><td>Face</td><td>55</td><td>60</td><td>70</td><td>0</td><td>0</td><td>0</td><td>30</td><td>10</td><td>100</td></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>30</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>背中/尻尾</td><td>30</td><td>60</td><td>25</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Back/Tail</td><td>30</td><td>60</td><td>25</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Neck</td><td>30</td><td>40</td><td>25</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>胸</td><td>70</td><td>35</td><td>45</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
+<tr><td>Chest</td><td>70</td><td>35</td><td>45</td><td>0</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>40</td><td>40</td><td>50</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>腹/脚</td><td>30</td><td>50</td><td>30</td><td>0</td><td>30</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(溜め中)</th></tr>
+<tr><td>Belly/Leg</td><td>30</td><td>50</td><td>30</td><td>0</td><td>30</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(溜め中)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>顔</td><td>45</td><td>50</td><td>60</td><td>0</td><td>0</td><td>0</td><td>30</td><td>10</td><td>100</td></tr>
+<tr><td>Face</td><td>45</td><td>50</td><td>60</td><td>0</td><td>0</td><td>0</td><td>30</td><td>10</td><td>100</td></tr>
 <tr><td>Head</td><td>30</td><td>35</td><td>20</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>背中/尻尾</td><td>20</td><td>50</td><td>15</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Back/Tail</td><td>20</td><td>50</td><td>15</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Neck</td><td>20</td><td>30</td><td>15</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>胸</td><td>60</td><td>25</td><td>35</td><td>0</td><td>0</td><td>0</td><td>100</td><td>10</td><td>0</td></tr>
+<tr><td>Chest</td><td>60</td><td>25</td><td>35</td><td>0</td><td>0</td><td>0</td><td>100</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>30</td><td>30</td><td>40</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>腹/脚</td><td>20</td><td>40</td><td>20</td><td>0</td><td>30</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(蒼炎纏(溜め中))</th></tr>
+<tr><td>Belly/Leg</td><td>20</td><td>40</td><td>20</td><td>0</td><td>30</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(蒼炎纏(溜め中))</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>顔</td><td>55</td><td>60</td><td>70</td><td>0</td><td>0</td><td>0</td><td>30</td><td>10</td><td>100</td></tr>
+<tr><td>Face</td><td>55</td><td>60</td><td>70</td><td>0</td><td>0</td><td>0</td><td>30</td><td>10</td><td>100</td></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>30</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>背中/尻尾</td><td>30</td><td>60</td><td>25</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Back/Tail</td><td>30</td><td>60</td><td>25</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Neck</td><td>30</td><td>40</td><td>25</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>胸</td><td>70</td><td>35</td><td>45</td><td>0</td><td>0</td><td>0</td><td>100</td><td>10</td><td>0</td></tr>
+<tr><td>Chest</td><td>70</td><td>35</td><td>45</td><td>0</td><td>0</td><td>0</td><td>100</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>40</td><td>40</td><td>50</td><td>0</td><td>0</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>腹/脚</td><td>30</td><td>50</td><td>30</td><td>0</td><td>30</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Belly/Leg</td><td>30</td><td>50</td><td>30</td><td>0</td><td>30</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
-<tr><td>胸</td><td>900</td><td>１ stagger(s) required</td></tr>
+<tr><td>Chest</td><td>900</td><td>１ stagger(s) required</td></tr>
 <tr><td>Back</td><td>700</td><td></td></tr>
 <tr><td>Leg</td><td>750</td><td></td></tr>
 <tr><td>Belly</td><td>750</td><td></td></tr>
 <tr><td>Head</td><td>750</td><td></td></tr>
-<tr><td>顔</td><td>650</td><td>１ stagger(s) required to break Horn<br>２ stagger(s) required<br>３ stagger(s) required</td></tr>
+<tr><td>Face</td><td>650</td><td>１ stagger(s) required to break Horn<br>２ stagger(s) required<br>３ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>800</td><td></td></tr>
 <tr><td>Wing</td><td>900</td><td>５ stagger(s) required</td></tr>
 </table>

--- a/mons/miraru_n.htm
+++ b/mons/miraru_n.htm
@@ -55,35 +55,35 @@
 <img id=icon src="../img/monsicons/whitefatalis.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>顔</td><td>80</td><td>75</td><td>45</td><td>25</td><td>10</td><td>10</td><td>40</td><td>15</td><td>100</td></tr>
+<tr><td>Face</td><td>80</td><td>75</td><td>45</td><td>25</td><td>10</td><td>10</td><td>40</td><td>15</td><td>100</td></tr>
 <tr><td>Head</td><td>50</td><td>55</td><td>30</td><td>20</td><td>10</td><td>10</td><td>30</td><td>15</td><td>0</td></tr>
-<tr><td>背中/尻尾</td><td>10</td><td>20</td><td>20</td><td>25</td><td>10</td><td>10</td><td>10</td><td>15</td><td>0</td></tr>
+<tr><td>Back/Tail</td><td>10</td><td>20</td><td>20</td><td>25</td><td>10</td><td>10</td><td>10</td><td>15</td><td>0</td></tr>
 <tr><td>Neck</td><td>30</td><td>25</td><td>25</td><td>20</td><td>10</td><td>10</td><td>30</td><td>15</td><td>0</td></tr>
-<tr><td>胸</td><td>10</td><td>15</td><td>20</td><td>15</td><td>10</td><td>10</td><td>10</td><td>15</td><td>0</td></tr>
+<tr><td>Chest</td><td>10</td><td>15</td><td>20</td><td>15</td><td>10</td><td>10</td><td>10</td><td>15</td><td>0</td></tr>
 <tr><td>Wing</td><td>30</td><td>25</td><td>20</td><td>25</td><td>10</td><td>10</td><td>10</td><td>15</td><td>0</td></tr>
-<tr><td>腹/脚</td><td>20</td><td>20</td><td>20</td><td>20</td><td>10</td><td>10</td><td>20</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(残り体力が50～20%)</th></tr>
+<tr><td>Belly/Leg</td><td>20</td><td>20</td><td>20</td><td>20</td><td>10</td><td>10</td><td>20</td><td>15</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(残り体力が50～20%)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>顔</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>10</td><td>100</td></tr>
+<tr><td>Face</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>10</td><td>100</td></tr>
 <tr><td>Head</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
-<tr><td>背中/尻尾</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
+<tr><td>Back/Tail</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Neck</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
-<tr><td>胸</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
+<tr><td>Chest</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
-<tr><td>腹/脚</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
+<tr><td>Belly/Leg</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
-<tr><td>胸</td><td>300</td><td>１ stagger(s) required</td></tr>
+<tr><td>Chest</td><td>300</td><td>１ stagger(s) required</td></tr>
 <tr><td>Back</td><td>180</td><td></td></tr>
 <tr><td>Leg</td><td>200</td><td></td></tr>
 <tr><td>Belly</td><td>200</td><td></td></tr>
 <tr><td>Head</td><td>250</td><td></td></tr>
-<tr><td>顔</td><td>500</td><td>１ stagger(s) required to break Horn<br>２ stagger(s) required<br>３ stagger(s) required</td></tr>
+<tr><td>Face</td><td>500</td><td>１ stagger(s) required to break Horn<br>２ stagger(s) required<br>３ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>180</td><td></td></tr>
 <tr><td>Wing</td><td>240</td><td>１０ stagger(s) required</td></tr>
 </table>

--- a/mons/miraru_ng.htm
+++ b/mons/miraru_ng.htm
@@ -97,35 +97,35 @@
 <img id=icon src="../img/monsicons/whitefatalis.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>顔</td><td>25</td><td>35</td><td>30</td><td>20</td><td>10</td><td>10</td><td>30</td><td>15</td><td>100</td></tr>
+<tr><td>Face</td><td>25</td><td>35</td><td>30</td><td>20</td><td>10</td><td>10</td><td>30</td><td>15</td><td>100</td></tr>
 <tr><td>Head</td><td>30</td><td>20</td><td>20</td><td>15</td><td>10</td><td>10</td><td>15</td><td>15</td><td>0</td></tr>
-<tr><td>背中/尻尾</td><td>20</td><td>15</td><td>10</td><td>20</td><td>10</td><td>10</td><td>10</td><td>15</td><td>0</td></tr>
+<tr><td>Back/Tail</td><td>20</td><td>15</td><td>10</td><td>20</td><td>10</td><td>10</td><td>10</td><td>15</td><td>0</td></tr>
 <tr><td>Neck</td><td>15</td><td>20</td><td>15</td><td>15</td><td>10</td><td>10</td><td>15</td><td>15</td><td>0</td></tr>
-<tr><td>胸</td><td>25</td><td>20</td><td>25</td><td>10</td><td>10</td><td>10</td><td>10</td><td>15</td><td>0</td></tr>
+<tr><td>Chest</td><td>25</td><td>20</td><td>25</td><td>10</td><td>10</td><td>10</td><td>10</td><td>15</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>15</td><td>10</td><td>20</td><td>10</td><td>10</td><td>10</td><td>15</td><td>0</td></tr>
-<tr><td>腹/脚</td><td>15</td><td>15</td><td>15</td><td>15</td><td>10</td><td>10</td><td>10</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(残り体力が50～20%)</th></tr>
+<tr><td>Belly/Leg</td><td>15</td><td>15</td><td>15</td><td>15</td><td>10</td><td>10</td><td>10</td><td>15</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(残り体力が50～20%)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>顔</td><td>30</td><td>40</td><td>35</td><td>25</td><td>5</td><td>-15</td><td>35</td><td>10</td><td>100</td></tr>
+<tr><td>Face</td><td>30</td><td>40</td><td>35</td><td>25</td><td>5</td><td>-15</td><td>35</td><td>10</td><td>100</td></tr>
 <tr><td>Head</td><td>35</td><td>25</td><td>25</td><td>20</td><td>5</td><td>-10</td><td>15</td><td>5</td><td>0</td></tr>
-<tr><td>背中/尻尾</td><td>20</td><td>15</td><td>10</td><td>20</td><td>5</td><td>-5</td><td>5</td><td>5</td><td>0</td></tr>
+<tr><td>Back/Tail</td><td>20</td><td>15</td><td>10</td><td>20</td><td>5</td><td>-5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Neck</td><td>20</td><td>25</td><td>20</td><td>15</td><td>5</td><td>-10</td><td>15</td><td>5</td><td>0</td></tr>
-<tr><td>胸</td><td>30</td><td>25</td><td>30</td><td>10</td><td>5</td><td>-10</td><td>20</td><td>5</td><td>0</td></tr>
+<tr><td>Chest</td><td>30</td><td>25</td><td>30</td><td>10</td><td>5</td><td>-10</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>20</td><td>15</td><td>25</td><td>5</td><td>-5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr><td>腹/脚</td><td>15</td><td>15</td><td>15</td><td>15</td><td>5</td><td>-10</td><td>15</td><td>5</td><td>0</td></tr>
+<tr><td>Belly/Leg</td><td>15</td><td>15</td><td>15</td><td>15</td><td>5</td><td>-10</td><td>15</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
-<tr><td>胸</td><td>900</td><td>１ stagger(s) required</td></tr>
+<tr><td>Chest</td><td>900</td><td>１ stagger(s) required</td></tr>
 <tr><td>Back</td><td>1400</td><td></td></tr>
 <tr><td>Leg</td><td>1600</td><td></td></tr>
 <tr><td>Belly</td><td>1400</td><td></td></tr>
 <tr><td>Head</td><td>900</td><td></td></tr>
-<tr><td>顔</td><td>900</td><td>１ stagger(s) required to break Horn<br>２ stagger(s) required<br>３ stagger(s) required</td></tr>
+<tr><td>Face</td><td>900</td><td>１ stagger(s) required to break Horn<br>２ stagger(s) required<br>３ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>1000</td><td></td></tr>
 <tr><td>Wing</td><td>1100</td><td>１０ stagger(s) required</td></tr>
 </table>

--- a/mons/miraval_n.htm
+++ b/mons/miraval_n.htm
@@ -54,35 +54,35 @@
 <img id=icon src="../img/monsicons/crimsonfatalis.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>顔</td><td>50</td><td>45</td><td>45</td><td>25</td><td>10</td><td>10</td><td>40</td><td>15</td><td>100</td></tr>
+<tr><td>Face</td><td>50</td><td>45</td><td>45</td><td>25</td><td>10</td><td>10</td><td>40</td><td>15</td><td>100</td></tr>
 <tr><td>Head</td><td>30</td><td>25</td><td>30</td><td>20</td><td>10</td><td>10</td><td>30</td><td>15</td><td>0</td></tr>
-<tr><td>背中/尻尾</td><td>10</td><td>20</td><td>20</td><td>25</td><td>10</td><td>10</td><td>10</td><td>15</td><td>0</td></tr>
+<tr><td>Back/Tail</td><td>10</td><td>20</td><td>20</td><td>25</td><td>10</td><td>10</td><td>10</td><td>15</td><td>0</td></tr>
 <tr><td>Neck</td><td>30</td><td>25</td><td>25</td><td>20</td><td>10</td><td>10</td><td>30</td><td>15</td><td>0</td></tr>
-<tr><td>胸</td><td>10</td><td>15</td><td>20</td><td>15</td><td>10</td><td>10</td><td>10</td><td>15</td><td>0</td></tr>
+<tr><td>Chest</td><td>10</td><td>15</td><td>20</td><td>15</td><td>10</td><td>10</td><td>10</td><td>15</td><td>0</td></tr>
 <tr><td>Wing</td><td>30</td><td>25</td><td>20</td><td>25</td><td>10</td><td>10</td><td>10</td><td>15</td><td>0</td></tr>
-<tr><td>腹/脚</td><td>20</td><td>20</td><td>20</td><td>20</td><td>10</td><td>10</td><td>20</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(残り体力が50～20%)</th></tr>
+<tr><td>Belly/Leg</td><td>20</td><td>20</td><td>20</td><td>20</td><td>10</td><td>10</td><td>20</td><td>15</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(残り体力が50～20%)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>顔</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>5</td><td>100</td></tr>
+<tr><td>Face</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>5</td><td>100</td></tr>
 <tr><td>Head</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
-<tr><td>背中/尻尾</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
+<tr><td>Back/Tail</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Neck</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
-<tr><td>胸</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
+<tr><td>Chest</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
-<tr><td>腹/脚</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
+<tr><td>Belly/Leg</td><td>10</td><td>10</td><td>10</td><td>10</td><td>5</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
-<tr><td>胸</td><td>300</td><td>１ stagger(s) required</td></tr>
+<tr><td>Chest</td><td>300</td><td>１ stagger(s) required</td></tr>
 <tr><td>Back</td><td>180</td><td></td></tr>
 <tr><td>Leg</td><td>200</td><td></td></tr>
 <tr><td>Belly</td><td>200</td><td></td></tr>
 <tr><td>Head</td><td>250</td><td></td></tr>
-<tr><td>顔</td><td>500</td><td>１ stagger(s) required to break Horn<br>２ stagger(s) required<br>３ stagger(s) required</td></tr>
+<tr><td>Face</td><td>500</td><td>１ stagger(s) required to break Horn<br>２ stagger(s) required<br>３ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>180</td><td></td></tr>
 <tr><td>Wing</td><td>240</td><td>１０ stagger(s) required</td></tr>
 </table>

--- a/mons/miraval_ng.htm
+++ b/mons/miraval_ng.htm
@@ -99,26 +99,26 @@
 <img id=icon src="../img/monsicons/crimsonfatalis.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>顔</td><td>60</td><td>70</td><td>60</td><td>-15</td><td>10</td><td>0</td><td>40</td><td>20</td><td>100</td></tr>
+<tr><td>Face</td><td>60</td><td>70</td><td>60</td><td>-15</td><td>10</td><td>0</td><td>40</td><td>20</td><td>100</td></tr>
 <tr><td>Head</td><td>40</td><td>50</td><td>40</td><td>-10</td><td>10</td><td>0</td><td>20</td><td>10</td><td>0</td></tr>
-<tr><td>背中/尻尾</td><td>20</td><td>30</td><td>15</td><td>-5</td><td>10</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
+<tr><td>Back/Tail</td><td>20</td><td>30</td><td>15</td><td>-5</td><td>10</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Neck</td><td>40</td><td>25</td><td>40</td><td>-10</td><td>5</td><td>0</td><td>20</td><td>10</td><td>0</td></tr>
-<tr><td>胸</td><td>40</td><td>25</td><td>40</td><td>-10</td><td>5</td><td>0</td><td>20</td><td>10</td><td>0</td></tr>
+<tr><td>Chest</td><td>40</td><td>25</td><td>40</td><td>-10</td><td>5</td><td>0</td><td>20</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>50</td><td>20</td><td>10</td><td>-5</td><td>5</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
-<tr><td>腹/脚</td><td>20</td><td>40</td><td>20</td><td>-10</td><td>10</td><td>0</td><td>20</td><td>5</td><td>0</td></tr>
+<tr><td>Belly/Leg</td><td>20</td><td>40</td><td>20</td><td>-10</td><td>10</td><td>0</td><td>20</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
-<tr><td>胸</td><td>800</td><td>１ stagger(s) required</td></tr>
+<tr><td>Chest</td><td>800</td><td>１ stagger(s) required</td></tr>
 <tr><td>Back</td><td>1000</td><td></td></tr>
 <tr><td>Leg</td><td>1200</td><td></td></tr>
 <tr><td>Belly</td><td>1200</td><td></td></tr>
 <tr><td>Head</td><td>500</td><td></td></tr>
-<tr><td>顔</td><td>500</td><td>１ stagger(s) required to break Horn<br>２ stagger(s) required<br>３ stagger(s) required</td></tr>
+<tr><td>Face</td><td>500</td><td>１ stagger(s) required to break Horn<br>２ stagger(s) required<br>３ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>700</td><td></td></tr>
 <tr><td>Wing</td><td>800</td><td>１０ stagger(s) required</td></tr>
 </table>

--- a/mons/mono_n.htm
+++ b/mons/mono_n.htm
@@ -66,7 +66,7 @@
 <img id=icon src="../img/monsicons/monoblos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>20</td><td>40</td><td>5</td><td>0</td><td>20</td><td>0</td><td>30</td><td>120</td></tr>
 <tr><td>Neck</td><td>50</td><td>80</td><td>80</td><td>10</td><td>0</td><td>30</td><td>0</td><td>20</td><td>0</td></tr>
@@ -83,8 +83,8 @@
 <tr><td>Torso</td><td>120</td><td></td></tr>
 <tr><td>Left Wing</td><td>100</td><td></td></tr>
 <tr><td>Right Wing</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>150</td><td></td></tr>
-<tr><td>Right Foot</td><td>150</td><td></td></tr>
+<tr><td>Left Leg</td><td>150</td><td></td></tr>
+<tr><td>Right Leg</td><td>150</td><td></td></tr>
 <tr><td>Neck</td><td>100</td><td></td></tr>
 <tr><td>Head</td><td>250</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>180</td><td></td></tr>

--- a/mons/mono_ng.htm
+++ b/mons/mono_ng.htm
@@ -104,7 +104,7 @@
 <img id=icon src="../img/monsicons/monoblos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>20</td><td>40</td><td>5</td><td>0</td><td>20</td><td>0</td><td>30</td><td>120</td></tr>
 <tr><td>Neck</td><td>50</td><td>40</td><td>45</td><td>10</td><td>0</td><td>30</td><td>0</td><td>20</td><td>0</td></tr>
@@ -121,8 +121,8 @@
 <tr><td>Torso</td><td>240</td><td></td></tr>
 <tr><td>Left Wing</td><td>230</td><td></td></tr>
 <tr><td>Right Wing</td><td>230</td><td></td></tr>
-<tr><td>Left Foot</td><td>240</td><td></td></tr>
-<tr><td>Right Foot</td><td>240</td><td></td></tr>
+<tr><td>Left Leg</td><td>240</td><td></td></tr>
+<tr><td>Right Leg</td><td>240</td><td></td></tr>
 <tr><td>Neck</td><td>200</td><td></td></tr>
 <tr><td>Head</td><td>400</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>400</td><td></td></tr>

--- a/mons/monosiro_n.htm
+++ b/mons/monosiro_n.htm
@@ -54,7 +54,7 @@
 <img id=icon src="../img/monsicons/whitemonoblos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>20</td><td>40</td><td>0</td><td>30</td><td>15</td><td>0</td><td>20</td><td>120</td></tr>
 <tr><td>Neck</td><td>50</td><td>70</td><td>70</td><td>0</td><td>20</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
@@ -71,8 +71,8 @@
 <tr><td>Torso</td><td>120</td><td></td></tr>
 <tr><td>Left Wing</td><td>100</td><td></td></tr>
 <tr><td>Right Wing</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>150</td><td></td></tr>
-<tr><td>Right Foot</td><td>150</td><td></td></tr>
+<tr><td>Left Leg</td><td>150</td><td></td></tr>
+<tr><td>Right Leg</td><td>150</td><td></td></tr>
 <tr><td>Neck</td><td>100</td><td></td></tr>
 <tr><td>Head</td><td>250</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>180</td><td></td></tr>

--- a/mons/monosiro_ng.htm
+++ b/mons/monosiro_ng.htm
@@ -103,7 +103,7 @@
 <img id=icon src="../img/monsicons/whitemonoblos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>15</td><td>30</td><td>0</td><td>30</td><td>15</td><td>0</td><td>20</td><td>120</td></tr>
 <tr><td>Neck</td><td>40</td><td>50</td><td>50</td><td>0</td><td>20</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
@@ -120,8 +120,8 @@
 <tr><td>Torso</td><td>240</td><td></td></tr>
 <tr><td>Left Wing</td><td>230</td><td></td></tr>
 <tr><td>Right Wing</td><td>230</td><td></td></tr>
-<tr><td>Left Foot</td><td>240</td><td></td></tr>
-<tr><td>Right Foot</td><td>240</td><td></td></tr>
+<tr><td>Left Leg</td><td>240</td><td></td></tr>
+<tr><td>Right Leg</td><td>240</td><td></td></tr>
 <tr><td>Neck</td><td>200</td><td></td></tr>
 <tr><td>Head</td><td>400</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>400</td><td></td></tr>

--- a/mons/monsF_n.htm
+++ b/mons/monsF_n.htm
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
 <meta http-equiv="content-type" content="text/html; charset=utf-8">
-<title>Hitzone Info</title>
+<title>Hitzones</title>
 </head>
 <style>
 :root {

--- a/mons/mons_n.htm
+++ b/mons/mons_n.htm
@@ -4,7 +4,7 @@
 <meta http-equiv="content-type" content="text/html; charset=utf-8">
 <meta http-equiv="Content-Style-Type" content="text/css">
 <base target="low">
-<title>Hitzone Info</title>
+<title>Hitzones</title>
 <style type="text/css">
 <!--
 body {margin:5px 0 0 7px; padding:0;}

--- a/mons/mos_n.htm
+++ b/mons/mos_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/mosswine.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>150</td><td>150</td><td>120</td><td>100</td><td>100</td><td>100</td><td>10</td><td>100</td><td>0</td></tr>
 </table>

--- a/mons/nalgaK_ng.htm
+++ b/mons/nalgaK_ng.htm
@@ -99,7 +99,7 @@
 <img id=icon src="../img/monsicons/musou_nargacuga.webp" width="500"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>36</td><td>35</td><td>39</td><td>20</td><td>10</td><td>25</td><td>15</td><td>15</td><td>100</td></tr>
 <tr><td>？？</td><td>18</td><td>18</td><td>24</td><td>5</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
@@ -108,7 +108,7 @@
 <tr><td>？？</td><td>24</td><td>24</td><td>25</td><td>10</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>？？</td><td>26</td><td>25</td><td>18</td><td>5</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>？？</td><td>18</td><td>18</td><td>22</td><td>25</td><td>5</td><td>30</td><td>10</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>35</td><td>35</td><td>35</td><td>15</td><td>5</td><td>20</td><td>10</td><td>10</td><td>100</td></tr>
 <tr><td>？？</td><td>18</td><td>18</td><td>14</td><td>5</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>

--- a/mons/nalga_ng.htm
+++ b/mons/nalga_ng.htm
@@ -97,7 +97,7 @@
 <img id=icon src="../img/monsicons/nargacuga.webp" width="350"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>36</td><td>35</td><td>39</td><td>20</td><td>10</td><td>25</td><td>15</td><td>15</td><td>100</td></tr>
 <tr><td>？？</td><td>18</td><td>18</td><td>24</td><td>5</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
@@ -106,7 +106,7 @@
 <tr><td>？？</td><td>24</td><td>24</td><td>25</td><td>10</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>？？</td><td>26</td><td>25</td><td>18</td><td>5</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>？？</td><td>18</td><td>18</td><td>22</td><td>25</td><td>5</td><td>30</td><td>10</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>40</td><td>38</td><td>42</td><td>20</td><td>10</td><td>30</td><td>15</td><td>15</td><td>100</td></tr>
 <tr><td>？？</td><td>18</td><td>18</td><td>24</td><td>5</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>

--- a/mons/nalga_nh.htm
+++ b/mons/nalga_nh.htm
@@ -75,7 +75,7 @@
 <img id=icon src="../img/monsicons/nargacuga.webp" width="350"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>42</td><td>42</td><td>45</td><td>20</td><td>10</td><td>25</td><td>15</td><td>15</td><td>100</td></tr>
 <tr><td>？？</td><td>22</td><td>22</td><td>24</td><td>5</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
@@ -84,7 +84,7 @@
 <tr><td>？？</td><td>30</td><td>30</td><td>32</td><td>10</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>？？</td><td>32</td><td>32</td><td>22</td><td>5</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>？？</td><td>20</td><td>20</td><td>25</td><td>25</td><td>5</td><td>30</td><td>10</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>48</td><td>46</td><td>50</td><td>20</td><td>10</td><td>30</td><td>15</td><td>15</td><td>100</td></tr>
 <tr><td>？？</td><td>22</td><td>22</td><td>24</td><td>5</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>

--- a/mons/nana_n.htm
+++ b/mons/nana_n.htm
@@ -60,22 +60,22 @@
 <img id=icon src="../img/monsicons/lunastra.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>70</td><td>30</td><td>0</td><td>15</td><td>10</td><td>25</td><td>35</td><td>100</td></tr>
 <tr><td>Belly</td><td>35</td><td>50</td><td>25</td><td>0</td><td>10</td><td>5</td><td>15</td><td>20</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>25</td><td>30</td><td>0</td><td>10</td><td>5</td><td>15</td><td>20</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>25</td><td>60</td><td>0</td><td>15</td><td>5</td><td>60</td><td>35</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>25</td><td>20</td><td>0</td><td>10</td><td>5</td><td>15</td><td>20</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>25</td><td>20</td><td>0</td><td>10</td><td>5</td><td>15</td><td>20</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>40</td><td>25</td><td>0</td><td>15</td><td>5</td><td>25</td><td>25</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>15</td><td>20</td><td>0</td><td>10</td><td>5</td><td>15</td><td>20</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(炎纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(炎纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>70</td><td>20</td><td>0</td><td>25</td><td>10</td><td>35</td><td>10</td><td>100</td></tr>
 <tr><td>Belly</td><td>25</td><td>40</td><td>25</td><td>0</td><td>20</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>25</td><td>20</td><td>0</td><td>20</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>25</td><td>40</td><td>0</td><td>25</td><td>5</td><td>40</td><td>10</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>25</td><td>20</td><td>0</td><td>20</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>25</td><td>20</td><td>0</td><td>20</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>30</td><td>25</td><td>0</td><td>25</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>15</td><td>20</td><td>0</td><td>20</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
 </table>
@@ -86,8 +86,8 @@
 <tr><td>Head</td><td>250</td><td>２ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying<br>Deal at least 1 point of Dragon damage</td></tr>
 <tr><td>Torso</td><td>160</td><td></td></tr>
 <tr><td>Tail</td><td>200</td><td></td></tr>
-<tr><td>Left Foot</td><td>180</td><td></td></tr>
-<tr><td>Right Foot</td><td>180</td><td></td></tr>
+<tr><td>Left Leg</td><td>180</td><td></td></tr>
+<tr><td>Right Leg</td><td>180</td><td></td></tr>
 <tr><td>Wing</td><td>90</td><td>２ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying</td></tr>
 <tr><td>-</td><td>200</td><td></td></tr>
 <tr><td>-</td><td>140</td><td></td></tr>

--- a/mons/nana_ng.htm
+++ b/mons/nana_ng.htm
@@ -103,22 +103,22 @@
 <img id=icon src="../img/monsicons/lunastra.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>35</td><td>10</td><td>0</td><td>10</td><td>10</td><td>15</td><td>15</td><td>100</td></tr>
 <tr><td>Belly</td><td>10</td><td>15</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Back</td><td>10</td><td>5</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>25</td><td>30</td><td>0</td><td>10</td><td>5</td><td>25</td><td>20</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>10</td><td>15</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>10</td><td>15</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>15</td><td>15</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>10</td><td>20</td><td>10</td><td>0</td><td>5</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(炎纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(炎纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>35</td><td>10</td><td>0</td><td>15</td><td>10</td><td>10</td><td>5</td><td>100</td></tr>
 <tr><td>Belly</td><td>10</td><td>15</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>10</td><td>5</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>25</td><td>30</td><td>0</td><td>20</td><td>5</td><td>15</td><td>10</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>10</td><td>15</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>10</td><td>15</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>15</td><td>15</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>10</td><td>20</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
 </table>
@@ -129,8 +129,8 @@
 <tr><td>Head</td><td>750</td><td>２ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying<br>Deal at least 1 point of Dragon damage</td></tr>
 <tr><td>Torso</td><td>480</td><td></td></tr>
 <tr><td>Tail</td><td>600</td><td></td></tr>
-<tr><td>Left Foot</td><td>540</td><td></td></tr>
-<tr><td>Right Foot</td><td>540</td><td></td></tr>
+<tr><td>Left Leg</td><td>540</td><td></td></tr>
+<tr><td>Right Leg</td><td>540</td><td></td></tr>
 <tr><td>Wing</td><td>270</td><td>２ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying</td></tr>
 <tr><td>-</td><td>200</td><td></td></tr>
 <tr><td>-</td><td>140</td><td></td></tr>

--- a/mons/nana_nh.htm
+++ b/mons/nana_nh.htm
@@ -81,22 +81,22 @@
 <img id=icon src="../img/monsicons/lunastra.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>10</td><td>0</td><td>30</td><td>10</td><td>20</td><td>30</td><td>100</td></tr>
 <tr><td>Belly</td><td>15</td><td>25</td><td>15</td><td>0</td><td>5</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>10</td><td>10</td><td>20</td><td>0</td><td>5</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>25</td><td>30</td><td>0</td><td>30</td><td>5</td><td>10</td><td>40</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>20</td><td>20</td><td>15</td><td>0</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>20</td><td>20</td><td>15</td><td>0</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>20</td><td>15</td><td>0</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>15</td><td>15</td><td>10</td><td>0</td><td>0</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(炎纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(炎纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>45</td><td>15</td><td>0</td><td>35</td><td>10</td><td>30</td><td>25</td><td>100</td></tr>
 <tr><td>Belly</td><td>20</td><td>30</td><td>10</td><td>0</td><td>10</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>25</td><td>15</td><td>30</td><td>0</td><td>10</td><td>5</td><td>15</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>35</td><td>25</td><td>0</td><td>40</td><td>5</td><td>20</td><td>50</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>20</td><td>10</td><td>0</td><td>-10</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>20</td><td>10</td><td>0</td><td>-10</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>20</td><td>10</td><td>0</td><td>-10</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>15</td><td>15</td><td>20</td><td>0</td><td>0</td><td>5</td><td>20</td><td>0</td><td>0</td></tr>
 </table>
@@ -107,8 +107,8 @@
 <tr><td>Head</td><td>500</td><td>２ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying<br>Deal at least 1 point of Dragon damage</td></tr>
 <tr><td>Torso</td><td>320</td><td></td></tr>
 <tr><td>Tail</td><td>400</td><td></td></tr>
-<tr><td>Left Foot</td><td>360</td><td></td></tr>
-<tr><td>Right Foot</td><td>360</td><td></td></tr>
+<tr><td>Left Leg</td><td>360</td><td></td></tr>
+<tr><td>Right Leg</td><td>360</td><td></td></tr>
 <tr><td>Wing</td><td>180</td><td>２ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying</td></tr>
 <tr><td>-</td><td>200</td><td></td></tr>
 <tr><td>-</td><td>140</td><td></td></tr>

--- a/mons/odiva_ng.htm
+++ b/mons/odiva_ng.htm
@@ -103,33 +103,33 @@
 <img id=icon src="../img/monsicons/odibatorasu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>38</td><td>15</td><td>0</td><td>0</td><td>10</td><td>5</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>30</td><td>25</td><td>35</td><td>0</td><td>5</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>30</td><td>30</td><td>10</td><td>0</td><td>5</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>15</td><td>15</td><td>0</td><td>5</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>20</td><td>25</td><td>25</td><td>0</td><td>0</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>32</td><td>10</td><td>5</td><td>0</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>32</td><td>10</td><td>5</td><td>0</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>15</td><td>18</td><td>15</td><td>5</td><td>5</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>38</td><td>42</td><td>15</td><td>0</td><td>0</td><td>10</td><td>5</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>30</td><td>30</td><td>40</td><td>0</td><td>5</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>35</td><td>35</td><td>10</td><td>0</td><td>5</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>19</td><td>15</td><td>0</td><td>5</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>25</td><td>25</td><td>0</td><td>0</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>36</td><td>10</td><td>5</td><td>0</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>36</td><td>10</td><td>5</td><td>0</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>15</td><td>20</td><td>15</td><td>5</td><td>5</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
-<tr><td>左前脚</td><td>1100</td><td>２ stagger(s) required</td></tr>
-<tr><td>右前脚</td><td>1100</td><td>２ stagger(s) required</td></tr>
-<tr><td>左後脚</td><td>700</td><td></td></tr>
-<tr><td>右後脚</td><td>700</td><td></td></tr>
+<tr><td>Left Foreleg</td><td>1100</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Foreleg</td><td>1100</td><td>２ stagger(s) required</td></tr>
+<tr><td>Left Hind Leg</td><td>700</td><td></td></tr>
+<tr><td>Right Hind Leg</td><td>700</td><td></td></tr>
 <tr><td>Back</td><td>1000</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>800</td><td></td></tr>
 <tr><td>Belly</td><td>2200</td><td></td></tr>

--- a/mons/odiva_nh.htm
+++ b/mons/odiva_nh.htm
@@ -82,33 +82,33 @@
 <img id=icon src="../img/monsicons/odibatorasu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>55</td><td>15</td><td>0</td><td>0</td><td>10</td><td>5</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>35</td><td>30</td><td>35</td><td>0</td><td>5</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>35</td><td>35</td><td>10</td><td>0</td><td>5</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>25</td><td>15</td><td>15</td><td>0</td><td>5</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>25</td><td>25</td><td>0</td><td>0</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>35</td><td>10</td><td>5</td><td>0</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>35</td><td>10</td><td>5</td><td>0</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>15</td><td>20</td><td>15</td><td>5</td><td>5</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>60</td><td>60</td><td>15</td><td>0</td><td>0</td><td>10</td><td>5</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>35</td><td>40</td><td>0</td><td>5</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>40</td><td>40</td><td>10</td><td>0</td><td>5</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>25</td><td>20</td><td>15</td><td>0</td><td>5</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>25</td><td>25</td><td>0</td><td>0</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>40</td><td>10</td><td>5</td><td>0</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>40</td><td>10</td><td>5</td><td>0</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>15</td><td>20</td><td>15</td><td>5</td><td>5</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
-<tr><td>左前脚</td><td>1100</td><td>２ stagger(s) required</td></tr>
-<tr><td>右前脚</td><td>1100</td><td>２ stagger(s) required</td></tr>
-<tr><td>左後脚</td><td>700</td><td></td></tr>
-<tr><td>右後脚</td><td>700</td><td></td></tr>
+<tr><td>Left Foreleg</td><td>1100</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Foreleg</td><td>1100</td><td>２ stagger(s) required</td></tr>
+<tr><td>Left Hind Leg</td><td>700</td><td></td></tr>
+<tr><td>Right Hind Leg</td><td>700</td><td></td></tr>
 <tr><td>Back</td><td>1000</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>800</td><td></td></tr>
 <tr><td>Belly</td><td>2200</td><td></td></tr>

--- a/mons/olgk_n.htm
+++ b/mons/olgk_n.htm
@@ -71,25 +71,25 @@
 <img id=icon src="../img/monsicons/kamuorugaron.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>20</td><td>10</td><td>30</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Back</td><td>25</td><td>35</td><td>30</td><td>5</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>胴</td><td>30</td><td>25</td><td>20</td><td>5</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Torso</td><td>30</td><td>25</td><td>20</td><td>5</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>20</td><td>5</td><td>30</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>25</td><td>30</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>30</td><td>15</td><td>30</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Back</td><td>50</td><td>60</td><td>40</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>胴</td><td>30</td><td>30</td><td>25</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Torso</td><td>30</td><td>30</td><td>25</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>25</td><td>5</td><td>40</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>30</td><td>30</td><td>15</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(咆哮時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(咆哮時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>5</td><td>15</td><td>30</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Back</td><td>50</td><td>60</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>胴</td><td>30</td><td>30</td><td>5</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Torso</td><td>30</td><td>30</td><td>5</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>5</td><td>5</td><td>40</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>30</td><td>5</td><td>15</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
@@ -100,7 +100,7 @@
 <tr><td>Head</td><td>350</td><td>３ stagger(s) required</td></tr>
 <tr><td>Back</td><td>300</td><td>３ stagger(s) required</td></tr>
 <tr><td>Torso</td><td>350</td><td></td></tr>
-<tr><td>Fore Leg</td><td>400</td><td><div>
+<tr><td>Foreleg</td><td>400</td><td><div>
 <span><em>若</em>350</span>
 </div>
 </td></tr>

--- a/mons/olgk_ng.htm
+++ b/mons/olgk_ng.htm
@@ -104,39 +104,39 @@
 <img id=icon src="../img/monsicons/kamuorugaron.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>20</td><td>10</td><td>30</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Back</td><td>25</td><td>35</td><td>30</td><td>5</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>胴</td><td>30</td><td>25</td><td>20</td><td>5</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Torso</td><td>30</td><td>25</td><td>20</td><td>5</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>20</td><td>5</td><td>30</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>25</td><td>30</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>30</td><td>15</td><td>30</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Back</td><td>50</td><td>60</td><td>40</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>胴</td><td>30</td><td>30</td><td>25</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Torso</td><td>30</td><td>30</td><td>25</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>25</td><td>5</td><td>40</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>30</td><td>30</td><td>15</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(咆哮時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(咆哮時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>5</td><td>15</td><td>30</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Back</td><td>50</td><td>60</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>胴</td><td>30</td><td>30</td><td>5</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Torso</td><td>30</td><td>30</td><td>5</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>5</td><td>5</td><td>40</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>30</td><td>5</td><td>15</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質()</th></tr>
+<tr class=l><th colspan=10>Hitzones()</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>35</td><td>15</td><td>20</td><td>30</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Back</td><td>20</td><td>30</td><td>25</td><td>10</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>胴</td><td>25</td><td>20</td><td>15</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Torso</td><td>25</td><td>20</td><td>15</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>15</td><td>5</td><td>80</td><td>0</td><td>0</td><td>0</td><td>-20</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>20</td><td>25</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質()</th></tr>
+<tr class=l><th colspan=10>Hitzones()</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>25</td><td>5</td><td>20</td><td>30</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Back</td><td>10</td><td>20</td><td>15</td><td>10</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>胴</td><td>15</td><td>10</td><td>5</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Torso</td><td>15</td><td>10</td><td>5</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>15</td><td>5</td><td>90</td><td>0</td><td>0</td><td>0</td><td>-30</td><td>0</td></tr>
 <tr><td>Tail</td><td>20</td><td>10</td><td>15</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
@@ -147,7 +147,7 @@
 <tr><td>Head</td><td>400</td><td>３ stagger(s) required</td></tr>
 <tr><td>Back</td><td>350</td><td>３ stagger(s) required</td></tr>
 <tr><td>Torso</td><td>420</td><td></td></tr>
-<tr><td>Fore Leg</td><td>380</td><td></td></tr>
+<tr><td>Foreleg</td><td>380</td><td></td></tr>
 <tr><td>Hind Leg</td><td>380</td><td></td></tr>
 <tr><td>Tail</td><td>350</td><td>３ stagger(s) required</td></tr>
 </table>

--- a/mons/olgk_nh.htm
+++ b/mons/olgk_nh.htm
@@ -82,25 +82,25 @@
 <img id=icon src="../img/monsicons/kamuorugaron.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>30</td><td>15</td><td>10</td><td>20</td><td>5</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Back</td><td>30</td><td>25</td><td>30</td><td>5</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>胴</td><td>25</td><td>25</td><td>15</td><td>5</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Torso</td><td>25</td><td>25</td><td>15</td><td>5</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>15</td><td>15</td><td>5</td><td>30</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>30</td><td>20</td><td>10</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>35</td><td>25</td><td>10</td><td>25</td><td>5</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Back</td><td>40</td><td>45</td><td>30</td><td>15</td><td>0</td><td>5</td><td>0</td><td>30</td><td>0</td></tr>
-<tr><td>胴</td><td>25</td><td>20</td><td>20</td><td>5</td><td>25</td><td>5</td><td>0</td><td>-30</td><td>0</td></tr>
+<tr><td>Torso</td><td>25</td><td>20</td><td>20</td><td>5</td><td>25</td><td>5</td><td>0</td><td>-30</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>20</td><td>5</td><td>30</td><td>5</td><td>0</td><td>-20</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>30</td><td>10</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(咆哮時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(咆哮時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>35</td><td>5</td><td>10</td><td>25</td><td>5</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Back</td><td>40</td><td>45</td><td>5</td><td>15</td><td>0</td><td>5</td><td>0</td><td>30</td><td>0</td></tr>
-<tr><td>胴</td><td>25</td><td>20</td><td>5</td><td>5</td><td>25</td><td>5</td><td>0</td><td>-30</td><td>0</td></tr>
+<tr><td>Torso</td><td>25</td><td>20</td><td>5</td><td>5</td><td>25</td><td>5</td><td>0</td><td>-30</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>5</td><td>5</td><td>30</td><td>5</td><td>0</td><td>-20</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>5</td><td>10</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
@@ -111,7 +111,7 @@
 <tr><td>Head</td><td>350</td><td>３ stagger(s) required</td></tr>
 <tr><td>Back</td><td>300</td><td>３ stagger(s) required</td></tr>
 <tr><td>Torso</td><td>350</td><td></td></tr>
-<tr><td>Fore Leg</td><td>400</td><td></td></tr>
+<tr><td>Foreleg</td><td>400</td><td></td></tr>
 <tr><td>Hind Leg</td><td>400</td><td></td></tr>
 <tr><td>Tail</td><td>300</td><td>３ stagger(s) required</td></tr>
 </table>

--- a/mons/olgn_n.htm
+++ b/mons/olgn_n.htm
@@ -71,25 +71,25 @@
 <img id=icon src="../img/monsicons/nonoorugaron.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>20</td><td>10</td><td>30</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Back</td><td>25</td><td>35</td><td>30</td><td>5</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>胴</td><td>30</td><td>25</td><td>20</td><td>5</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Torso</td><td>30</td><td>25</td><td>20</td><td>5</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>20</td><td>5</td><td>30</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>25</td><td>30</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>30</td><td>15</td><td>30</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Back</td><td>50</td><td>60</td><td>40</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>胴</td><td>30</td><td>30</td><td>25</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Torso</td><td>30</td><td>30</td><td>25</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>25</td><td>5</td><td>40</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>30</td><td>30</td><td>15</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(咆哮時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(咆哮時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>5</td><td>15</td><td>30</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Back</td><td>50</td><td>60</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>胴</td><td>30</td><td>30</td><td>5</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Torso</td><td>30</td><td>30</td><td>5</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>5</td><td>5</td><td>40</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>30</td><td>5</td><td>15</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
@@ -100,7 +100,7 @@
 <tr><td>Head</td><td>350</td><td>３ stagger(s) required</td></tr>
 <tr><td>Back</td><td>300</td><td>３ stagger(s) required</td></tr>
 <tr><td>Torso</td><td>350</td><td></td></tr>
-<tr><td>Fore Leg</td><td>400</td><td><div>
+<tr><td>Foreleg</td><td>400</td><td><div>
 <span><em>若</em>350</span>
 </div>
 </td></tr>

--- a/mons/olgn_ng.htm
+++ b/mons/olgn_ng.htm
@@ -122,39 +122,39 @@
 <img id=icon src="../img/monsicons/nonoorugaron.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>20</td><td>10</td><td>30</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Back</td><td>25</td><td>35</td><td>30</td><td>5</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>胴</td><td>30</td><td>25</td><td>20</td><td>5</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Torso</td><td>30</td><td>25</td><td>20</td><td>5</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>20</td><td>5</td><td>30</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>25</td><td>30</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>30</td><td>15</td><td>30</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Back</td><td>50</td><td>60</td><td>40</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>胴</td><td>30</td><td>30</td><td>25</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Torso</td><td>30</td><td>30</td><td>25</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>25</td><td>5</td><td>40</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>30</td><td>30</td><td>15</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(咆哮時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(咆哮時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>5</td><td>15</td><td>30</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Back</td><td>50</td><td>60</td><td>5</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>胴</td><td>30</td><td>30</td><td>5</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Torso</td><td>30</td><td>30</td><td>5</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>5</td><td>5</td><td>40</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>30</td><td>5</td><td>15</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質()</th></tr>
+<tr class=l><th colspan=10>Hitzones()</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>35</td><td>15</td><td>20</td><td>30</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Back</td><td>20</td><td>30</td><td>25</td><td>10</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>胴</td><td>25</td><td>20</td><td>15</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Torso</td><td>25</td><td>20</td><td>15</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>15</td><td>5</td><td>80</td><td>0</td><td>0</td><td>0</td><td>-20</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>20</td><td>25</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質()</th></tr>
+<tr class=l><th colspan=10>Hitzones()</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>25</td><td>5</td><td>20</td><td>30</td><td>10</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Back</td><td>10</td><td>20</td><td>15</td><td>10</td><td>20</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>胴</td><td>15</td><td>10</td><td>5</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Torso</td><td>15</td><td>10</td><td>5</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>15</td><td>5</td><td>90</td><td>0</td><td>0</td><td>0</td><td>-30</td><td>0</td></tr>
 <tr><td>Tail</td><td>20</td><td>10</td><td>15</td><td>20</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
@@ -165,7 +165,7 @@
 <tr><td>Head</td><td>350</td><td>３ stagger(s) required</td></tr>
 <tr><td>Back</td><td>300</td><td>３ stagger(s) required</td></tr>
 <tr><td>Torso</td><td>370</td><td></td></tr>
-<tr><td>Fore Leg</td><td>330</td><td></td></tr>
+<tr><td>Foreleg</td><td>330</td><td></td></tr>
 <tr><td>Hind Leg</td><td>330</td><td></td></tr>
 <tr><td>Tail</td><td>300</td><td>３ stagger(s) required</td></tr>
 </table>

--- a/mons/olgn_nh.htm
+++ b/mons/olgn_nh.htm
@@ -82,25 +82,25 @@
 <img id=icon src="../img/monsicons/nonoorugaron.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>30</td><td>15</td><td>10</td><td>20</td><td>5</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Back</td><td>30</td><td>25</td><td>30</td><td>5</td><td>15</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>胴</td><td>25</td><td>25</td><td>15</td><td>5</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Torso</td><td>25</td><td>25</td><td>15</td><td>5</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>15</td><td>15</td><td>5</td><td>30</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>30</td><td>20</td><td>10</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>35</td><td>25</td><td>10</td><td>25</td><td>5</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Back</td><td>40</td><td>45</td><td>30</td><td>15</td><td>0</td><td>5</td><td>0</td><td>30</td><td>0</td></tr>
-<tr><td>胴</td><td>25</td><td>20</td><td>20</td><td>5</td><td>25</td><td>5</td><td>0</td><td>-30</td><td>0</td></tr>
+<tr><td>Torso</td><td>25</td><td>20</td><td>20</td><td>5</td><td>25</td><td>5</td><td>0</td><td>-30</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>20</td><td>5</td><td>30</td><td>5</td><td>0</td><td>-20</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>30</td><td>10</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(咆哮時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(咆哮時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>35</td><td>5</td><td>10</td><td>25</td><td>5</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Back</td><td>40</td><td>45</td><td>5</td><td>15</td><td>0</td><td>5</td><td>0</td><td>30</td><td>0</td></tr>
-<tr><td>胴</td><td>25</td><td>20</td><td>5</td><td>5</td><td>25</td><td>5</td><td>0</td><td>-30</td><td>0</td></tr>
+<tr><td>Torso</td><td>25</td><td>20</td><td>5</td><td>5</td><td>25</td><td>5</td><td>0</td><td>-30</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>5</td><td>5</td><td>30</td><td>5</td><td>0</td><td>-20</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>5</td><td>10</td><td>20</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
@@ -111,7 +111,7 @@
 <tr><td>Head</td><td>350</td><td>３ stagger(s) required</td></tr>
 <tr><td>Back</td><td>300</td><td>３ stagger(s) required</td></tr>
 <tr><td>Torso</td><td>350</td><td></td></tr>
-<tr><td>Fore Leg</td><td>400</td><td></td></tr>
+<tr><td>Foreleg</td><td>400</td><td></td></tr>
 <tr><td>Hind Leg</td><td>400</td><td></td></tr>
 <tr><td>Tail</td><td>300</td><td>３ stagger(s) required</td></tr>
 </table>

--- a/mons/oo_n.htm
+++ b/mons/oo_n.htm
@@ -69,22 +69,22 @@
 <img id=icon src="../img/monsicons/chameleos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>40</td><td>40</td><td>0</td><td>0</td><td>20</td><td>25</td><td>35</td><td>100</td></tr>
-<tr><td>胸</td><td>35</td><td>20</td><td>15</td><td>5</td><td>0</td><td>15</td><td>20</td><td>35</td><td>0</td></tr>
+<tr><td>Chest</td><td>35</td><td>20</td><td>15</td><td>5</td><td>0</td><td>15</td><td>20</td><td>35</td><td>0</td></tr>
 <tr><td>Back</td><td>25</td><td>15</td><td>15</td><td>0</td><td>0</td><td>15</td><td>20</td><td>25</td><td>0</td></tr>
-<tr><td>Right Foot</td><td>20</td><td>15</td><td>15</td><td>0</td><td>0</td><td>20</td><td>10</td><td>20</td><td>0</td></tr>
-<tr><td>左脚/腹</td><td>25</td><td>20</td><td>30</td><td>0</td><td>0</td><td>10</td><td>20</td><td>20</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>20</td><td>15</td><td>15</td><td>0</td><td>0</td><td>20</td><td>10</td><td>20</td><td>0</td></tr>
+<tr><td>Left Leg/Belly</td><td>25</td><td>20</td><td>30</td><td>0</td><td>0</td><td>10</td><td>20</td><td>20</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>10</td><td>15</td><td>0</td><td>0</td><td>15</td><td>20</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>20</td><td>15</td><td>15</td><td>0</td><td>0</td><td>10</td><td>5</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(ステルス)</th></tr>
+<tr class=l><th colspan=10>Hitzones(ステルス)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>50</td><td>50</td><td>0</td><td>0</td><td>20</td><td>25</td><td>35</td><td>100</td></tr>
-<tr><td>胸</td><td>30</td><td>25</td><td>15</td><td>5</td><td>0</td><td>15</td><td>20</td><td>25</td><td>0</td></tr>
+<tr><td>Chest</td><td>30</td><td>25</td><td>15</td><td>5</td><td>0</td><td>15</td><td>20</td><td>25</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>15</td><td>10</td><td>0</td><td>0</td><td>15</td><td>20</td><td>20</td><td>0</td></tr>
-<tr><td>Right Foot</td><td>10</td><td>10</td><td>15</td><td>0</td><td>0</td><td>10</td><td>10</td><td>15</td><td>0</td></tr>
-<tr><td>左脚/腹</td><td>20</td><td>15</td><td>15</td><td>0</td><td>0</td><td>15</td><td>20</td><td>20</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>10</td><td>10</td><td>15</td><td>0</td><td>0</td><td>10</td><td>10</td><td>15</td><td>0</td></tr>
+<tr><td>Left Leg/Belly</td><td>20</td><td>15</td><td>15</td><td>0</td><td>0</td><td>15</td><td>20</td><td>20</td><td>0</td></tr>
 <tr><td>Wing</td><td>10</td><td>10</td><td>15</td><td>0</td><td>0</td><td>5</td><td>20</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>15</td><td>15</td><td>15</td><td>0</td><td>0</td><td>10</td><td>5</td><td>10</td><td>0</td></tr>
 </table>
@@ -95,7 +95,7 @@
 <tr><td>Head</td><td>150</td><td>１ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying<br>Deal at least 1 point of Dragon damage</td></tr>
 <tr><td>Belly</td><td>200</td><td></td></tr>
 <tr><td>Back</td><td>200</td><td></td></tr>
-<tr><td>Fore Leg</td><td>180</td><td><div>
+<tr><td>Foreleg</td><td>180</td><td><div>
 <span><em>13</em>249</span><span><em>14</em>253</span><span><em>15</em>258</span><span><em>16</em>263</span><span><em>17</em>268</span>
 </div>
 </td></tr>

--- a/mons/oo_ng.htm
+++ b/mons/oo_ng.htm
@@ -104,22 +104,22 @@
 <img id=icon src="../img/monsicons/chameleos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>38</td><td>36</td><td>36</td><td>5</td><td>0</td><td>5</td><td>30</td><td>35</td><td>100</td></tr>
-<tr><td>胸</td><td>25</td><td>10</td><td>15</td><td>5</td><td>0</td><td>5</td><td>15</td><td>35</td><td>0</td></tr>
+<tr><td>Chest</td><td>25</td><td>10</td><td>15</td><td>5</td><td>0</td><td>5</td><td>15</td><td>35</td><td>0</td></tr>
 <tr><td>Back</td><td>22</td><td>16</td><td>15</td><td>5</td><td>0</td><td>5</td><td>15</td><td>25</td><td>0</td></tr>
-<tr><td>Right Foot</td><td>18</td><td>16</td><td>15</td><td>5</td><td>0</td><td>0</td><td>10</td><td>20</td><td>0</td></tr>
-<tr><td>左脚/腹</td><td>22</td><td>20</td><td>25</td><td>5</td><td>0</td><td>20</td><td>15</td><td>20</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>18</td><td>16</td><td>15</td><td>5</td><td>0</td><td>0</td><td>10</td><td>20</td><td>0</td></tr>
+<tr><td>Left Leg/Belly</td><td>22</td><td>20</td><td>25</td><td>5</td><td>0</td><td>20</td><td>15</td><td>20</td><td>0</td></tr>
 <tr><td>Wing</td><td>18</td><td>25</td><td>15</td><td>5</td><td>0</td><td>20</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>18</td><td>18</td><td>15</td><td>5</td><td>0</td><td>25</td><td>5</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(ステルス)</th></tr>
+<tr class=l><th colspan=10>Hitzones(ステルス)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>38</td><td>42</td><td>5</td><td>0</td><td>10</td><td>30</td><td>35</td><td>100</td></tr>
-<tr><td>胸</td><td>22</td><td>15</td><td>15</td><td>5</td><td>0</td><td>5</td><td>15</td><td>25</td><td>0</td></tr>
+<tr><td>Chest</td><td>22</td><td>15</td><td>15</td><td>5</td><td>0</td><td>5</td><td>15</td><td>25</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>20</td><td>10</td><td>5</td><td>0</td><td>5</td><td>15</td><td>20</td><td>0</td></tr>
-<tr><td>Right Foot</td><td>15</td><td>20</td><td>15</td><td>5</td><td>0</td><td>0</td><td>10</td><td>15</td><td>0</td></tr>
-<tr><td>左脚/腹</td><td>18</td><td>24</td><td>15</td><td>5</td><td>0</td><td>20</td><td>15</td><td>20</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>15</td><td>20</td><td>15</td><td>5</td><td>0</td><td>0</td><td>10</td><td>15</td><td>0</td></tr>
+<tr><td>Left Leg/Belly</td><td>18</td><td>24</td><td>15</td><td>5</td><td>0</td><td>20</td><td>15</td><td>20</td><td>0</td></tr>
 <tr><td>Wing</td><td>15</td><td>25</td><td>15</td><td>5</td><td>0</td><td>20</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>15</td><td>22</td><td>15</td><td>5</td><td>0</td><td>25</td><td>5</td><td>10</td><td>0</td></tr>
 </table>
@@ -130,7 +130,7 @@
 <tr><td>Head</td><td>700</td><td>１ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying<br>Deal at least 1 point of Dragon damage</td></tr>
 <tr><td>Belly</td><td>1800</td><td></td></tr>
 <tr><td>Back</td><td>800</td><td></td></tr>
-<tr><td>Fore Leg</td><td>1200</td><td></td></tr>
+<tr><td>Foreleg</td><td>1200</td><td></td></tr>
 <tr><td>Hind Leg</td><td>1200</td><td></td></tr>
 <tr><td>Wing</td><td>880</td><td></td></tr>
 <tr><td>Tail</td><td>1100</td><td></td></tr>

--- a/mons/oo_nh.htm
+++ b/mons/oo_nh.htm
@@ -82,22 +82,22 @@
 <img id=icon src="../img/monsicons/chameleos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>60</td><td>40</td><td>5</td><td>0</td><td>5</td><td>30</td><td>40</td><td>100</td></tr>
-<tr><td>胸</td><td>35</td><td>20</td><td>15</td><td>5</td><td>0</td><td>-5</td><td>-5</td><td>-5</td><td>0</td></tr>
+<tr><td>Chest</td><td>35</td><td>20</td><td>15</td><td>5</td><td>0</td><td>-5</td><td>-5</td><td>-5</td><td>0</td></tr>
 <tr><td>Back</td><td>25</td><td>15</td><td>15</td><td>5</td><td>0</td><td>-5</td><td>-5</td><td>-5</td><td>0</td></tr>
-<tr><td>Right Foot</td><td>20</td><td>15</td><td>15</td><td>5</td><td>0</td><td>5</td><td>10</td><td>25</td><td>0</td></tr>
-<tr><td>左脚/腹</td><td>20</td><td>35</td><td>30</td><td>5</td><td>0</td><td>30</td><td>-5</td><td>-5</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>20</td><td>15</td><td>15</td><td>5</td><td>0</td><td>5</td><td>10</td><td>25</td><td>0</td></tr>
+<tr><td>Left Leg/Belly</td><td>20</td><td>35</td><td>30</td><td>5</td><td>0</td><td>30</td><td>-5</td><td>-5</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>35</td><td>15</td><td>5</td><td>0</td><td>30</td><td>0</td><td>-5</td><td>0</td></tr>
 <tr><td>Tail</td><td>20</td><td>15</td><td>15</td><td>5</td><td>0</td><td>5</td><td>5</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(ステルス)</th></tr>
+<tr class=l><th colspan=10>Hitzones(ステルス)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>60</td><td>55</td><td>5</td><td>0</td><td>5</td><td>25</td><td>40</td><td>100</td></tr>
-<tr><td>胸</td><td>30</td><td>25</td><td>15</td><td>5</td><td>0</td><td>-10</td><td>-10</td><td>-15</td><td>0</td></tr>
+<tr><td>Chest</td><td>30</td><td>25</td><td>15</td><td>5</td><td>0</td><td>-10</td><td>-10</td><td>-15</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>15</td><td>10</td><td>5</td><td>0</td><td>-10</td><td>-10</td><td>-15</td><td>0</td></tr>
-<tr><td>Right Foot</td><td>15</td><td>10</td><td>15</td><td>5</td><td>0</td><td>5</td><td>10</td><td>25</td><td>0</td></tr>
-<tr><td>左脚/腹</td><td>15</td><td>30</td><td>15</td><td>5</td><td>0</td><td>25</td><td>-5</td><td>-15</td><td>0</td></tr>
+<tr><td>Right Leg</td><td>15</td><td>10</td><td>15</td><td>5</td><td>0</td><td>5</td><td>10</td><td>25</td><td>0</td></tr>
+<tr><td>Left Leg/Belly</td><td>15</td><td>30</td><td>15</td><td>5</td><td>0</td><td>25</td><td>-5</td><td>-15</td><td>0</td></tr>
 <tr><td>Wing</td><td>15</td><td>30</td><td>15</td><td>5</td><td>0</td><td>25</td><td>0</td><td>-15</td><td>0</td></tr>
 <tr><td>Tail</td><td>15</td><td>15</td><td>15</td><td>5</td><td>0</td><td>5</td><td>-5</td><td>15</td><td>0</td></tr>
 </table>
@@ -108,7 +108,7 @@
 <tr><td>Head</td><td>340</td><td>１ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying<br>Deal at least 1 point of Dragon damage</td></tr>
 <tr><td>Belly</td><td>700</td><td></td></tr>
 <tr><td>Back</td><td>180</td><td></td></tr>
-<tr><td>Fore Leg</td><td>320</td><td></td></tr>
+<tr><td>Foreleg</td><td>320</td><td></td></tr>
 <tr><td>Hind Leg</td><td>320</td><td></td></tr>
 <tr><td>Wing</td><td>270</td><td></td></tr>
 <tr><td>Tail</td><td>200</td><td></td></tr>

--- a/mons/paria_n.htm
+++ b/mons/paria_n.htm
@@ -72,17 +72,17 @@
 <img id=icon src="../img/monsicons/pariapuria.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>80</td><td>40</td><td>30</td><td>0</td><td>5</td><td>0</td><td>5</td><td>100</td></tr>
-<tr><td>胴</td><td>50</td><td>30</td><td>20</td><td>20</td><td>0</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Torso</td><td>50</td><td>30</td><td>20</td><td>20</td><td>0</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>30</td><td>50</td><td>25</td><td>10</td><td>0</td><td>25</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>30</td><td>50</td><td>25</td><td>10</td><td>0</td><td>25</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>20</td><td>75</td><td>20</td><td>0</td><td>20</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(満腹時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(満腹時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>80</td><td>40</td><td>40</td><td>0</td><td>20</td><td>0</td><td>5</td><td>100</td></tr>
-<tr><td>胴</td><td>50</td><td>30</td><td>20</td><td>50</td><td>0</td><td>20</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Torso</td><td>50</td><td>30</td><td>20</td><td>50</td><td>0</td><td>20</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>30</td><td>50</td><td>25</td><td>20</td><td>0</td><td>30</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>30</td><td>50</td><td>25</td><td>20</td><td>0</td><td>30</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>20</td><td>75</td><td>50</td><td>0</td><td>40</td><td>0</td><td>5</td><td>0</td></tr>
@@ -101,11 +101,11 @@
 ２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>300</td><td></td></tr>
 <tr><td>Right Wing</td><td>300</td><td></td></tr>
-<tr><td>Left Foot</td><td>400</td><td><div>
+<tr><td>Left Leg</td><td>400</td><td><div>
 <span><em>若</em>350</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>400</td><td><div>
+<tr><td>Right Leg</td><td>400</td><td><div>
 <span><em>若</em>350</span>
 </div>
 </td></tr>

--- a/mons/paria_ng.htm
+++ b/mons/paria_ng.htm
@@ -89,17 +89,17 @@
 <img id=icon src="../img/monsicons/pariapuria.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>60</td><td>40</td><td>30</td><td>0</td><td>5</td><td>0</td><td>5</td><td>100</td></tr>
-<tr><td>胴</td><td>30</td><td>30</td><td>20</td><td>20</td><td>0</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Torso</td><td>30</td><td>30</td><td>20</td><td>20</td><td>0</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>30</td><td>25</td><td>10</td><td>0</td><td>25</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>30</td><td>25</td><td>10</td><td>0</td><td>25</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>55</td><td>20</td><td>55</td><td>20</td><td>0</td><td>20</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(満腹時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(満腹時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>60</td><td>40</td><td>40</td><td>0</td><td>20</td><td>0</td><td>5</td><td>100</td></tr>
-<tr><td>胴</td><td>30</td><td>30</td><td>20</td><td>50</td><td>0</td><td>20</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Torso</td><td>30</td><td>30</td><td>20</td><td>50</td><td>0</td><td>20</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>30</td><td>25</td><td>20</td><td>0</td><td>30</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>30</td><td>25</td><td>20</td><td>0</td><td>30</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>55</td><td>20</td><td>55</td><td>50</td><td>0</td><td>40</td><td>0</td><td>5</td><td>0</td></tr>
@@ -112,8 +112,8 @@
 <tr><td>Torso</td><td>800</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>500</td><td></td></tr>
 <tr><td>Right Wing</td><td>500</td><td></td></tr>
-<tr><td>Left Foot</td><td>550</td><td></td></tr>
-<tr><td>Right Foot</td><td>550</td><td></td></tr>
+<tr><td>Left Leg</td><td>550</td><td></td></tr>
+<tr><td>Right Leg</td><td>550</td><td></td></tr>
 <tr><td>Tail</td><td>700</td><td>３ stagger(s) required</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/pariapuria.png" width="400"/>

--- a/mons/paria_nh.htm
+++ b/mons/paria_nh.htm
@@ -70,17 +70,17 @@
 <img id=icon src="../img/monsicons/pariapuria.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>70</td><td>30</td><td>30</td><td>0</td><td>5</td><td>0</td><td>5</td><td>100</td></tr>
-<tr><td>胴</td><td>40</td><td>20</td><td>10</td><td>20</td><td>0</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Torso</td><td>40</td><td>20</td><td>10</td><td>20</td><td>0</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>40</td><td>15</td><td>10</td><td>0</td><td>25</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>40</td><td>15</td><td>10</td><td>0</td><td>25</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>10</td><td>65</td><td>20</td><td>0</td><td>20</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(満腹時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(満腹時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>70</td><td>30</td><td>5</td><td>0</td><td>30</td><td>0</td><td>5</td><td>100</td></tr>
-<tr><td>胴</td><td>40</td><td>20</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Torso</td><td>40</td><td>20</td><td>10</td><td>10</td><td>0</td><td>20</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>40</td><td>15</td><td>25</td><td>0</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>40</td><td>15</td><td>25</td><td>0</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>10</td><td>65</td><td>20</td><td>0</td><td>20</td><td>0</td><td>5</td><td>0</td></tr>
@@ -93,8 +93,8 @@
 <tr><td>Torso</td><td>600</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>300</td><td></td></tr>
 <tr><td>Right Wing</td><td>300</td><td></td></tr>
-<tr><td>Left Foot</td><td>400</td><td></td></tr>
-<tr><td>Right Foot</td><td>400</td><td></td></tr>
+<tr><td>Left Leg</td><td>400</td><td></td></tr>
+<tr><td>Right Leg</td><td>400</td><td></td></tr>
 <tr><td>Tail</td><td>500</td><td>３ stagger(s) required</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/pariapuria.png" width="400"/>

--- a/mons/paria_nt.htm
+++ b/mons/paria_nt.htm
@@ -88,17 +88,17 @@
 <img id=icon src="../img/monsicons/pariapuria.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>60</td><td>40</td><td>30</td><td>0</td><td>5</td><td>0</td><td>5</td><td>100</td></tr>
-<tr><td>胴</td><td>30</td><td>30</td><td>20</td><td>20</td><td>0</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Torso</td><td>30</td><td>30</td><td>20</td><td>20</td><td>0</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>30</td><td>25</td><td>10</td><td>0</td><td>25</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>30</td><td>25</td><td>10</td><td>0</td><td>25</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>55</td><td>20</td><td>55</td><td>20</td><td>0</td><td>20</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(満腹時)</th></tr>
+<tr class=l><th colspan=10>Hitzones(満腹時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>60</td><td>40</td><td>40</td><td>0</td><td>20</td><td>0</td><td>5</td><td>100</td></tr>
-<tr><td>胴</td><td>30</td><td>30</td><td>20</td><td>50</td><td>0</td><td>20</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Torso</td><td>30</td><td>30</td><td>20</td><td>50</td><td>0</td><td>20</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>30</td><td>25</td><td>20</td><td>0</td><td>30</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>30</td><td>25</td><td>20</td><td>0</td><td>30</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>55</td><td>20</td><td>55</td><td>50</td><td>0</td><td>40</td><td>0</td><td>5</td><td>0</td></tr>
@@ -111,8 +111,8 @@
 <tr><td>Torso</td><td>600</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>300</td><td></td></tr>
 <tr><td>Right Wing</td><td>300</td><td></td></tr>
-<tr><td>Left Foot</td><td>400</td><td></td></tr>
-<tr><td>Right Foot</td><td>400</td><td></td></tr>
+<tr><td>Left Leg</td><td>400</td><td></td></tr>
+<tr><td>Right Leg</td><td>400</td><td></td></tr>
 <tr><td>Tail</td><td>500</td><td>３ stagger(s) required</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/pariapuria.png" width="400"/>

--- a/mons/pobol_ng.htm
+++ b/mons/pobol_ng.htm
@@ -111,7 +111,7 @@
 <tr><td>Hind Leg</td><td>20</td><td>25</td><td>15</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>35</td><td>30</td><td>30</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>40</td><td>35</td><td>10</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>翼膜</td><td>35</td><td>30</td><td>30</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Webbing</td><td>35</td><td>30</td><td>30</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>

--- a/mons/pobol_ng.htm
+++ b/mons/pobol_ng.htm
@@ -103,11 +103,11 @@
 <img id=icon src="../img/monsicons/poborubarumu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Torso</td><td>25</td><td>20</td><td>15</td><td>5</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>30</td><td>10</td><td>0</td><td>15</td><td>0</td><td>0</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>35</td><td>25</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>35</td><td>25</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>25</td><td>15</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>35</td><td>30</td><td>30</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>40</td><td>35</td><td>10</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
@@ -121,10 +121,10 @@
 <tr><td>Belly</td><td>1200</td><td></td></tr>
 <tr><td>Back</td><td>1400</td><td></td></tr>
 <tr><td>Tail</td><td>900</td><td>２ stagger(s) required</td></tr>
-<tr><td>右前脚</td><td>1200</td><td>２ stagger(s) required<br>(Both will break)</td></tr>
-<tr><td>右後脚</td><td>1200</td><td></td></tr>
-<tr><td>左前脚</td><td>1200</td><td>２ stagger(s) required</td></tr>
-<tr><td>左後脚</td><td>1200</td><td></td></tr>
+<tr><td>Right Foreleg</td><td>1200</td><td>２ stagger(s) required<br>(Both will break)</td></tr>
+<tr><td>Right Hind Leg</td><td>1200</td><td></td></tr>
+<tr><td>Left Foreleg</td><td>1200</td><td>２ stagger(s) required</td></tr>
+<tr><td>Left Hind Leg</td><td>1200</td><td></td></tr>
 <tr><td>？</td><td>1500</td><td></td></tr>
 </table>
 <img id=hitzones src="../img/monszones/poborubarumu.png" width="400"/>

--- a/mons/pobol_nh.htm
+++ b/mons/pobol_nh.htm
@@ -76,11 +76,11 @@
 <img id=icon src="../img/monsicons/poborubarumu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Torso</td><td>30</td><td>25</td><td>20</td><td>5</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Head</td><td>45</td><td>50</td><td>40</td><td>10</td><td>0</td><td>15</td><td>0</td><td>0</td><td>100</td></tr>
-<tr><td>Fore Leg</td><td>40</td><td>45</td><td>35</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>40</td><td>45</td><td>35</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>25</td><td>20</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>45</td><td>40</td><td>35</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>45</td><td>40</td><td>10</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
@@ -94,10 +94,10 @@
 <tr><td>Belly</td><td>600</td><td></td></tr>
 <tr><td>Back</td><td>700</td><td></td></tr>
 <tr><td>Tail</td><td>500</td><td>２ stagger(s) required</td></tr>
-<tr><td>右前脚</td><td>600</td><td>２ stagger(s) required<br>(Both will break)</td></tr>
-<tr><td>右後脚</td><td>600</td><td></td></tr>
-<tr><td>左前脚</td><td>600</td><td>２ stagger(s) required</td></tr>
-<tr><td>左後脚</td><td>600</td><td></td></tr>
+<tr><td>Right Foreleg</td><td>600</td><td>２ stagger(s) required<br>(Both will break)</td></tr>
+<tr><td>Right Hind Leg</td><td>600</td><td></td></tr>
+<tr><td>Left Foreleg</td><td>600</td><td>２ stagger(s) required</td></tr>
+<tr><td>Left Hind Leg</td><td>600</td><td></td></tr>
 <tr><td>？</td><td>800</td><td></td></tr>
 </table>
 <img id=hitzones src="../img/monszones/poborubarumu.png" width="400"/>

--- a/mons/pobol_nh.htm
+++ b/mons/pobol_nh.htm
@@ -84,7 +84,7 @@
 <tr><td>Hind Leg</td><td>25</td><td>25</td><td>20</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>45</td><td>40</td><td>35</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>45</td><td>40</td><td>10</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>翼膜</td><td>40</td><td>35</td><td>40</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Webbing</td><td>40</td><td>35</td><td>40</td><td>5</td><td>0</td><td>10</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>

--- a/mons/pokara_ng.htm
+++ b/mons/pokara_ng.htm
@@ -81,11 +81,11 @@
 <img id=icon src="../img/monsicons/pokara.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>55</td><td>65</td><td>15</td><td>10</td><td>5</td><td>20</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Torso</td><td>45</td><td>45</td><td>20</td><td>10</td><td>5</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>45</td><td>45</td><td>35</td><td>10</td><td>5</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>45</td><td>45</td><td>35</td><td>10</td><td>5</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>35</td><td>30</td><td>10</td><td>10</td><td>5</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>30</td><td>15</td><td>10</td><td>5</td><td>20</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
@@ -95,11 +95,11 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>100</td><td></td></tr>
 <tr><td>Torso</td><td>150</td><td></td></tr>
-<tr><td>右前脚</td><td>100</td><td></td></tr>
-<tr><td>左前脚</td><td>100</td><td></td></tr>
+<tr><td>Right Foreleg</td><td>100</td><td></td></tr>
+<tr><td>Left Foreleg</td><td>100</td><td></td></tr>
 <tr><td>Back</td><td>100</td><td></td></tr>
-<tr><td>右後脚</td><td>100</td><td></td></tr>
-<tr><td>左後脚</td><td>100</td><td></td></tr>
+<tr><td>Right Hind Leg</td><td>100</td><td></td></tr>
+<tr><td>Left Hind Leg</td><td>100</td><td></td></tr>
 </table>
 <img id=hitzones src="../img/monszones/pokara.png" width="400"/>
 <script type="text/javascript" src="hover.js"></script>

--- a/mons/pokaradon_ng.htm
+++ b/mons/pokaradon_ng.htm
@@ -97,11 +97,11 @@
 <img id=icon src="../img/monsicons/pokaradon.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>50</td><td>25</td><td>5</td><td>5</td><td>15</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Torso</td><td>30</td><td>35</td><td>20</td><td>20</td><td>5</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>45</td><td>35</td><td>15</td><td>5</td><td>5</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>45</td><td>35</td><td>15</td><td>5</td><td>5</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>30</td><td>35</td><td>10</td><td>5</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>25</td><td>40</td><td>0</td><td>5</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>-</td><td>25</td><td>35</td><td>30</td><td>0</td><td>5</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
@@ -113,12 +113,12 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>500</td><td>２ stagger(s) required</td></tr>
 <tr><td>Torso</td><td>800</td><td></td></tr>
-<tr><td>右前脚</td><td>450</td><td></td></tr>
-<tr><td>左前脚</td><td>450</td><td></td></tr>
+<tr><td>Right Foreleg</td><td>450</td><td></td></tr>
+<tr><td>Left Foreleg</td><td>450</td><td></td></tr>
 <tr><td>Back</td><td>300</td><td>２ stagger(s) required</td></tr>
-<tr><td>右後脚</td><td>450</td><td></td></tr>
-<tr><td>左後脚</td><td>450</td><td></td></tr>
-<tr><td>尾</td><td>900</td><td></td></tr>
+<tr><td>Right Hind Leg</td><td>450</td><td></td></tr>
+<tr><td>Left Hind Leg</td><td>450</td><td></td></tr>
+<tr><td>Tail</td><td>900</td><td></td></tr>
 </table>
 <img id=hitzones src="../img/monszones/pokaradon.png" width="400"/>
 <script type="text/javascript" src="hover.js"></script>

--- a/mons/popo_n.htm
+++ b/mons/popo_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/popo.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>100</td><td>100</td><td>100</td><td>50</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
 </table>

--- a/mons/qual_n.htm
+++ b/mons/qual_n.htm
@@ -62,12 +62,12 @@
 <img id=icon src="../img/monsicons/kuarusepusu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>45</td><td>25</td><td>20</td><td>5</td><td>10</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>25</td><td>15</td><td>20</td><td>10</td><td>5</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Belly</td><td>50</td><td>40</td><td>15</td><td>0</td><td>5</td><td>30</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>40</td><td>30</td><td>20</td><td>10</td><td>5</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>40</td><td>30</td><td>20</td><td>10</td><td>5</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>40</td><td>30</td><td>25</td><td>10</td><td>5</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Back</td><td>25</td><td>35</td><td>35</td><td>15</td><td>5</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>15</td><td>25</td><td>20</td><td>15</td><td>5</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
@@ -78,12 +78,12 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>400</td><td>2nd time breaks head</td></tr>
 <tr><td>Belly</td><td>700</td><td></td></tr>
-<tr><td>左前脚</td><td>500</td><td>２ stagger(s) required</td></tr>
-<tr><td>右前脚</td><td>500</td><td>２ stagger(s) required</td></tr>
-<tr><td>左後脚</td><td>500</td><td>２ stagger(s) required</td></tr>
-<tr><td>右後脚</td><td>500</td><td>２ stagger(s) required</td></tr>
+<tr><td>Left Foreleg</td><td>500</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Foreleg</td><td>500</td><td>２ stagger(s) required</td></tr>
+<tr><td>Left Hind Leg</td><td>500</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Hind Leg</td><td>500</td><td>２ stagger(s) required</td></tr>
 <tr><td>Back</td><td>600</td><td>２ stagger(s) required</td></tr>
-<tr><td>尾</td><td>200</td><td>２ stagger(s) required</td></tr>
+<tr><td>Tail</td><td>200</td><td>２ stagger(s) required</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/kuarusepusu.png" width="400"/>
 <script type="text/javascript" src="hover.js"></script>

--- a/mons/qual_ng.htm
+++ b/mons/qual_ng.htm
@@ -123,12 +123,12 @@
 <img id=icon src="../img/monsicons/kuarusepusu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>40</td><td>25</td><td>25</td><td>5</td><td>5</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>25</td><td>15</td><td>15</td><td>10</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Belly</td><td>45</td><td>35</td><td>10</td><td>0</td><td>5</td><td>30</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>25</td><td>20</td><td>5</td><td>5</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>25</td><td>20</td><td>5</td><td>5</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>30</td><td>20</td><td>5</td><td>5</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Back</td><td>25</td><td>30</td><td>35</td><td>15</td><td>5</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>15</td><td>25</td><td>20</td><td>20</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
@@ -139,12 +139,12 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>600</td><td>2nd time breaks head</td></tr>
 <tr><td>Belly</td><td>900</td><td></td></tr>
-<tr><td>左前脚</td><td>700</td><td>２ stagger(s) required</td></tr>
-<tr><td>右前脚</td><td>700</td><td>２ stagger(s) required</td></tr>
-<tr><td>左後脚</td><td>900</td><td>２ stagger(s) required</td></tr>
-<tr><td>右後脚</td><td>900</td><td>２ stagger(s) required</td></tr>
+<tr><td>Left Foreleg</td><td>700</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Foreleg</td><td>700</td><td>２ stagger(s) required</td></tr>
+<tr><td>Left Hind Leg</td><td>900</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Hind Leg</td><td>900</td><td>２ stagger(s) required</td></tr>
 <tr><td>Back</td><td>1000</td><td>２ stagger(s) required</td></tr>
-<tr><td>尾</td><td>400</td><td>２ stagger(s) required</td></tr>
+<tr><td>Tail</td><td>400</td><td>２ stagger(s) required</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/kuarusepusu.png" width="400"/>
 <script type="text/javascript" src="hover.js"></script>

--- a/mons/qual_nh.htm
+++ b/mons/qual_nh.htm
@@ -81,12 +81,12 @@
 <img id=icon src="../img/monsicons/kuarusepusu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>40</td><td>25</td><td>10</td><td>5</td><td>5</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>25</td><td>15</td><td>15</td><td>5</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Belly</td><td>45</td><td>35</td><td>10</td><td>0</td><td>5</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>30</td><td>20</td><td>5</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>30</td><td>20</td><td>5</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>35</td><td>30</td><td>20</td><td>5</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Back</td><td>25</td><td>35</td><td>30</td><td>10</td><td>5</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>15</td><td>25</td><td>20</td><td>10</td><td>5</td><td>5</td><td>0</td><td>5</td><td>0</td></tr>
@@ -97,12 +97,12 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>450</td><td>2nd time breaks head</td></tr>
 <tr><td>Belly</td><td>750</td><td></td></tr>
-<tr><td>左前脚</td><td>550</td><td>２ stagger(s) required</td></tr>
-<tr><td>右前脚</td><td>550</td><td>２ stagger(s) required</td></tr>
-<tr><td>左後脚</td><td>600</td><td>２ stagger(s) required</td></tr>
-<tr><td>右後脚</td><td>600</td><td>２ stagger(s) required</td></tr>
+<tr><td>Left Foreleg</td><td>550</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Foreleg</td><td>550</td><td>２ stagger(s) required</td></tr>
+<tr><td>Left Hind Leg</td><td>600</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Hind Leg</td><td>600</td><td>２ stagger(s) required</td></tr>
 <tr><td>Back</td><td>700</td><td>２ stagger(s) required</td></tr>
-<tr><td>尾</td><td>300</td><td>２ stagger(s) required</td></tr>
+<tr><td>Tail</td><td>300</td><td>２ stagger(s) required</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/kuarusepusu.png" width="400"/>
 <script type="text/javascript" src="hover.js"></script>

--- a/mons/ra-ro_n.htm
+++ b/mons/ra-ro_n.htm
@@ -7,7 +7,7 @@
 </head><body>
 <div id=monsname>Unknown</div><div id=tophosoku><a href="ra-ro_nh.htm">Henshu</a>／<a href="ra-ro_ng.htm">GR</a>／<a href="ra-ro_h.htm">Carves</a></div>
 <div id=hosoku>
-<span><em>Roar</em>大/怒3特</span><span><em>Wind Pres.</em>Dragon</span><span><em>Tremor</em>－/Weak</span><span><em>Pitfall T.</em>20s/怒3無効</span><span><em>Shock T.</em>8s/怒3無効</span><span><em>Flash</em>30s/怒3無効</span><span><em>肉質移行</em><a style="margin:0" href="ra-ro-memo.htm">Details</a></span>
+<span><em>Roar</em>大/怒3特</span><span><em>Wind Pres.</em>Dragon</span><span><em>Tremor</em>－/Weak</span><span><em>Pitfall T.</em>20s/怒3無効</span><span><em>Shock T.</em>8s/怒3無効</span><span><em>Flash</em>30s/怒3無効</span><span><em>Hitzones移行</em><a style="margin:0" href="ra-ro-memo.htm">Details</a></span>
 </div>
 <table id=izyo>
 <col class=c1><col class=c2><col class=c3><col class=c4><col class=c5>
@@ -78,7 +78,7 @@
 <img id=icon src="../img/monsicons/unknown.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>60</td><td>40</td><td>40</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>50</td><td>10</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
@@ -87,7 +87,7 @@
 <tr><td>Tail</td><td>40</td><td>30</td><td>25</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>20</td><td>25</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>45</td><td>40</td><td>50</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(状態1)</th></tr>
+<tr class=l><th colspan=10>Hitzones(状態1)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>40</td><td>40</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>40</td><td>10</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
@@ -96,7 +96,7 @@
 <tr><td>Tail</td><td>40</td><td>30</td><td>25</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>20</td><td>25</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>45</td><td>40</td><td>40</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(状態2)</th></tr>
+<tr class=l><th colspan=10>Hitzones(状態2)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>40</td><td>30</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>40</td><td>10</td><td>15</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
@@ -105,7 +105,7 @@
 <tr><td>Tail</td><td>40</td><td>30</td><td>25</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>20</td><td>25</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>45</td><td>40</td><td>30</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(状態3)</th></tr>
+<tr class=l><th colspan=10>Hitzones(状態3)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>45</td><td>30</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>40</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
@@ -114,7 +114,7 @@
 <tr><td>Tail</td><td>40</td><td>30</td><td>25</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>35</td><td>20</td><td>25</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>35</td><td>35</td><td>25</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(状態4)</th></tr>
+<tr class=l><th colspan=10>Hitzones(状態4)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>45</td><td>25</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>30</td><td>5</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
@@ -123,7 +123,7 @@
 <tr><td>Tail</td><td>40</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>40</td><td>20</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>30</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(状態5)</th></tr>
+<tr class=l><th colspan=10>Hitzones(状態5)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>55</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>30</td><td>30</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
@@ -149,11 +149,11 @@ Rage state 4:１ stagger(s) required</td></tr>
 <span><em>6</em>300</span><span><em>6(状態2,3)</em>400</span><span><em>6(状態4)</em>500</span><span><em>6(状態5,6)</em>700</span>
 </div>
 Rage state 4:１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>250</td><td><div>
+<tr><td>Left Leg</td><td>250</td><td><div>
 <span><em>6</em>375</span><span><em>6(状態2,3)</em>600</span><span><em>6(状態4)</em>625</span><span><em>6(状態5,6)</em>875</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>250</td><td><div>
+<tr><td>Right Leg</td><td>250</td><td><div>
 <span><em>6</em>375</span><span><em>6(状態2,3)</em>500</span><span><em>6(状態4)</em>625</span><span><em>6(状態5,6)</em>875</span>
 </div>
 </td></tr>

--- a/mons/ra-ro_ng.htm
+++ b/mons/ra-ro_ng.htm
@@ -7,7 +7,7 @@
 </head><body>
 <div id=monsname>Unknown[GR]</div><div id=tophosoku><a href="ra-ro_n.htm">Normal</a>／<a href="ra-ro_nh.htm">Henshu</a>／<a href="ra-ro_h.htm">Carves</a></div>
 <div id=hosoku>
-<span><em>Roar</em>大/怒3特</span><span><em>Wind Pres.</em>Dragon</span><span><em>Tremor</em>－/Weak</span><span><em>Pitfall T.</em>20s/怒3無効</span><span><em>Shock T.</em>8s/怒3無効</span><span><em>Flash</em>30s/怒3無効</span><span><em>肉質移行</em><a style="margin:0" href="ra-ro-memo.htm">Details</a></span>
+<span><em>Roar</em>大/怒3特</span><span><em>Wind Pres.</em>Dragon</span><span><em>Tremor</em>－/Weak</span><span><em>Pitfall T.</em>20s/怒3無効</span><span><em>Shock T.</em>8s/怒3無効</span><span><em>Flash</em>30s/怒3無効</span><span><em>Hitzones移行</em><a style="margin:0" href="ra-ro-memo.htm">Details</a></span>
 </div>
 <table id=izyo>
 <col class=c1><col class=c2><col class=c3><col class=c4><col class=c5>
@@ -112,7 +112,7 @@
 <img id=icon src="../img/monsicons/unknown.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>60</td><td>40</td><td>40</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>50</td><td>10</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
@@ -121,7 +121,7 @@
 <tr><td>Tail</td><td>40</td><td>30</td><td>25</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>20</td><td>25</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>45</td><td>40</td><td>50</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(状態1)</th></tr>
+<tr class=l><th colspan=10>Hitzones(状態1)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>40</td><td>40</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>40</td><td>10</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
@@ -130,7 +130,7 @@
 <tr><td>Tail</td><td>40</td><td>30</td><td>25</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>20</td><td>25</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>45</td><td>40</td><td>40</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(状態2)</th></tr>
+<tr class=l><th colspan=10>Hitzones(状態2)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>40</td><td>30</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>40</td><td>10</td><td>15</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
@@ -139,7 +139,7 @@
 <tr><td>Tail</td><td>40</td><td>30</td><td>25</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>20</td><td>25</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>45</td><td>40</td><td>30</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(状態3)</th></tr>
+<tr class=l><th colspan=10>Hitzones(状態3)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>45</td><td>30</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>40</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
@@ -148,7 +148,7 @@
 <tr><td>Tail</td><td>40</td><td>30</td><td>25</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>35</td><td>20</td><td>25</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>35</td><td>35</td><td>25</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(状態4)</th></tr>
+<tr class=l><th colspan=10>Hitzones(状態4)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>45</td><td>25</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>30</td><td>5</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
@@ -157,7 +157,7 @@
 <tr><td>Tail</td><td>40</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>40</td><td>20</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>30</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(状態5)</th></tr>
+<tr class=l><th colspan=10>Hitzones(状態5)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>55</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>30</td><td>30</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
@@ -166,7 +166,7 @@
 <tr><td>Tail</td><td>55</td><td>30</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>20</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>30</td><td>30</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(状態6)</th></tr>
+<tr class=l><th colspan=10>Hitzones(状態6)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>55</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>30</td><td>30</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
@@ -175,7 +175,7 @@
 <tr><td>Tail</td><td>55</td><td>30</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>20</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>30</td><td>30</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(状態7)</th></tr>
+<tr class=l><th colspan=10>Hitzones(状態7)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>40</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>35</td><td>20</td><td>30</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
@@ -184,7 +184,7 @@
 <tr><td>Tail</td><td>40</td><td>25</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>25</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>15</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(？？)</th></tr>
+<tr class=l><th colspan=10>Hitzones(？？)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>50</td><td>25</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>45</td><td>30</td><td>35</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
@@ -210,11 +210,11 @@ Rage state 4:１ stagger(s) required</td></tr>
 <span><em>53</em>400</span><span><em>53(状態2)</em>440</span><span><em>53(状態3)</em>560</span><span><em>53(状態4)</em>600</span><span><em>53(状態5)</em>640</span><span><em>53(状態6)</em>700</span><span><em>53(状態7)</em>2400</span>
 </div>
 Rage state 4:１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>250</td><td><div>
+<tr><td>Left Leg</td><td>250</td><td><div>
 <span><em>53</em>500</span><span><em>53(状態2)</em>1100</span><span><em>53(状態3)</em>1400</span><span><em>53(状態4)</em>1500</span><span><em>53(状態5)</em>1600</span><span><em>53(状態6)</em>1750</span><span><em>53(状態7)</em>3000</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>250</td><td><div>
+<tr><td>Right Leg</td><td>250</td><td><div>
 <span><em>53</em>500</span><span><em>53(状態2)</em>550</span><span><em>53(状態3)</em>1400</span><span><em>53(状態4)</em>1500</span><span><em>53(状態5)</em>1600</span><span><em>53(状態6)</em>1750</span><span><em>53(状態7)</em>3000</span>
 </div>
 </td></tr>

--- a/mons/ra-ro_nh.htm
+++ b/mons/ra-ro_nh.htm
@@ -7,7 +7,7 @@
 </head><body>
 <div id=monsname>Unknown[Henshu]</div><div id=tophosoku><a href="ra-ro_n.htm">Normal</a>／<a href="ra-ro_ng.htm">GR</a>／<a href="ra-ro_h.htm">Carves</a></div>
 <div id=hosoku>
-<span><em>Roar</em>大/怒3特</span><span><em>Wind Pres.</em>Dragon</span><span><em>Tremor</em>－/Weak</span><span><em>Pitfall T.</em>20s/怒3無効</span><span><em>Shock T.</em>8s/怒3無効</span><span><em>Flash</em>30s/怒3無効</span><span><em>肉質移行</em><a style="margin:0" href="ra-ro-memo.htm">Details</a></span>
+<span><em>Roar</em>大/怒3特</span><span><em>Wind Pres.</em>Dragon</span><span><em>Tremor</em>－/Weak</span><span><em>Pitfall T.</em>20s/怒3無効</span><span><em>Shock T.</em>8s/怒3無効</span><span><em>Flash</em>30s/怒3無効</span><span><em>Hitzones移行</em><a style="margin:0" href="ra-ro-memo.htm">Details</a></span>
 </div>
 <table id=izyo>
 <col class=c1><col class=c2><col class=c3><col class=c4><col class=c5>
@@ -92,7 +92,7 @@
 <img id=icon src="../img/monsicons/unknown.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>60</td><td>40</td><td>40</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>50</td><td>10</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
@@ -101,7 +101,7 @@
 <tr><td>Tail</td><td>40</td><td>30</td><td>25</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>20</td><td>25</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>45</td><td>40</td><td>50</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(状態1)</th></tr>
+<tr class=l><th colspan=10>Hitzones(状態1)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>40</td><td>40</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>40</td><td>10</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
@@ -110,7 +110,7 @@
 <tr><td>Tail</td><td>40</td><td>30</td><td>25</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>20</td><td>25</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>45</td><td>40</td><td>40</td><td>0</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(状態2)</th></tr>
+<tr class=l><th colspan=10>Hitzones(状態2)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>40</td><td>30</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>40</td><td>10</td><td>15</td><td>15</td><td>15</td><td>15</td><td>0</td></tr>
@@ -119,7 +119,7 @@
 <tr><td>Tail</td><td>40</td><td>30</td><td>25</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>20</td><td>25</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>45</td><td>40</td><td>30</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(状態3)</th></tr>
+<tr class=l><th colspan=10>Hitzones(状態3)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>45</td><td>30</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>40</td><td>10</td><td>10</td><td>10</td><td>10</td><td>10</td><td>0</td></tr>
@@ -128,7 +128,7 @@
 <tr><td>Tail</td><td>40</td><td>30</td><td>25</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>35</td><td>20</td><td>25</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>35</td><td>35</td><td>25</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(状態4)</th></tr>
+<tr class=l><th colspan=10>Hitzones(状態4)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>45</td><td>25</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>30</td><td>30</td><td>5</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
@@ -137,7 +137,7 @@
 <tr><td>Tail</td><td>40</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>40</td><td>20</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>30</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(状態5)</th></tr>
+<tr class=l><th colspan=10>Hitzones(状態5)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>55</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>30</td><td>30</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
@@ -146,7 +146,7 @@
 <tr><td>Tail</td><td>55</td><td>30</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>20</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 <tr><td>Leg</td><td>30</td><td>30</td><td>15</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(状態6(覇種))</th></tr>
+<tr class=l><th colspan=10>Hitzones(状態6(覇種))</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>55</td><td>20</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>30</td><td>30</td><td>0</td><td>5</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
@@ -172,11 +172,11 @@ Rage state 4:１ stagger(s) required</td></tr>
 <span><em>6</em>300</span><span><em>6(状態2,3)</em>400</span><span><em>6(状態4)</em>500</span><span><em>6(状態5,6)</em>700</span>
 </div>
 Rage state 4:１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>250</td><td><div>
+<tr><td>Left Leg</td><td>250</td><td><div>
 <span><em>6</em>375</span><span><em>6(状態2,3)</em>600</span><span><em>6(状態4)</em>625</span><span><em>6(状態5,6)</em>875</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>250</td><td><div>
+<tr><td>Right Leg</td><td>250</td><td><div>
 <span><em>6</em>375</span><span><em>6(状態2,3)</em>500</span><span><em>6(状態4)</em>625</span><span><em>6(状態5,6)</em>875</span>
 </div>
 </td></tr>

--- a/mons/ra_n.htm
+++ b/mons/ra_n.htm
@@ -78,10 +78,10 @@
 <img id=icon src="../img/monsicons/rajang.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>60</td><td>60</td><td>60</td><td>5</td><td>5</td><td>0</td><td>0</td><td>30</td><td>50</td></tr>
-<tr><td>Fore Leg</td><td>45</td><td>40</td><td>40</td><td>0</td><td>5</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>45</td><td>40</td><td>40</td><td>0</td><td>5</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>45</td><td>40</td><td>40</td><td>0</td><td>5</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Torso</td><td>45</td><td>50</td><td>45</td><td>0</td><td>5</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>40</td><td>30</td><td>0</td><td>5</td><td>0</td><td>0</td><td>20</td><td>0</td></tr>
@@ -94,11 +94,11 @@
 <span><em>若14</em>350</span><span><em>59</em>1500</span>
 </div>
 １ stagger(s) required<br>２ stagger(s) required to break Horn to get the reward</td></tr>
-<tr><td>Right Foot</td><td>350</td><td><div>
+<tr><td>Right Leg</td><td>350</td><td><div>
 <span><em>59</em>1048</span>
 </div>
 </td></tr>
-<tr><td>Left Foot</td><td>350</td><td><div>
+<tr><td>Left Leg</td><td>350</td><td><div>
 <span><em>59</em>1027</span>
 </div>
 </td></tr>

--- a/mons/ra_ng.htm
+++ b/mons/ra_ng.htm
@@ -123,10 +123,10 @@
 <img id=icon src="../img/monsicons/rajang.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>60</td><td>60</td><td>60</td><td>5</td><td>5</td><td>0</td><td>0</td><td>30</td><td>50</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>30</td><td>30</td><td>0</td><td>5</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>30</td><td>30</td><td>0</td><td>5</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>35</td><td>30</td><td>30</td><td>0</td><td>5</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Torso</td><td>35</td><td>40</td><td>35</td><td>0</td><td>5</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>45</td><td>40</td><td>0</td><td>5</td><td>0</td><td>0</td><td>40</td><td>0</td></tr>
@@ -136,8 +136,8 @@
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>800</td><td>１ stagger(s) required<br>２ stagger(s) required to break Horn to get the reward</td></tr>
-<tr><td>Right Foot</td><td>550</td><td></td></tr>
-<tr><td>Left Foot</td><td>550</td><td></td></tr>
+<tr><td>Right Leg</td><td>550</td><td></td></tr>
+<tr><td>Left Leg</td><td>550</td><td></td></tr>
 <tr><td>Torso</td><td>700</td><td></td></tr>
 <tr><td>Tail</td><td>1400</td><td></td></tr>
 <tr><td></td><td>1400</td><td>Severs after enough Ice Cutting attacks are done<br>Will only sever when enraged </td></tr>

--- a/mons/ra_nh.htm
+++ b/mons/ra_nh.htm
@@ -82,10 +82,10 @@
 <img id=icon src="../img/monsicons/rajang.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>50</td><td>50</td><td>-5</td><td>0</td><td>-5</td><td>5</td><td>15</td><td>50</td></tr>
-<tr><td>Fore Leg</td><td>40</td><td>40</td><td>40</td><td>0</td><td>8</td><td>-5</td><td>-5</td><td>0</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>40</td><td>40</td><td>40</td><td>0</td><td>8</td><td>-5</td><td>-5</td><td>0</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>40</td><td>40</td><td>20</td><td>0</td><td>8</td><td>-5</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Torso</td><td>40</td><td>50</td><td>45</td><td>0</td><td>0</td><td>-5</td><td>-5</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>45</td><td>20</td><td>-5</td><td>0</td><td>-5</td><td>5</td><td>10</td><td>0</td></tr>
@@ -95,8 +95,8 @@
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>500</td><td>１ stagger(s) required<br>２ stagger(s) required to break Horn to get the reward</td></tr>
-<tr><td>Right Foot</td><td>350</td><td></td></tr>
-<tr><td>Left Foot</td><td>350</td><td></td></tr>
+<tr><td>Right Leg</td><td>350</td><td></td></tr>
+<tr><td>Left Leg</td><td>350</td><td></td></tr>
 <tr><td>Torso</td><td>300</td><td></td></tr>
 <tr><td>Tail</td><td>1000</td><td></td></tr>
 <tr><td></td><td>1000</td><td>Severs after enough Ice Cutting attacks are done<br>Will only sever when enraged </td></tr>

--- a/mons/ra_nt.htm
+++ b/mons/ra_nt.htm
@@ -103,10 +103,10 @@
 <img id=icon src="../img/monsicons/rajang.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>60</td><td>60</td><td>60</td><td>5</td><td>5</td><td>0</td><td>0</td><td>30</td><td>50</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>30</td><td>30</td><td>0</td><td>5</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>30</td><td>30</td><td>0</td><td>5</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>35</td><td>30</td><td>30</td><td>0</td><td>5</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Torso</td><td>35</td><td>40</td><td>35</td><td>0</td><td>5</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>50</td><td>45</td><td>40</td><td>0</td><td>5</td><td>0</td><td>0</td><td>40</td><td>0</td></tr>
@@ -116,8 +116,8 @@
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>500</td><td>１ stagger(s) required<br>２ stagger(s) required to break Horn to get the reward</td></tr>
-<tr><td>Right Foot</td><td>350</td><td></td></tr>
-<tr><td>Left Foot</td><td>350</td><td></td></tr>
+<tr><td>Right Leg</td><td>350</td><td></td></tr>
+<tr><td>Left Leg</td><td>350</td><td></td></tr>
 <tr><td>Torso</td><td>300</td><td></td></tr>
 <tr><td>Tail</td><td>1000</td><td></td></tr>
 <tr><td></td><td>1000</td><td>Severs after enough Ice Cutting attacks are done<br>Will only sever when enraged </td></tr>

--- a/mons/raikou_n.htm
+++ b/mons/raikou_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/greatthunderbug.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>70</td><td>70</td><td>70</td><td>20</td><td>20</td><td>20</td><td>20</td><td>20</td><td>0</td></tr>
 </table>

--- a/mons/ran_n.htm
+++ b/mons/ran_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/velociprey.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>120</td><td>120</td><td>120</td><td>50</td><td>50</td><td>50</td><td>10</td><td>50</td><td>100</td></tr>
 </table>

--- a/mons/rango_n.htm
+++ b/mons/rango_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/vespoid.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>120</td><td>130</td><td>110</td><td>100</td><td>50</td><td>10</td><td>0</td><td>50</td><td>0</td></tr>
 </table>

--- a/mons/rao_n.htm
+++ b/mons/rao_n.htm
@@ -62,7 +62,7 @@
 <tr><td>Head</td><td>28</td><td>20</td><td>30</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>20</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>Shoulder</td><td>10</td><td>20</td><td>20</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
-<tr><td>Weak Point/Inside</td><td>80</td><td>90</td><td>80</td><td>50</td><td>5</td><td>15</td><td>100</td><td>5</td><td>0</td></tr>
+<tr><td>Weak Point/Body Inside</td><td>80</td><td>90</td><td>80</td><td>50</td><td>5</td><td>15</td><td>100</td><td>5</td><td>0</td></tr>
 <tr><td>Back/Tail</td><td>10</td><td>20</td><td>20</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>Belly</td><td>55</td><td>50</td><td>40</td><td>20</td><td>5</td><td>15</td><td>30</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>32</td><td>37</td><td>25</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>

--- a/mons/rao_n.htm
+++ b/mons/rao_n.htm
@@ -57,12 +57,12 @@
 <img id=icon src="../img/monsicons/lao-shanlung.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>28</td><td>20</td><td>30</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>20</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>Shoulder</td><td>10</td><td>20</td><td>20</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
-<tr><td>Weakpoint/Inside</td><td>80</td><td>90</td><td>80</td><td>50</td><td>5</td><td>15</td><td>100</td><td>5</td><td>0</td></tr>
+<tr><td>Weak Point/Inside</td><td>80</td><td>90</td><td>80</td><td>50</td><td>5</td><td>15</td><td>100</td><td>5</td><td>0</td></tr>
 <tr><td>Back/Tail</td><td>10</td><td>20</td><td>20</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>Belly</td><td>55</td><td>50</td><td>40</td><td>20</td><td>5</td><td>15</td><td>30</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>32</td><td>37</td><td>25</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>

--- a/mons/rao_n.htm
+++ b/mons/rao_n.htm
@@ -61,9 +61,9 @@
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>28</td><td>20</td><td>30</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>20</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
-<tr><td>肩</td><td>10</td><td>20</td><td>20</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
-<tr><td>弱点/体中</td><td>80</td><td>90</td><td>80</td><td>50</td><td>5</td><td>15</td><td>100</td><td>5</td><td>0</td></tr>
-<tr><td>背中/尻尾</td><td>10</td><td>20</td><td>20</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
+<tr><td>Shoulder</td><td>10</td><td>20</td><td>20</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
+<tr><td>Weakpoint/Inside</td><td>80</td><td>90</td><td>80</td><td>50</td><td>5</td><td>15</td><td>100</td><td>5</td><td>0</td></tr>
+<tr><td>Back/Tail</td><td>10</td><td>20</td><td>20</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>Belly</td><td>55</td><td>50</td><td>40</td><td>20</td><td>5</td><td>15</td><td>30</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>32</td><td>37</td><td>25</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
 </table>
@@ -72,19 +72,19 @@
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>400</td><td>１ stagger(s) required<br>２ stagger(s) required</td></tr>
-<tr><td>装甲</td><td>300</td><td></td></tr>
-<tr><td>Fore Leg</td><td>600</td><td><div>
+<tr><td>Armor</td><td>300</td><td></td></tr>
+<tr><td>Foreleg</td><td>600</td><td><div>
 <span><em>13</em>828</span>
 </div>
 </td></tr>
-<tr><td>後脚/背中</td><td>880</td><td><div>
+<tr><td>Hind Leg/Back</td><td>880</td><td><div>
 <span><em>13</em>1215</span>
 </div>
 </td></tr>
-<tr><td>背中の突起</td><td>300</td><td>３ stagger(s) required</td></tr>
-<tr><td>左肩</td><td>600</td><td>２ stagger(s) required</td></tr>
-<tr><td>右肩</td><td>600</td><td>２ stagger(s) required</td></tr>
-<tr><td>胸/腹</td><td>1200</td><td></td></tr>
+<tr><td>Back Protrusion</td><td>300</td><td>３ stagger(s) required</td></tr>
+<tr><td>Left Shoulder</td><td>600</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Shoulder</td><td>600</td><td>２ stagger(s) required</td></tr>
+<tr><td>Chest/Belly</td><td>1200</td><td></td></tr>
 </table>
 <img id=hitzones src="../img/monszones/lao-shanlung.png" width="400"/>
 <table id=kou>

--- a/mons/rao_nh.htm
+++ b/mons/rao_nh.htm
@@ -76,13 +76,13 @@
 <img id=icon src="../img/monsicons/lao-shanlung.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>28</td><td>37</td><td>30</td><td>10</td><td>0</td><td>5</td><td>30</td><td>5</td><td>0</td></tr>
 <tr><td>Neck</td><td>30</td><td>20</td><td>20</td><td>10</td><td>40</td><td>5</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>肩</td><td>10</td><td>20</td><td>20</td><td>15</td><td>0</td><td>5</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>弱点/体中</td><td>80</td><td>90</td><td>50</td><td>15</td><td>0</td><td>5</td><td>20</td><td>5</td><td>0</td></tr>
-<tr><td>背中/尻尾</td><td>40</td><td>20</td><td>15</td><td>10</td><td>40</td><td>5</td><td>15</td><td>5</td><td>0</td></tr>
+<tr><td>Back/Tail</td><td>40</td><td>20</td><td>15</td><td>10</td><td>40</td><td>5</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Belly</td><td>30</td><td>40</td><td>20</td><td>10</td><td>0</td><td>5</td><td>30</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>37</td><td>32</td><td>25</td><td>10</td><td>40</td><td>5</td><td>30</td><td>5</td><td>0</td></tr>
 </table>
@@ -91,13 +91,13 @@
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>400</td><td>１ stagger(s) required<br>２ stagger(s) required</td></tr>
-<tr><td>装甲</td><td>300</td><td></td></tr>
-<tr><td>Fore Leg</td><td>600</td><td></td></tr>
-<tr><td>後脚/背中</td><td>880</td><td></td></tr>
-<tr><td>背中の突起</td><td>300</td><td>３ stagger(s) required</td></tr>
-<tr><td>左肩</td><td>600</td><td>２ stagger(s) required</td></tr>
-<tr><td>右肩</td><td>600</td><td>２ stagger(s) required</td></tr>
-<tr><td>胸/腹</td><td>1200</td><td></td></tr>
+<tr><td>Armor</td><td>300</td><td></td></tr>
+<tr><td>Foreleg</td><td>600</td><td></td></tr>
+<tr><td>Hind Leg/Back</td><td>880</td><td></td></tr>
+<tr><td>Back Protrusion</td><td>300</td><td>３ stagger(s) required</td></tr>
+<tr><td>Left Shoulder</td><td>600</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Shoulder</td><td>600</td><td>２ stagger(s) required</td></tr>
+<tr><td>Chest/Belly</td><td>1200</td><td></td></tr>
 </table>
 <img id=hitzones src="../img/monszones/lao-shanlunghr5.png" width="400"/>
 <table id=kou>

--- a/mons/rao_nh.htm
+++ b/mons/rao_nh.htm
@@ -80,8 +80,8 @@
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>28</td><td>37</td><td>30</td><td>10</td><td>0</td><td>5</td><td>30</td><td>5</td><td>0</td></tr>
 <tr><td>Neck</td><td>30</td><td>20</td><td>20</td><td>10</td><td>40</td><td>5</td><td>15</td><td>5</td><td>0</td></tr>
-<tr><td>肩</td><td>10</td><td>20</td><td>20</td><td>15</td><td>0</td><td>5</td><td>20</td><td>5</td><td>0</td></tr>
-<tr><td>弱点/体中</td><td>80</td><td>90</td><td>50</td><td>15</td><td>0</td><td>5</td><td>20</td><td>5</td><td>0</td></tr>
+<tr><td>Shoulder</td><td>10</td><td>20</td><td>20</td><td>15</td><td>0</td><td>5</td><td>20</td><td>5</td><td>0</td></tr>
+<tr><td>Weak Point/Body Inside</td><td>80</td><td>90</td><td>50</td><td>15</td><td>0</td><td>5</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>Back/Tail</td><td>40</td><td>20</td><td>15</td><td>10</td><td>40</td><td>5</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Belly</td><td>30</td><td>40</td><td>20</td><td>10</td><td>0</td><td>5</td><td>30</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>37</td><td>32</td><td>25</td><td>10</td><td>40</td><td>5</td><td>30</td><td>5</td><td>0</td></tr>

--- a/mons/raoao_n.htm
+++ b/mons/raoao_n.htm
@@ -58,13 +58,13 @@
 <img id=icon src="../img/monsicons/ashenlao-shanlung.webp" width="250"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>28</td><td>20</td><td>30</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>20</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>肩</td><td>10</td><td>20</td><td>20</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>弱点/体中</td><td>80</td><td>90</td><td>80</td><td>50</td><td>5</td><td>15</td><td>100</td><td>5</td><td>0</td></tr>
-<tr><td>背中/尻尾</td><td>10</td><td>20</td><td>20</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
+<tr><td>Back/Tail</td><td>10</td><td>20</td><td>20</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>Belly</td><td>55</td><td>50</td><td>40</td><td>20</td><td>5</td><td>15</td><td>30</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>32</td><td>37</td><td>25</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
 </table>
@@ -73,19 +73,19 @@
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>400</td><td>１ stagger(s) required<br>２ stagger(s) required</td></tr>
-<tr><td>装甲</td><td>300</td><td></td></tr>
-<tr><td>Fore Leg</td><td>600</td><td><div>
+<tr><td>Armor</td><td>300</td><td></td></tr>
+<tr><td>Foreleg</td><td>600</td><td><div>
 <span><em>14</em>846</span>
 </div>
 </td></tr>
-<tr><td>後脚/背中</td><td>880</td><td><div>
+<tr><td>Hind Leg/Back</td><td>880</td><td><div>
 <span><em>14</em>1240</span>
 </div>
 </td></tr>
-<tr><td>背中の突起</td><td>300</td><td>３ stagger(s) required</td></tr>
-<tr><td>左肩</td><td>600</td><td>２ stagger(s) required</td></tr>
-<tr><td>右肩</td><td>600</td><td>２ stagger(s) required</td></tr>
-<tr><td>胸/腹</td><td>1200</td><td></td></tr>
+<tr><td>Back Protrusion</td><td>300</td><td>３ stagger(s) required</td></tr>
+<tr><td>Left Shoulder</td><td>600</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Shoulder</td><td>600</td><td>２ stagger(s) required</td></tr>
+<tr><td>Chest/Belly</td><td>1200</td><td></td></tr>
 </table>
 <img id=hitzones src="../img/monszones/ashenlao-shanlung.png" width="500"/>
 <table id=kou>

--- a/mons/raoao_n.htm
+++ b/mons/raoao_n.htm
@@ -62,8 +62,8 @@
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>28</td><td>20</td><td>30</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>20</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
-<tr><td>肩</td><td>10</td><td>20</td><td>20</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
-<tr><td>弱点/体中</td><td>80</td><td>90</td><td>80</td><td>50</td><td>5</td><td>15</td><td>100</td><td>5</td><td>0</td></tr>
+<tr><td>Shoulder</td><td>10</td><td>20</td><td>20</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
+<tr><td>Weak Point/Body Inside</td><td>80</td><td>90</td><td>80</td><td>50</td><td>5</td><td>15</td><td>100</td><td>5</td><td>0</td></tr>
 <tr><td>Back/Tail</td><td>10</td><td>20</td><td>20</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>Belly</td><td>55</td><td>50</td><td>40</td><td>20</td><td>5</td><td>15</td><td>30</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>32</td><td>37</td><td>25</td><td>20</td><td>5</td><td>15</td><td>20</td><td>5</td><td>0</td></tr>

--- a/mons/reia_n.htm
+++ b/mons/reia_n.htm
@@ -79,7 +79,7 @@
 <img id=icon src="../img/monsicons/rathian.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>70</td><td>60</td><td>50</td><td>0</td><td>15</td><td>20</td><td>35</td><td>15</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>40</td><td>40</td><td>0</td><td>10</td><td>15</td><td>20</td><td>10</td><td>0</td></tr>
@@ -96,11 +96,11 @@
 <tr><td>Torso</td><td>150</td><td></td></tr>
 <tr><td>Left Wing</td><td>100</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>100</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>180</td><td><div>
+<tr><td>Left Leg</td><td>180</td><td><div>
 <span><em>12</em>244</span><span><em>13</em>249</span><span><em>14</em>253</span><span><em>15</em>258</span><span><em>16</em>263</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>180</td><td><div>
+<tr><td>Right Leg</td><td>180</td><td><div>
 <span><em>12</em>244</span><span><em>13</em>249</span><span><em>14</em>253</span><span><em>15</em>258</span><span><em>16</em>263</span>
 </div>
 </td></tr>

--- a/mons/reia_ng.htm
+++ b/mons/reia_ng.htm
@@ -116,7 +116,7 @@
 <img id=icon src="../img/monsicons/rathian.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>45</td><td>30</td><td>0</td><td>10</td><td>20</td><td>35</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>30</td><td>30</td><td>20</td><td>0</td><td>5</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>
@@ -133,8 +133,8 @@
 <tr><td>Torso</td><td>350</td><td></td></tr>
 <tr><td>Left Wing</td><td>300</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>300</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>380</td><td></td></tr>
-<tr><td>Right Foot</td><td>380</td><td></td></tr>
+<tr><td>Left Leg</td><td>380</td><td></td></tr>
+<tr><td>Right Leg</td><td>380</td><td></td></tr>
 <tr><td>Neck</td><td>290</td><td></td></tr>
 <tr><td>Head</td><td>400</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>340</td><td></td></tr>

--- a/mons/reia_nh.htm
+++ b/mons/reia_nh.htm
@@ -83,7 +83,7 @@
 <img id=icon src="../img/monsicons/rathian.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>45</td><td>40</td><td>-5</td><td>15</td><td>-5</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>60</td><td>40</td><td>25</td><td>20</td><td>-5</td><td>25</td><td>0</td><td>0</td><td>0</td></tr>
@@ -100,8 +100,8 @@
 <tr><td>Torso</td><td>150</td><td></td></tr>
 <tr><td>Left Wing</td><td>100</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>100</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>180</td><td></td></tr>
-<tr><td>Right Foot</td><td>180</td><td></td></tr>
+<tr><td>Left Leg</td><td>180</td><td></td></tr>
+<tr><td>Right Leg</td><td>180</td><td></td></tr>
 <tr><td>Neck</td><td>90</td><td></td></tr>
 <tr><td>Head</td><td>200</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>140</td><td></td></tr>

--- a/mons/reiakin_n.htm
+++ b/mons/reiakin_n.htm
@@ -66,7 +66,7 @@
 <img id=icon src="../img/monsicons/goldrathian.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>80</td><td>40</td><td>0</td><td>15</td><td>30</td><td>0</td><td>5</td><td>150</td></tr>
 <tr><td>Neck</td><td>35</td><td>50</td><td>40</td><td>0</td><td>10</td><td>20</td><td>0</td><td>5</td><td>0</td></tr>
@@ -83,11 +83,11 @@
 <tr><td>Torso</td><td>150</td><td></td></tr>
 <tr><td>Left Wing</td><td>100</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>100</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>180</td><td><div>
+<tr><td>Left Leg</td><td>180</td><td><div>
 <span><em>14</em>253</span><span><em>15</em>258</span><span><em>16</em>263</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>180</td><td><div>
+<tr><td>Right Leg</td><td>180</td><td><div>
 <span><em>14</em>253</span><span><em>15</em>258</span><span><em>16</em>263</span>
 </div>
 </td></tr>

--- a/mons/reiakin_ng.htm
+++ b/mons/reiakin_ng.htm
@@ -103,7 +103,7 @@
 <img id=icon src="../img/monsicons/goldrathian.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>60</td><td>40</td><td>0</td><td>15</td><td>35</td><td>0</td><td>5</td><td>150</td></tr>
 <tr><td>Neck</td><td>35</td><td>50</td><td>40</td><td>0</td><td>10</td><td>20</td><td>0</td><td>5</td><td>0</td></tr>
@@ -120,8 +120,8 @@
 <tr><td>Torso</td><td>480</td><td></td></tr>
 <tr><td>Left Wing</td><td>800</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>800</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>460</td><td></td></tr>
-<tr><td>Right Foot</td><td>460</td><td></td></tr>
+<tr><td>Left Leg</td><td>460</td><td></td></tr>
+<tr><td>Right Leg</td><td>460</td><td></td></tr>
 <tr><td>Neck</td><td>400</td><td></td></tr>
 <tr><td>Head</td><td>800</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>350</td><td></td></tr>

--- a/mons/reiakin_nh.htm
+++ b/mons/reiakin_nh.htm
@@ -90,7 +90,7 @@
 <img id=icon src="../img/monsicons/goldrathian.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>60</td><td>30</td><td>15</td><td>0</td><td>5</td><td>0</td><td>5</td><td>50</td></tr>
 <tr><td>Neck</td><td>25</td><td>50</td><td>20</td><td>10</td><td>0</td><td>5</td><td>0</td><td>15</td><td>0</td></tr>
@@ -107,8 +107,8 @@
 <tr><td>Torso</td><td>480</td><td></td></tr>
 <tr><td>Left Wing</td><td>800</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>800</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>460</td><td></td></tr>
-<tr><td>Right Foot</td><td>460</td><td></td></tr>
+<tr><td>Left Leg</td><td>460</td><td></td></tr>
+<tr><td>Right Leg</td><td>460</td><td></td></tr>
 <tr><td>Neck</td><td>400</td><td></td></tr>
 <tr><td>Head</td><td>800</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>350</td><td></td></tr>

--- a/mons/reiasa_n.htm
+++ b/mons/reiasa_n.htm
@@ -72,7 +72,7 @@
 <img id=icon src="../img/monsicons/pinkrathian.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>65</td><td>55</td><td>40</td><td>0</td><td>35</td><td>10</td><td>20</td><td>10</td><td>120</td></tr>
 <tr><td>Neck</td><td>45</td><td>35</td><td>35</td><td>0</td><td>15</td><td>10</td><td>15</td><td>5</td><td>0</td></tr>
@@ -89,11 +89,11 @@
 <tr><td>Torso</td><td>150</td><td></td></tr>
 <tr><td>Left Wing</td><td>100</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>100</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>180</td><td><div>
+<tr><td>Left Leg</td><td>180</td><td><div>
 <span><em>12</em>244</span><span><em>13</em>249</span><span><em>14</em>253</span><span><em>15</em>258</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>180</td><td><div>
+<tr><td>Right Leg</td><td>180</td><td><div>
 <span><em>12</em>244</span><span><em>13</em>249</span><span><em>14</em>253</span><span><em>15</em>258</span>
 </div>
 </td></tr>

--- a/mons/reiasa_ng.htm
+++ b/mons/reiasa_ng.htm
@@ -124,7 +124,7 @@
 <img id=icon src="../img/monsicons/pinkrathian.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>45</td><td>30</td><td>0</td><td>30</td><td>10</td><td>25</td><td>10</td><td>120</td></tr>
 <tr><td>Neck</td><td>25</td><td>25</td><td>25</td><td>0</td><td>10</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
@@ -141,8 +141,8 @@
 <tr><td>Torso</td><td>700</td><td></td></tr>
 <tr><td>Left Wing</td><td>600</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>600</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>760</td><td></td></tr>
-<tr><td>Right Foot</td><td>760</td><td></td></tr>
+<tr><td>Left Leg</td><td>760</td><td></td></tr>
+<tr><td>Right Leg</td><td>760</td><td></td></tr>
 <tr><td>Neck</td><td>580</td><td></td></tr>
 <tr><td>Head</td><td>800</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>680</td><td></td></tr>

--- a/mons/reiasa_nh.htm
+++ b/mons/reiasa_nh.htm
@@ -93,7 +93,7 @@
 <img id=icon src="../img/monsicons/pinkrathian.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>50</td><td>30</td><td>0</td><td>15</td><td>5</td><td>5</td><td>5</td><td>120</td></tr>
 <tr><td>Neck</td><td>35</td><td>30</td><td>45</td><td>0</td><td>-5</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>
@@ -110,8 +110,8 @@
 <tr><td>Torso</td><td>200</td><td></td></tr>
 <tr><td>Left Wing</td><td>150</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>150</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>200</td><td></td></tr>
-<tr><td>Right Foot</td><td>200</td><td></td></tr>
+<tr><td>Left Leg</td><td>200</td><td></td></tr>
+<tr><td>Right Leg</td><td>200</td><td></td></tr>
 <tr><td>Neck</td><td>120</td><td></td></tr>
 <tr><td>Head</td><td>230</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>400</td><td></td></tr>

--- a/mons/reusu_n.htm
+++ b/mons/reusu_n.htm
@@ -74,7 +74,7 @@
 <img id=icon src="../img/monsicons/rathalos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>60</td><td>50</td><td>50</td><td>0</td><td>30</td><td>15</td><td>30</td><td>40</td><td>100</td></tr>
 <tr><td>Neck</td><td>45</td><td>45</td><td>40</td><td>0</td><td>20</td><td>10</td><td>20</td><td>30</td><td>0</td></tr>
@@ -91,11 +91,11 @@
 <tr><td>Torso</td><td>160</td><td></td></tr>
 <tr><td>Left Wing</td><td>100</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>100</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>160</td><td><div>
+<tr><td>Left Leg</td><td>160</td><td><div>
 <span><em>13</em>221</span><span><em>14</em>225</span><span><em>15</em>229</span><span><em>16</em>234</span><span><em>17</em>238</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>160</td><td><div>
+<tr><td>Right Leg</td><td>160</td><td><div>
 <span><em>13</em>221</span><span><em>14</em>225</span><span><em>15</em>229</span><span><em>16</em>234</span><span><em>17</em>238</span>
 </div>
 </td></tr>

--- a/mons/reusu_ng.htm
+++ b/mons/reusu_ng.htm
@@ -118,7 +118,7 @@
 <img id=icon src="../img/monsicons/rathalos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>60</td><td>50</td><td>30</td><td>0</td><td>30</td><td>10</td><td>15</td><td>20</td><td>100</td></tr>
 <tr><td>Neck</td><td>30</td><td>25</td><td>20</td><td>0</td><td>5</td><td>5</td><td>5</td><td>15</td><td>0</td></tr>
@@ -135,8 +135,8 @@
 <tr><td>Torso</td><td>360</td><td></td></tr>
 <tr><td>Left Wing</td><td>300</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>300</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>360</td><td></td></tr>
-<tr><td>Right Foot</td><td>360</td><td></td></tr>
+<tr><td>Left Leg</td><td>360</td><td></td></tr>
+<tr><td>Right Leg</td><td>360</td><td></td></tr>
 <tr><td>Neck</td><td>300</td><td></td></tr>
 <tr><td>Head</td><td>380</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>350</td><td></td></tr>

--- a/mons/reusu_nh.htm
+++ b/mons/reusu_nh.htm
@@ -82,7 +82,7 @@
 <img id=icon src="../img/monsicons/rathalos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>40</td><td>0</td><td>0</td><td>0</td><td>10</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>45</td><td>20</td><td>20</td><td>0</td><td>15</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
@@ -99,8 +99,8 @@
 <tr><td>Torso</td><td>160</td><td></td></tr>
 <tr><td>Left Wing</td><td>100</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>100</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>160</td><td></td></tr>
-<tr><td>Right Foot</td><td>160</td><td></td></tr>
+<tr><td>Left Leg</td><td>160</td><td></td></tr>
+<tr><td>Right Leg</td><td>160</td><td></td></tr>
 <tr><td>Neck</td><td>100</td><td></td></tr>
 <tr><td>Head</td><td>180</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>150</td><td></td></tr>

--- a/mons/reusu_ni.htm
+++ b/mons/reusu_ni.htm
@@ -112,7 +112,7 @@
 <img id=icon src="../img/monsicons/zenith_rathalos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>35</td><td>20</td><td>0</td><td>20</td><td>5</td><td>15</td><td>15</td><td>100</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>15</td><td>0</td><td>5</td><td>5</td><td>5</td><td>10</td><td>0</td></tr>
@@ -129,8 +129,8 @@
 <tr><td>Torso</td><td>900</td><td></td></tr>
 <tr><td>Left Wing</td><td>7500</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>7500</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>880</td><td></td></tr>
-<tr><td>Right Foot</td><td>880</td><td></td></tr>
+<tr><td>Left Leg</td><td>880</td><td></td></tr>
+<tr><td>Right Leg</td><td>880</td><td></td></tr>
 <tr><td>Neck</td><td>900</td><td></td></tr>
 <tr><td>Head</td><td>1200</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>1000</td><td></td></tr>

--- a/mons/reusuao_n.htm
+++ b/mons/reusuao_n.htm
@@ -73,7 +73,7 @@
 <img id=icon src="../img/monsicons/azurerathalos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>60</td><td>50</td><td>50</td><td>0</td><td>15</td><td>30</td><td>25</td><td>10</td><td>150</td></tr>
 <tr><td>Neck</td><td>45</td><td>45</td><td>40</td><td>0</td><td>10</td><td>15</td><td>20</td><td>10</td><td>0</td></tr>
@@ -90,11 +90,11 @@
 <tr><td>Torso</td><td>160</td><td></td></tr>
 <tr><td>Left Wing</td><td>100</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>100</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>160</td><td><div>
+<tr><td>Left Leg</td><td>160</td><td><div>
 <span><em>13</em>221</span><span><em>14</em>225</span><span><em>15</em>229</span><span><em>16</em>234</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>160</td><td><div>
+<tr><td>Right Leg</td><td>160</td><td><div>
 <span><em>13</em>221</span><span><em>14</em>225</span><span><em>15</em>229</span><span><em>16</em>234</span>
 </div>
 </td></tr>

--- a/mons/reusuao_ng.htm
+++ b/mons/reusuao_ng.htm
@@ -124,7 +124,7 @@
 <img id=icon src="../img/monsicons/azurerathalos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>55</td><td>50</td><td>30</td><td>0</td><td>10</td><td>30</td><td>20</td><td>5</td><td>150</td></tr>
 <tr><td>Neck</td><td>30</td><td>35</td><td>20</td><td>0</td><td>5</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
@@ -141,8 +141,8 @@
 <tr><td>Torso</td><td>360</td><td></td></tr>
 <tr><td>Left Wing</td><td>300</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>300</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>360</td><td></td></tr>
-<tr><td>Right Foot</td><td>360</td><td></td></tr>
+<tr><td>Left Leg</td><td>360</td><td></td></tr>
+<tr><td>Right Leg</td><td>360</td><td></td></tr>
 <tr><td>Neck</td><td>300</td><td></td></tr>
 <tr><td>Head</td><td>380</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>350</td><td></td></tr>

--- a/mons/reusuao_nh.htm
+++ b/mons/reusuao_nh.htm
@@ -92,7 +92,7 @@
 <img id=icon src="../img/monsicons/azurerathalos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>50</td><td>30</td><td>0</td><td>5</td><td>30</td><td>25</td><td>10</td><td>150</td></tr>
 <tr><td>Neck</td><td>35</td><td>30</td><td>45</td><td>5</td><td>10</td><td>-5</td><td>0</td><td>5</td><td>0</td></tr>
@@ -109,8 +109,8 @@
 <tr><td>Torso</td><td>220</td><td></td></tr>
 <tr><td>Left Wing</td><td>150</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>150</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>180</td><td></td></tr>
-<tr><td>Right Foot</td><td>180</td><td></td></tr>
+<tr><td>Left Leg</td><td>180</td><td></td></tr>
+<tr><td>Right Leg</td><td>180</td><td></td></tr>
 <tr><td>Neck</td><td>140</td><td></td></tr>
 <tr><td>Head</td><td>200</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>420</td><td></td></tr>

--- a/mons/reusugin_n.htm
+++ b/mons/reusugin_n.htm
@@ -65,7 +65,7 @@
 <img id=icon src="../img/monsicons/silverrathalos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>80</td><td>25</td><td>0</td><td>30</td><td>30</td><td>0</td><td>10</td><td>200</td></tr>
 <tr><td>Neck</td><td>35</td><td>55</td><td>40</td><td>0</td><td>20</td><td>20</td><td>0</td><td>5</td><td>0</td></tr>
@@ -82,11 +82,11 @@
 <tr><td>Torso</td><td>160</td><td></td></tr>
 <tr><td>Left Wing</td><td>100</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>100</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>160</td><td><div>
+<tr><td>Left Leg</td><td>160</td><td><div>
 <span><em>14</em>225</span><span><em>16</em>234</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>160</td><td><div>
+<tr><td>Right Leg</td><td>160</td><td><div>
 <span><em>14</em>225</span><span><em>16</em>234</span>
 </div>
 </td></tr>

--- a/mons/reusugin_ng.htm
+++ b/mons/reusugin_ng.htm
@@ -102,7 +102,7 @@
 <img id=icon src="../img/monsicons/silverrathalos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>60</td><td>25</td><td>0</td><td>20</td><td>25</td><td>0</td><td>10</td><td>200</td></tr>
 <tr><td>Neck</td><td>35</td><td>40</td><td>25</td><td>0</td><td>15</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
@@ -119,8 +119,8 @@
 <tr><td>Torso</td><td>800</td><td></td></tr>
 <tr><td>Left Wing</td><td>1000</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>1000</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>800</td><td></td></tr>
-<tr><td>Right Foot</td><td>800</td><td></td></tr>
+<tr><td>Left Leg</td><td>800</td><td></td></tr>
+<tr><td>Right Leg</td><td>800</td><td></td></tr>
 <tr><td>Neck</td><td>750</td><td></td></tr>
 <tr><td>Head</td><td>900</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>400</td><td></td></tr>

--- a/mons/reusugin_nh.htm
+++ b/mons/reusugin_nh.htm
@@ -89,7 +89,7 @@
 <img id=icon src="../img/monsicons/silverrathalos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>60</td><td>25</td><td>0</td><td>0</td><td>10</td><td>20</td><td>20</td><td>100</td></tr>
 <tr><td>Neck</td><td>25</td><td>55</td><td>20</td><td>0</td><td>0</td><td>5</td><td>15</td><td>20</td><td>0</td></tr>
@@ -106,8 +106,8 @@
 <tr><td>Torso</td><td>480</td><td></td></tr>
 <tr><td>Left Wing</td><td>800</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>800</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>460</td><td></td></tr>
-<tr><td>Right Foot</td><td>460</td><td></td></tr>
+<tr><td>Left Leg</td><td>460</td><td></td></tr>
+<tr><td>Right Leg</td><td>460</td><td></td></tr>
 <tr><td>Neck</td><td>400</td><td></td></tr>
 <tr><td>Head</td><td>800</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>350</td><td></td></tr>

--- a/mons/ruco_n.htm
+++ b/mons/ruco_n.htm
@@ -63,22 +63,22 @@
 <img id=icon src="../img/monsicons/rukodiora.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>60</td><td>30</td><td>0</td><td>5</td><td>0</td><td>5</td><td>10</td><td>100</td></tr>
 <tr><td>Belly</td><td>35</td><td>40</td><td>45</td><td>0</td><td>10</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>25</td><td>35</td><td>0</td><td>10</td><td>0</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>55</td><td>50</td><td>40</td><td>0</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>35</td><td>30</td><td>0</td><td>10</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>35</td><td>30</td><td>0</td><td>10</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>35</td><td>30</td><td>0</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>60</td><td>25</td><td>30</td><td>0</td><td>5</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(磁力纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(磁力纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>60</td><td>30</td><td>0</td><td>10</td><td>0</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Belly</td><td>35</td><td>40</td><td>45</td><td>0</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>25</td><td>35</td><td>0</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>55</td><td>50</td><td>40</td><td>0</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>35</td><td>30</td><td>0</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>35</td><td>30</td><td>0</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>35</td><td>30</td><td>0</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>60</td><td>25</td><td>30</td><td>0</td><td>10</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 </table>
@@ -89,11 +89,11 @@
 <tr><td>Head</td><td>500</td><td>２ stagger(s) required for first partbreak stage<br>４ stagger(s) required for complete partbreak</td></tr>
 <tr><td>Torso</td><td>400</td><td></td></tr>
 <tr><td>Tail</td><td>500</td><td></td></tr>
-<tr><td>Left Foot</td><td>300</td><td><div>
+<tr><td>Left Leg</td><td>300</td><td><div>
 <span><em>12</em>407</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>300</td><td><div>
+<tr><td>Right Leg</td><td>300</td><td><div>
 <span><em>12</em>407</span>
 </div>
 </td></tr>

--- a/mons/ruco_ng.htm
+++ b/mons/ruco_ng.htm
@@ -123,22 +123,22 @@
 <img id=icon src="../img/monsicons/rukodiora.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>30</td><td>0</td><td>5</td><td>0</td><td>10</td><td>10</td><td>100</td></tr>
 <tr><td>Belly</td><td>25</td><td>30</td><td>35</td><td>0</td><td>10</td><td>0</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>Back</td><td>15</td><td>15</td><td>25</td><td>0</td><td>10</td><td>0</td><td>25</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>35</td><td>40</td><td>0</td><td>10</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>20</td><td>25</td><td>20</td><td>0</td><td>10</td><td>0</td><td>20</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>20</td><td>25</td><td>20</td><td>0</td><td>10</td><td>0</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>25</td><td>20</td><td>0</td><td>10</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>45</td><td>25</td><td>20</td><td>0</td><td>5</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(磁力纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(磁力纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>30</td><td>0</td><td>5</td><td>0</td><td>0</td><td>25</td><td>100</td></tr>
 <tr><td>Belly</td><td>25</td><td>30</td><td>35</td><td>0</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Back</td><td>15</td><td>15</td><td>25</td><td>0</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>35</td><td>40</td><td>0</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>20</td><td>25</td><td>20</td><td>0</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>20</td><td>25</td><td>20</td><td>0</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>25</td><td>20</td><td>0</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Wing</td><td>45</td><td>25</td><td>20</td><td>0</td><td>5</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 </table>
@@ -149,8 +149,8 @@
 <tr><td>Head</td><td>500</td><td>２ stagger(s) required for first partbreak stage<br>４ stagger(s) required for complete partbreak</td></tr>
 <tr><td>Torso</td><td>900</td><td></td></tr>
 <tr><td>Tail</td><td>750</td><td></td></tr>
-<tr><td>Left Foot</td><td>700</td><td></td></tr>
-<tr><td>Right Foot</td><td>700</td><td></td></tr>
+<tr><td>Left Leg</td><td>700</td><td></td></tr>
+<tr><td>Right Leg</td><td>700</td><td></td></tr>
 <tr><td>Wing</td><td>600</td><td>２ stagger(s) required for first partbreak stage<br>４ stagger(s) required for complete partbreak</td></tr>
 <tr><td>Tail Cut</td><td>1300</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>

--- a/mons/ruco_nh.htm
+++ b/mons/ruco_nh.htm
@@ -81,22 +81,22 @@
 <img id=icon src="../img/monsicons/rukodiora.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>60</td><td>30</td><td>0</td><td>5</td><td>0</td><td>5</td><td>10</td><td>100</td></tr>
 <tr><td>Belly</td><td>30</td><td>40</td><td>35</td><td>0</td><td>10</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>20</td><td>25</td><td>0</td><td>10</td><td>0</td><td>20</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>40</td><td>40</td><td>0</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>25</td><td>20</td><td>0</td><td>10</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>25</td><td>20</td><td>0</td><td>10</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>25</td><td>20</td><td>0</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>60</td><td>20</td><td>20</td><td>0</td><td>5</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(磁力纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(磁力纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>60</td><td>30</td><td>0</td><td>10</td><td>0</td><td>0</td><td>10</td><td>100</td></tr>
 <tr><td>Belly</td><td>30</td><td>40</td><td>35</td><td>0</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>20</td><td>25</td><td>0</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>45</td><td>40</td><td>40</td><td>0</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>25</td><td>20</td><td>0</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>25</td><td>20</td><td>0</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>25</td><td>20</td><td>0</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Wing</td><td>60</td><td>20</td><td>20</td><td>0</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 </table>
@@ -107,8 +107,8 @@
 <tr><td>Head</td><td>500</td><td>２ stagger(s) required for first partbreak stage<br>４ stagger(s) required for complete partbreak</td></tr>
 <tr><td>Torso</td><td>400</td><td></td></tr>
 <tr><td>Tail</td><td>500</td><td></td></tr>
-<tr><td>Left Foot</td><td>300</td><td></td></tr>
-<tr><td>Right Foot</td><td>300</td><td></td></tr>
+<tr><td>Left Leg</td><td>300</td><td></td></tr>
+<tr><td>Right Leg</td><td>300</td><td></td></tr>
 <tr><td>Wing</td><td>800</td><td>２ stagger(s) required for first partbreak stage<br>４ stagger(s) required for complete partbreak</td></tr>
 <tr><td>-</td><td>250</td><td></td></tr>
 <tr><td>-</td><td>190</td><td></td></tr>

--- a/mons/ruco_ni.htm
+++ b/mons/ruco_ni.htm
@@ -112,22 +112,22 @@
 <img id=icon src="../img/monsicons/zenith_rukodiora.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>35</td><td>30</td><td>0</td><td>5</td><td>0</td><td>20</td><td>10</td><td>100</td></tr>
 <tr><td>Belly</td><td>15</td><td>20</td><td>15</td><td>0</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Back</td><td>10</td><td>10</td><td>10</td><td>0</td><td>10</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>15</td><td>15</td><td>0</td><td>10</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>10</td><td>10</td><td>15</td><td>0</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>10</td><td>10</td><td>15</td><td>0</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>10</td><td>10</td><td>10</td><td>0</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>35</td><td>25</td><td>20</td><td>0</td><td>5</td><td>0</td><td>20</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(磁力纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(磁力纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>30</td><td>0</td><td>5</td><td>0</td><td>0</td><td>25</td><td>100</td></tr>
 <tr><td>Belly</td><td>25</td><td>30</td><td>35</td><td>0</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Back</td><td>15</td><td>15</td><td>25</td><td>0</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>35</td><td>40</td><td>0</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>20</td><td>25</td><td>20</td><td>0</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>20</td><td>25</td><td>20</td><td>0</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>25</td><td>20</td><td>0</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Wing</td><td>45</td><td>25</td><td>20</td><td>0</td><td>5</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 </table>
@@ -138,8 +138,8 @@
 <tr><td>Head</td><td>1200</td><td>２ stagger(s) required</td></tr>
 <tr><td>Torso</td><td>1400</td><td></td></tr>
 <tr><td>Tail</td><td>1200</td><td></td></tr>
-<tr><td>Left Foot</td><td>900</td><td></td></tr>
-<tr><td>Right Foot</td><td>900</td><td></td></tr>
+<tr><td>Left Leg</td><td>900</td><td></td></tr>
+<tr><td>Right Leg</td><td>900</td><td></td></tr>
 <tr><td>Wing</td><td>6000</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail Cut</td><td>2000</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>

--- a/mons/saboten_n.htm
+++ b/mons/saboten_n.htm
@@ -78,7 +78,7 @@
 <img id=icon src="../img/monsicons/cactus.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>100</td><td>100</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>150</td></tr>
 </table>

--- a/mons/sell_ng.htm
+++ b/mons/sell_ng.htm
@@ -97,7 +97,7 @@
 <img id=icon src="../img/monsicons/seregios.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>25</td><td>35</td><td>25</td><td>0</td><td>10</td><td>20</td><td>5</td><td>15</td><td>100</td></tr>
 <tr><td>？？</td><td>15</td><td>15</td><td>20</td><td>10</td><td>5</td><td>10</td><td>5</td><td>10</td><td>0</td></tr>
@@ -106,7 +106,7 @@
 <tr><td>？？</td><td>22</td><td>22</td><td>22</td><td>0</td><td>5</td><td>10</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>35</td><td>30</td><td>30</td><td>0</td><td>5</td><td>15</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>？？</td><td>25</td><td>15</td><td>15</td><td>0</td><td>5</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>25</td><td>35</td><td>25</td><td>0</td><td>10</td><td>20</td><td>5</td><td>15</td><td>100</td></tr>
 <tr><td>？？</td><td>15</td><td>15</td><td>20</td><td>10</td><td>5</td><td>10</td><td>5</td><td>10</td><td>0</td></tr>

--- a/mons/sell_nh.htm
+++ b/mons/sell_nh.htm
@@ -75,7 +75,7 @@
 <img id=icon src="../img/monsicons/seregios.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>28</td><td>35</td><td>30</td><td>0</td><td>10</td><td>25</td><td>5</td><td>15</td><td>100</td></tr>
 <tr><td>？？</td><td>25</td><td>20</td><td>20</td><td>15</td><td>10</td><td>15</td><td>5</td><td>15</td><td>0</td></tr>
@@ -84,7 +84,7 @@
 <tr><td>？？</td><td>26</td><td>26</td><td>26</td><td>0</td><td>10</td><td>15</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>35</td><td>30</td><td>30</td><td>0</td><td>5</td><td>20</td><td>5</td><td>15</td><td>0</td></tr>
 <tr><td>？？</td><td>30</td><td>25</td><td>20</td><td>0</td><td>5</td><td>10</td><td>5</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>28</td><td>35</td><td>30</td><td>0</td><td>10</td><td>25</td><td>5</td><td>15</td><td>100</td></tr>
 <tr><td>？？</td><td>25</td><td>20</td><td>20</td><td>15</td><td>10</td><td>15</td><td>5</td><td>15</td><td>0</td></tr>

--- a/mons/shagal_ng.htm
+++ b/mons/shagal_ng.htm
@@ -97,7 +97,7 @@
 <img id=icon src="../img/monsicons/shagarumagala.webp" width="300"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>28</td><td>25</td><td>28</td><td>15</td><td>0</td><td>15</td><td>20</td><td>5</td><td>100</td></tr>
 <tr><td>？？</td><td>19</td><td>19</td><td>17</td><td>5</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
@@ -106,7 +106,7 @@
 <tr><td>？？</td><td>12</td><td>12</td><td>12</td><td>5</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>？？</td><td>20</td><td>20</td><td>18</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>？？</td><td>25</td><td>17</td><td>28</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(狂竜化)</th></tr>
+<tr class=l><th colspan=10>Hitzones(狂竜化)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>35</td><td>33</td><td>35</td><td>25</td><td>0</td><td>15</td><td>25</td><td>5</td><td>100</td></tr>
 <tr><td>？？</td><td>19</td><td>19</td><td>17</td><td>5</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
@@ -115,7 +115,7 @@
 <tr><td>？？</td><td>12</td><td>12</td><td>12</td><td>5</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>？？</td><td>20</td><td>20</td><td>18</td><td>15</td><td>0</td><td>5</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>？？</td><td>25</td><td>17</td><td>28</td><td>10</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(真・狂竜化)</th></tr>
+<tr class=l><th colspan=10>Hitzones(真・狂竜化)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>35</td><td>33</td><td>35</td><td>25</td><td>0</td><td>10</td><td>25</td><td>5</td><td>100</td></tr>
 <tr><td>？？</td><td>19</td><td>19</td><td>17</td><td>5</td><td>0</td><td>5</td><td>5</td><td>5</td><td>0</td></tr>

--- a/mons/shagal_nh.htm
+++ b/mons/shagal_nh.htm
@@ -75,7 +75,7 @@
 <img id=icon src="../img/monsicons/shagarumagala.webp" width="300"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>50</td><td>45</td><td>35</td><td>25</td><td>0</td><td>15</td><td>30</td><td>5</td><td>100</td></tr>
 <tr><td>？？</td><td>25</td><td>25</td><td>25</td><td>10</td><td>0</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
@@ -84,7 +84,7 @@
 <tr><td>？？</td><td>32</td><td>32</td><td>25</td><td>10</td><td>0</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>？？</td><td>20</td><td>26</td><td>20</td><td>15</td><td>0</td><td>10</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>？？</td><td>35</td><td>35</td><td>30</td><td>10</td><td>0</td><td>10</td><td>15</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(狂竜化)</th></tr>
+<tr class=l><th colspan=10>Hitzones(狂竜化)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>55</td><td>50</td><td>40</td><td>30</td><td>0</td><td>15</td><td>30</td><td>5</td><td>100</td></tr>
 <tr><td>？？</td><td>25</td><td>25</td><td>25</td><td>10</td><td>0</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>

--- a/mons/shan_ng.htm
+++ b/mons/shan_ng.htm
@@ -83,21 +83,21 @@
 <img id=icon src="../img/monsicons/shantien.webp" width="250"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>40</td><td>25</td><td>0</td><td>0</td><td>0</td><td>30</td><td>15</td><td>100</td></tr>
 <tr><td>Neck</td><td>25</td><td>15</td><td>15</td><td>0</td><td>0</td><td>0</td><td>20</td><td>10</td><td>0</td></tr>
 <tr><td>Belly</td><td>25</td><td>30</td><td>15</td><td>0</td><td>0</td><td>0</td><td>15</td><td>15</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>20</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>20</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>20</td><td>20</td><td>0</td><td>0</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>Back</td><td>45</td><td>30</td><td>35</td><td>0</td><td>0</td><td>0</td><td>25</td><td>30</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>35</td><td>20</td><td>0</td><td>0</td><td>0</td><td>20</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(炎纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(炎纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>55</td><td>30</td><td>0</td><td>0</td><td>0</td><td>45</td><td>25</td><td>100</td></tr>
 <tr><td>Neck</td><td>35</td><td>25</td><td>20</td><td>0</td><td>0</td><td>0</td><td>25</td><td>15</td><td>0</td></tr>
 <tr><td>Belly</td><td>30</td><td>40</td><td>20</td><td>0</td><td>0</td><td>0</td><td>20</td><td>20</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>35</td><td>30</td><td>0</td><td>0</td><td>0</td><td>20</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>35</td><td>30</td><td>0</td><td>0</td><td>0</td><td>20</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>35</td><td>25</td><td>25</td><td>0</td><td>0</td><td>0</td><td>10</td><td>20</td><td>0</td></tr>
 <tr><td>Back</td><td>55</td><td>40</td><td>25</td><td>0</td><td>0</td><td>0</td><td>40</td><td>45</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>40</td><td>45</td><td>0</td><td>0</td><td>0</td><td>30</td><td>20</td><td>0</td></tr>
@@ -108,11 +108,11 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>500</td><td>３ stagger(s) required</td></tr>
 <tr><td>Belly</td><td>700</td><td></td></tr>
-<tr><td>左前脚</td><td>600</td><td>２ stagger(s) required</td></tr>
-<tr><td>右前脚</td><td>600</td><td>２ stagger(s) required</td></tr>
+<tr><td>Left Foreleg</td><td>600</td><td>２ stagger(s) required</td></tr>
+<tr><td>Right Foreleg</td><td>600</td><td>２ stagger(s) required</td></tr>
 <tr><td>Hind Leg</td><td>600</td><td></td></tr>
 <tr><td>Back</td><td>600</td><td>２ stagger(s) required</td></tr>
-<tr><td>尾</td><td>600</td><td>２ stagger(s) required</td></tr>
+<tr><td>Tail</td><td>600</td><td>２ stagger(s) required</td></tr>
 <tr><td></td><td>1000</td><td></td></tr>
 <tr><td></td><td>600</td><td></td></tr>
 </table>

--- a/mons/shen_n.htm
+++ b/mons/shen_n.htm
@@ -59,28 +59,28 @@
 <img id=icon src="../img/monsicons/shengaoren.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>38</td><td>40</td><td>40</td><td>25</td><td>5</td><td>20</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Torso</td><td>40</td><td>45</td><td>30</td><td>20</td><td>5</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>ヤド</td><td>10</td><td>20</td><td>20</td><td>25</td><td>5</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Shell</td><td>10</td><td>20</td><td>20</td><td>25</td><td>5</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>32</td><td>37</td><td>25</td><td>25</td><td>5</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>爪</td><td>10</td><td>20</td><td>20</td><td>25</td><td>5</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>腕</td><td>20</td><td>20</td><td>20</td><td>25</td><td>5</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>弱点/ヤドの中</td><td>80</td><td>90</td><td>80</td><td>30</td><td>5</td><td>20</td><td>100</td><td>5</td><td>0</td></tr>
+<tr><td>Claw</td><td>10</td><td>20</td><td>20</td><td>25</td><td>5</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Arm</td><td>20</td><td>20</td><td>20</td><td>25</td><td>5</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Weak Point/Shell Inside</td><td>80</td><td>90</td><td>80</td><td>30</td><td>5</td><td>20</td><td>100</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
-<tr><td>顔</td><td>400</td><td></td></tr>
+<tr><td>Face</td><td>400</td><td></td></tr>
 <tr><td>Torso</td><td>800</td><td></td></tr>
-<tr><td>ヤド</td><td>1000</td><td>２ stagger(s) required for first partbreak stage<br>４ stagger(s) required for full partbreak</td></tr>
-<tr><td>左前脚</td><td>600</td><td>After staggering each leg twice<br>(All legs glow bright red)<br>(2nd stagger can only happen when upright)<br>Stagger any leg once (must be done while upright)</td></tr>
-<tr><td>左後脚</td><td>600</td><td></td></tr>
-<tr><td>右前脚</td><td>600</td><td></td></tr>
-<tr><td>右後脚</td><td>600</td><td></td></tr>
-<tr><td>爪</td><td>880</td><td></td></tr>
+<tr><td>Shell</td><td>1000</td><td>２ stagger(s) required for first partbreak stage<br>４ stagger(s) required for full partbreak</td></tr>
+<tr><td>Left Foreleg</td><td>600</td><td>After staggering each leg twice<br>(All legs glow bright red)<br>(2nd stagger can only happen when upright)<br>Stagger any leg once (must be done while upright)</td></tr>
+<tr><td>Left Hind Leg</td><td>600</td><td></td></tr>
+<tr><td>Right Foreleg</td><td>600</td><td></td></tr>
+<tr><td>Right Hind Leg</td><td>600</td><td></td></tr>
+<tr><td>Claw</td><td>880</td><td></td></tr>
 </table>
 <img id=hitzones src="../img/monszones/shengaoren.png" width="400"/>
 <table id=kou>

--- a/mons/shen_nh.htm
+++ b/mons/shen_nh.htm
@@ -75,28 +75,28 @@
 <img id=icon src="../img/monsicons/shengaoren.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>35</td><td>30</td><td>10</td><td>5</td><td>40</td><td>50</td><td>5</td><td>100</td></tr>
 <tr><td>Torso</td><td>15</td><td>50</td><td>20</td><td>10</td><td>5</td><td>-30</td><td>10</td><td>5</td><td>0</td></tr>
-<tr><td>ヤド</td><td>15</td><td>30</td><td>10</td><td>10</td><td>5</td><td>-30</td><td>30</td><td>5</td><td>0</td></tr>
+<tr><td>Shell</td><td>15</td><td>30</td><td>10</td><td>10</td><td>5</td><td>-30</td><td>30</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>40</td><td>30</td><td>15</td><td>15</td><td>5</td><td>-30</td><td>30</td><td>5</td><td>0</td></tr>
-<tr><td>爪</td><td>20</td><td>20</td><td>15</td><td>10</td><td>5</td><td>-30</td><td>10</td><td>5</td><td>0</td></tr>
-<tr><td>腕</td><td>30</td><td>20</td><td>15</td><td>10</td><td>5</td><td>-30</td><td>10</td><td>5</td><td>0</td></tr>
-<tr><td>弱点/ヤドの中</td><td>60</td><td>60</td><td>70</td><td>10</td><td>5</td><td>0</td><td>20</td><td>5</td><td>0</td></tr>
+<tr><td>Claw</td><td>20</td><td>20</td><td>15</td><td>10</td><td>5</td><td>-30</td><td>10</td><td>5</td><td>0</td></tr>
+<tr><td>Arm</td><td>30</td><td>20</td><td>15</td><td>10</td><td>5</td><td>-30</td><td>10</td><td>5</td><td>0</td></tr>
+<tr><td>Weak Point/Shell Inside</td><td>60</td><td>60</td><td>70</td><td>10</td><td>5</td><td>0</td><td>20</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
-<tr><td>顔</td><td>400</td><td></td></tr>
+<tr><td>Face</td><td>400</td><td></td></tr>
 <tr><td>Torso</td><td>800</td><td></td></tr>
-<tr><td>ヤド</td><td>1000</td><td>２ stagger(s) required for first partbreak stage<br>４ stagger(s) required for full partbreak</td></tr>
-<tr><td>左前脚</td><td>600</td><td>After staggering each leg twice<br>(All legs glow bright red)<br>(2nd stagger can only happen when upright)<br>Stagger any leg once (must be done while upright)</td></tr>
-<tr><td>左後脚</td><td>600</td><td></td></tr>
-<tr><td>右前脚</td><td>600</td><td></td></tr>
-<tr><td>右後脚</td><td>600</td><td></td></tr>
-<tr><td>爪</td><td>880</td><td></td></tr>
+<tr><td>Shell</td><td>1000</td><td>２ stagger(s) required for first partbreak stage<br>４ stagger(s) required for full partbreak</td></tr>
+<tr><td>Left Foreleg</td><td>600</td><td>After staggering each leg twice<br>(All legs glow bright red)<br>(2nd stagger can only happen when upright)<br>Stagger any leg once (must be done while upright)</td></tr>
+<tr><td>Left Hind Leg</td><td>600</td><td></td></tr>
+<tr><td>Right Foreleg</td><td>600</td><td></td></tr>
+<tr><td>Right Hind Leg</td><td>600</td><td></td></tr>
+<tr><td>Claw</td><td>880</td><td></td></tr>
 </table>
 <img id=hitzones src="../img/monszones/shengaorenhr5.png" width="400"/>
 <table id=kou>

--- a/mons/syougun_n.htm
+++ b/mons/syougun_n.htm
@@ -80,35 +80,35 @@
 <img id=icon src="../img/monsicons/shogunceanataur.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>55</td><td>35</td><td>10</td><td>10</td><td>35</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Torso</td><td>35</td><td>40</td><td>25</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>ヤド</td><td>25</td><td>40</td><td>20</td><td>5</td><td>5</td><td>25</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Shell</td><td>25</td><td>40</td><td>20</td><td>5</td><td>5</td><td>25</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>30</td><td>30</td><td>5</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>鋏</td><td>20</td><td>30</td><td>15</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>腕</td><td>20</td><td>35</td><td>25</td><td>5</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(殻破壊後)</th></tr>
+<tr><td>Pincer</td><td>20</td><td>30</td><td>15</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>20</td><td>35</td><td>25</td><td>5</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(殻破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>60</td><td>40</td><td>10</td><td>10</td><td>35</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Torso</td><td>40</td><td>50</td><td>30</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>ヤド</td><td>25</td><td>35</td><td>20</td><td>5</td><td>5</td><td>25</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Shell</td><td>25</td><td>35</td><td>20</td><td>5</td><td>5</td><td>25</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>35</td><td>50</td><td>30</td><td>5</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>鋏</td><td>25</td><td>35</td><td>15</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>腕</td><td>30</td><td>35</td><td>25</td><td>5</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Pincer</td><td>25</td><td>35</td><td>15</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>30</td><td>35</td><td>25</td><td>5</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>150</td><td></td></tr>
-<tr><td>胴</td><td>150</td><td></td></tr>
-<tr><td>ヤド</td><td>200</td><td>２ stagger(s) required for full partbreak<br>Can be replaced after break</td></tr>
-<tr><td>Left Foot</td><td>200</td><td></td></tr>
-<tr><td>Right Foot</td><td>180</td><td></td></tr>
-<tr><td>左爪</td><td>150</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
-<tr><td>右爪</td><td>100</td><td>１ stagger(s) required</td></tr>
-<tr><td>腕</td><td>100</td><td></td></tr>
+<tr><td>Torso</td><td>150</td><td></td></tr>
+<tr><td>Shell</td><td>200</td><td>２ stagger(s) required for full partbreak<br>Can be replaced after break</td></tr>
+<tr><td>Left Leg</td><td>200</td><td></td></tr>
+<tr><td>Right Leg</td><td>180</td><td></td></tr>
+<tr><td>Left Claw</td><td>150</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
+<tr><td>Right Claw</td><td>100</td><td>１ stagger(s) required</td></tr>
+<tr><td>Arm</td><td>100</td><td></td></tr>
 </table>
 <img id=hitzones src="../img/monszones/shogunceanataur.png" width="400"/>
 <table id=kou>

--- a/mons/syougun_ng.htm
+++ b/mons/syougun_ng.htm
@@ -124,35 +124,35 @@
 <img id=icon src="../img/monsicons/shogunceanataur.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>55</td><td>35</td><td>10</td><td>10</td><td>30</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Torso</td><td>40</td><td>35</td><td>25</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>ヤド</td><td>25</td><td>35</td><td>20</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Shell</td><td>25</td><td>35</td><td>20</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>15</td><td>5</td><td>5</td><td>15</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>鋏</td><td>20</td><td>30</td><td>20</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>腕</td><td>20</td><td>35</td><td>25</td><td>5</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(殻破壊後)</th></tr>
+<tr><td>Pincer</td><td>20</td><td>30</td><td>20</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>20</td><td>35</td><td>25</td><td>5</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(殻破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>60</td><td>40</td><td>10</td><td>10</td><td>30</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Torso</td><td>45</td><td>40</td><td>30</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>ヤド</td><td>25</td><td>35</td><td>20</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Shell</td><td>25</td><td>35</td><td>20</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>30</td><td>40</td><td>20</td><td>5</td><td>5</td><td>15</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>鋏</td><td>25</td><td>35</td><td>20</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>腕</td><td>30</td><td>35</td><td>30</td><td>5</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Pincer</td><td>25</td><td>35</td><td>20</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>30</td><td>35</td><td>30</td><td>5</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>350</td><td></td></tr>
-<tr><td>胴</td><td>350</td><td></td></tr>
-<tr><td>ヤド</td><td>400</td><td>２ stagger(s) required for full partbreak<br>Can be replaced after break</td></tr>
-<tr><td>Left Foot</td><td>400</td><td></td></tr>
-<tr><td>Right Foot</td><td>380</td><td></td></tr>
-<tr><td>左爪</td><td>350</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
-<tr><td>右爪</td><td>550</td><td>１ stagger(s) required</td></tr>
-<tr><td>腕</td><td>300</td><td></td></tr>
+<tr><td>Torso</td><td>350</td><td></td></tr>
+<tr><td>Shell</td><td>400</td><td>２ stagger(s) required for full partbreak<br>Can be replaced after break</td></tr>
+<tr><td>Left Leg</td><td>400</td><td></td></tr>
+<tr><td>Right Leg</td><td>380</td><td></td></tr>
+<tr><td>Left Claw</td><td>350</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
+<tr><td>Right Claw</td><td>550</td><td>１ stagger(s) required</td></tr>
+<tr><td>Arm</td><td>300</td><td></td></tr>
 </table>
 <img id=hitzones src="../img/monszones/shogunceanataur.png" width="400"/>
 <table id=kou>

--- a/mons/syougun_nh.htm
+++ b/mons/syougun_nh.htm
@@ -77,35 +77,35 @@
 <img id=icon src="../img/monsicons/shogunceanataur.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>40</td><td>10</td><td>5</td><td>0</td><td>15</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Torso</td><td>35</td><td>30</td><td>10</td><td>5</td><td>10</td><td>-5</td><td>-5</td><td>5</td><td>0</td></tr>
-<tr><td>ヤド</td><td>25</td><td>30</td><td>20</td><td>-5</td><td>10</td><td>-5</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Shell</td><td>25</td><td>30</td><td>20</td><td>-5</td><td>10</td><td>-5</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>30</td><td>30</td><td>10</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>鋏</td><td>20</td><td>30</td><td>35</td><td>10</td><td>5</td><td>0</td><td>15</td><td>10</td><td>0</td></tr>
-<tr><td>腕</td><td>20</td><td>35</td><td>25</td><td>5</td><td>5</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(殻破壊後)</th></tr>
+<tr><td>Pincer</td><td>20</td><td>30</td><td>35</td><td>10</td><td>5</td><td>0</td><td>15</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>20</td><td>35</td><td>25</td><td>5</td><td>5</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(殻破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>50</td><td>10</td><td>5</td><td>0</td><td>15</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Torso</td><td>40</td><td>40</td><td>10</td><td>5</td><td>10</td><td>-5</td><td>-5</td><td>5</td><td>0</td></tr>
-<tr><td>ヤド</td><td>25</td><td>35</td><td>20</td><td>-5</td><td>10</td><td>-5</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Shell</td><td>25</td><td>35</td><td>20</td><td>-5</td><td>10</td><td>-5</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Leg</td><td>35</td><td>40</td><td>30</td><td>10</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>鋏</td><td>25</td><td>35</td><td>40</td><td>10</td><td>5</td><td>0</td><td>15</td><td>10</td><td>0</td></tr>
-<tr><td>腕</td><td>30</td><td>35</td><td>20</td><td>5</td><td>5</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Pincer</td><td>25</td><td>35</td><td>40</td><td>10</td><td>5</td><td>0</td><td>15</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>30</td><td>35</td><td>20</td><td>5</td><td>5</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>150</td><td></td></tr>
-<tr><td>胴</td><td>150</td><td></td></tr>
-<tr><td>ヤド</td><td>200</td><td>２ stagger(s) required for full partbreak<br>Can be replaced after break</td></tr>
-<tr><td>Left Foot</td><td>200</td><td></td></tr>
-<tr><td>Right Foot</td><td>180</td><td></td></tr>
-<tr><td>左爪</td><td>150</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
-<tr><td>右爪</td><td>100</td><td>１ stagger(s) required</td></tr>
-<tr><td>腕</td><td>100</td><td></td></tr>
+<tr><td>Torso</td><td>150</td><td></td></tr>
+<tr><td>Shell</td><td>200</td><td>２ stagger(s) required for full partbreak<br>Can be replaced after break</td></tr>
+<tr><td>Left Leg</td><td>200</td><td></td></tr>
+<tr><td>Right Leg</td><td>180</td><td></td></tr>
+<tr><td>Left Claw</td><td>150</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
+<tr><td>Right Claw</td><td>100</td><td>１ stagger(s) required</td></tr>
+<tr><td>Arm</td><td>100</td><td></td></tr>
 </table>
 <img id=hitzones src="../img/monszones/shogunceanataurhr5.png" width="400"/>
 <table id=kou>

--- a/mons/syougun_nt.htm
+++ b/mons/syougun_nt.htm
@@ -104,35 +104,35 @@
 <img id=icon src="../img/monsicons/shogunceanataur.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>55</td><td>35</td><td>10</td><td>10</td><td>35</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Torso</td><td>40</td><td>35</td><td>25</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>ヤド</td><td>25</td><td>35</td><td>20</td><td>5</td><td>5</td><td>25</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Shell</td><td>25</td><td>35</td><td>20</td><td>5</td><td>5</td><td>25</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>25</td><td>25</td><td>15</td><td>5</td><td>5</td><td>15</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>鋏</td><td>20</td><td>30</td><td>20</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>腕</td><td>20</td><td>35</td><td>25</td><td>5</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(殻破壊後)</th></tr>
+<tr><td>Pincer</td><td>20</td><td>30</td><td>20</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>20</td><td>35</td><td>25</td><td>5</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(殻破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>60</td><td>40</td><td>10</td><td>10</td><td>35</td><td>0</td><td>20</td><td>100</td></tr>
 <tr><td>Torso</td><td>45</td><td>40</td><td>30</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>ヤド</td><td>25</td><td>35</td><td>20</td><td>5</td><td>5</td><td>25</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Shell</td><td>25</td><td>35</td><td>20</td><td>5</td><td>5</td><td>25</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>30</td><td>40</td><td>20</td><td>5</td><td>5</td><td>15</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>鋏</td><td>25</td><td>35</td><td>20</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>腕</td><td>30</td><td>35</td><td>30</td><td>5</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Pincer</td><td>25</td><td>35</td><td>20</td><td>5</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Arm</td><td>30</td><td>35</td><td>30</td><td>5</td><td>5</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>150</td><td></td></tr>
-<tr><td>胴</td><td>150</td><td></td></tr>
-<tr><td>ヤド</td><td>200</td><td>２ stagger(s) required for full partbreak<br>Can be replaced after break</td></tr>
-<tr><td>Left Foot</td><td>200</td><td></td></tr>
-<tr><td>Right Foot</td><td>180</td><td></td></tr>
-<tr><td>左爪</td><td>150</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
-<tr><td>右爪</td><td>100</td><td>１ stagger(s) required</td></tr>
-<tr><td>腕</td><td>100</td><td></td></tr>
+<tr><td>Torso</td><td>150</td><td></td></tr>
+<tr><td>Shell</td><td>200</td><td>２ stagger(s) required for full partbreak<br>Can be replaced after break</td></tr>
+<tr><td>Left Leg</td><td>200</td><td></td></tr>
+<tr><td>Right Leg</td><td>180</td><td></td></tr>
+<tr><td>Left Claw</td><td>150</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
+<tr><td>Right Claw</td><td>100</td><td>１ stagger(s) required</td></tr>
+<tr><td>Arm</td><td>100</td><td></td></tr>
 </table>
 <img id=hitzones src="../img/monszones/shogunceanataur.png" width="400"/>
 <table id=kou>

--- a/mons/taikun_n.htm
+++ b/mons/taikun_n.htm
@@ -59,29 +59,29 @@
 <img id=icon src="../img/monsicons/taikunzamuza.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>55</td><td>35</td><td>35</td><td>15</td><td>0</td><td>0</td><td>20</td><td>100</td></tr>
-<tr><td>胴</td><td>40</td><td>45</td><td>25</td><td>30</td><td>15</td><td>0</td><td>0</td><td>20</td><td>0</td></tr>
+<tr><td>Torso</td><td>40</td><td>45</td><td>25</td><td>30</td><td>15</td><td>0</td><td>0</td><td>20</td><td>0</td></tr>
 <tr><td>Leg</td><td>45</td><td>40</td><td>35</td><td>30</td><td>20</td><td>0</td><td>0</td><td>25</td><td>0</td></tr>
-<tr><td>右爪</td><td>35</td><td>50</td><td>40</td><td>25</td><td>20</td><td>0</td><td>0</td><td>25</td><td>0</td></tr>
-<tr><td>左爪</td><td>50</td><td>35</td><td>45</td><td>25</td><td>20</td><td>0</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>尾</td><td>40</td><td>25</td><td>30</td><td>20</td><td>15</td><td>0</td><td>0</td><td>20</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(紅状態)</th></tr>
+<tr><td>Right Claw</td><td>35</td><td>50</td><td>40</td><td>25</td><td>20</td><td>0</td><td>0</td><td>25</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>50</td><td>35</td><td>45</td><td>25</td><td>20</td><td>0</td><td>0</td><td>20</td><td>0</td></tr>
+<tr><td>Tail</td><td>40</td><td>25</td><td>30</td><td>20</td><td>15</td><td>0</td><td>0</td><td>20</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(紅状態)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>60</td><td>40</td><td>25</td><td>15</td><td>0</td><td>0</td><td>20</td><td>100</td></tr>
-<tr><td>胴</td><td>45</td><td>45</td><td>25</td><td>20</td><td>15</td><td>0</td><td>0</td><td>25</td><td>0</td></tr>
+<tr><td>Torso</td><td>45</td><td>45</td><td>25</td><td>20</td><td>15</td><td>0</td><td>0</td><td>25</td><td>0</td></tr>
 <tr><td>Leg</td><td>50</td><td>40</td><td>35</td><td>20</td><td>20</td><td>0</td><td>0</td><td>30</td><td>0</td></tr>
-<tr><td>右爪</td><td>40</td><td>50</td><td>50</td><td>15</td><td>20</td><td>0</td><td>0</td><td>25</td><td>0</td></tr>
-<tr><td>左爪</td><td>50</td><td>40</td><td>55</td><td>15</td><td>20</td><td>0</td><td>0</td><td>25</td><td>0</td></tr>
-<tr><td>尾</td><td>40</td><td>25</td><td>30</td><td>15</td><td>15</td><td>0</td><td>0</td><td>20</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(蒼状態)</th></tr>
+<tr><td>Right Claw</td><td>40</td><td>50</td><td>50</td><td>15</td><td>20</td><td>0</td><td>0</td><td>25</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>50</td><td>40</td><td>55</td><td>15</td><td>20</td><td>0</td><td>0</td><td>25</td><td>0</td></tr>
+<tr><td>Tail</td><td>40</td><td>25</td><td>30</td><td>15</td><td>15</td><td>0</td><td>0</td><td>20</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(蒼状態)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>70</td><td>45</td><td>5</td><td>25</td><td>0</td><td>0</td><td>10</td><td>100</td></tr>
-<tr><td>胴</td><td>45</td><td>50</td><td>25</td><td>5</td><td>25</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Torso</td><td>45</td><td>50</td><td>25</td><td>5</td><td>25</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>55</td><td>45</td><td>45</td><td>5</td><td>30</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>右爪</td><td>60</td><td>60</td><td>60</td><td>5</td><td>30</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>左爪</td><td>70</td><td>55</td><td>60</td><td>5</td><td>30</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>60</td><td>60</td><td>60</td><td>5</td><td>30</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>70</td><td>55</td><td>60</td><td>5</td><td>30</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
@@ -91,31 +91,31 @@
 <span><em>6</em>240</span>
 </div>
 ２ stagger(s) required、４ stagger(s) required to break the part. Cannot break while Paralyzed</td></tr>
-<tr><td>左爪</td><td>120</td><td><div>
+<tr><td>Left Claw</td><td>120</td><td><div>
 <span><em>6</em>72</span>
 </div>
 </td></tr>
-<tr><td>右爪</td><td>120</td><td><div>
+<tr><td>Right Claw</td><td>120</td><td><div>
 <span><em>6</em>72</span>
 </div>
 </td></tr>
-<tr><td>左前脚</td><td>60</td><td><div>
+<tr><td>Left Foreleg</td><td>60</td><td><div>
 <span><em>6</em>36</span>
 </div>
 </td></tr>
-<tr><td>左後脚</td><td>50</td><td><div>
+<tr><td>Left Hind Leg</td><td>50</td><td><div>
 <span><em>6</em>30</span>
 </div>
 </td></tr>
-<tr><td>右前脚</td><td>60</td><td><div>
+<tr><td>Right Foreleg</td><td>60</td><td><div>
 <span><em>6</em>36</span>
 </div>
 </td></tr>
-<tr><td>右後脚</td><td>50</td><td><div>
+<tr><td>Right Hind Leg</td><td>50</td><td><div>
 <span><em>6</em>30</span>
 </div>
 </td></tr>
-<tr><td>尾</td><td>50</td><td><div>
+<tr><td>Tail</td><td>50</td><td><div>
 <span><em>6</em>30</span>
 </div>
 </td></tr>

--- a/mons/taikun_nh.htm
+++ b/mons/taikun_nh.htm
@@ -78,42 +78,42 @@
 <img id=icon src="../img/monsicons/taikunzamuza.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>55</td><td>25</td><td>25</td><td>5</td><td>0</td><td>0</td><td>10</td><td>100</td></tr>
-<tr><td>胴</td><td>35</td><td>40</td><td>15</td><td>20</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Torso</td><td>35</td><td>40</td><td>15</td><td>20</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>40</td><td>35</td><td>25</td><td>20</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>右爪</td><td>25</td><td>40</td><td>30</td><td>15</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>左爪</td><td>40</td><td>25</td><td>35</td><td>15</td><td>10</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>尾</td><td>30</td><td>15</td><td>20</td><td>10</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(紅状態)</th></tr>
+<tr><td>Right Claw</td><td>25</td><td>40</td><td>30</td><td>15</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>40</td><td>25</td><td>35</td><td>15</td><td>10</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Tail</td><td>30</td><td>15</td><td>20</td><td>10</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(紅状態)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>60</td><td>30</td><td>15</td><td>5</td><td>0</td><td>0</td><td>10</td><td>100</td></tr>
-<tr><td>胴</td><td>40</td><td>45</td><td>20</td><td>10</td><td>5</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Torso</td><td>40</td><td>45</td><td>20</td><td>10</td><td>5</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Leg</td><td>45</td><td>40</td><td>30</td><td>10</td><td>10</td><td>0</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>右爪</td><td>30</td><td>45</td><td>35</td><td>5</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>左爪</td><td>45</td><td>30</td><td>40</td><td>5</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>尾</td><td>35</td><td>20</td><td>25</td><td>5</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(蒼状態)</th></tr>
+<tr><td>Right Claw</td><td>30</td><td>45</td><td>35</td><td>5</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>45</td><td>30</td><td>40</td><td>5</td><td>10</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Tail</td><td>35</td><td>20</td><td>25</td><td>5</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(蒼状態)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>60</td><td>65</td><td>45</td><td>5</td><td>15</td><td>0</td><td>0</td><td>5</td><td>100</td></tr>
-<tr><td>胴</td><td>40</td><td>50</td><td>25</td><td>5</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Torso</td><td>40</td><td>50</td><td>25</td><td>5</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>55</td><td>40</td><td>30</td><td>5</td><td>20</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>右爪</td><td>45</td><td>55</td><td>35</td><td>5</td><td>20</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>左爪</td><td>55</td><td>55</td><td>40</td><td>5</td><td>20</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>45</td><td>55</td><td>35</td><td>5</td><td>20</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>55</td><td>55</td><td>40</td><td>5</td><td>20</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Torso</td><td>450</td><td>２ stagger(s) required、４ stagger(s) required to break the part. Cannot break while Paralyzed</td></tr>
-<tr><td>左爪</td><td>250</td><td></td></tr>
-<tr><td>右爪</td><td>250</td><td></td></tr>
-<tr><td>左前脚</td><td>150</td><td></td></tr>
-<tr><td>左後脚</td><td>100</td><td></td></tr>
-<tr><td>右前脚</td><td>150</td><td></td></tr>
-<tr><td>右後脚</td><td>100</td><td></td></tr>
-<tr><td>尾</td><td>100</td><td></td></tr>
+<tr><td>Left Claw</td><td>250</td><td></td></tr>
+<tr><td>Right Claw</td><td>250</td><td></td></tr>
+<tr><td>Left Foreleg</td><td>150</td><td></td></tr>
+<tr><td>Left Hind Leg</td><td>100</td><td></td></tr>
+<tr><td>Right Foreleg</td><td>150</td><td></td></tr>
+<tr><td>Right Hind Leg</td><td>100</td><td></td></tr>
+<tr><td>Tail</td><td>100</td><td></td></tr>
 </table>
 <img id=hitzones src="../img/monszones/taikunzamuza.png" width="400"/>
 <script type="text/javascript" src="hover.js"></script>

--- a/mons/taikun_ni.htm
+++ b/mons/taikun_ni.htm
@@ -114,32 +114,32 @@
 <img id=icon src="../img/monsicons/zenith_taikunzamuza.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>30</td><td>20</td><td>15</td><td>5</td><td>0</td><td>0</td><td>10</td><td>100</td></tr>
-<tr><td>胴</td><td>10</td><td>15</td><td>5</td><td>10</td><td>5</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Torso</td><td>10</td><td>15</td><td>5</td><td>10</td><td>5</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>10</td><td>10</td><td>10</td><td>5</td><td>0</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>右爪</td><td>25</td><td>20</td><td>20</td><td>15</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>左爪</td><td>25</td><td>20</td><td>20</td><td>15</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
-<tr><td>尾</td><td>20</td><td>5</td><td>15</td><td>5</td><td>5</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(蒼状態)</th></tr>
+<tr><td>Right Claw</td><td>25</td><td>20</td><td>20</td><td>15</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>25</td><td>20</td><td>20</td><td>15</td><td>5</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Tail</td><td>20</td><td>5</td><td>15</td><td>5</td><td>5</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(蒼状態)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>35</td><td>30</td><td>5</td><td>15</td><td>0</td><td>0</td><td>10</td><td>100</td></tr>
-<tr><td>胴</td><td>15</td><td>20</td><td>10</td><td>5</td><td>15</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Torso</td><td>15</td><td>20</td><td>10</td><td>5</td><td>15</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>20</td><td>15</td><td>15</td><td>5</td><td>20</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>右爪</td><td>30</td><td>25</td><td>25</td><td>5</td><td>20</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
-<tr><td>左爪</td><td>30</td><td>25</td><td>25</td><td>5</td><td>20</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Right Claw</td><td>30</td><td>25</td><td>25</td><td>5</td><td>20</td><td>0</td><td>0</td><td>15</td><td>0</td></tr>
+<tr><td>Left Claw</td><td>30</td><td>25</td><td>25</td><td>5</td><td>20</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Torso</td><td>2000</td><td>？ stagger(s) required</td></tr>
-<tr><td>左爪</td><td>3000</td><td>？ stagger(s) required</td></tr>
-<tr><td>右爪</td><td>3000</td><td>？ stagger(s) required</td></tr>
-<tr><td>左前脚</td><td>700</td><td>？ stagger(s) (Only one break required for rewards)</td></tr>
-<tr><td>右前脚</td><td>700</td><td>？ stagger(s) required</td></tr>
-<tr><td>尾</td><td>1000</td><td></td></tr>
+<tr><td>Left Claw</td><td>3000</td><td>？ stagger(s) required</td></tr>
+<tr><td>Right Claw</td><td>3000</td><td>？ stagger(s) required</td></tr>
+<tr><td>Left Foreleg</td><td>700</td><td>？ stagger(s) (Only one break required for rewards)</td></tr>
+<tr><td>Right Foreleg</td><td>700</td><td>？ stagger(s) required</td></tr>
+<tr><td>Tail</td><td>1000</td><td></td></tr>
 </table>
 <img id=hitzones src="../img/monszones/zenith_taikunzamuza.png" width="400"/>
 <script type="text/javascript" src="hover.js"></script>

--- a/mons/teo_n.htm
+++ b/mons/teo_n.htm
@@ -69,22 +69,22 @@
 <img id=icon src="../img/monsicons/teostra.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>70</td><td>30</td><td>0</td><td>35</td><td>10</td><td>25</td><td>15</td><td>100</td></tr>
 <tr><td>Belly</td><td>35</td><td>50</td><td>25</td><td>0</td><td>20</td><td>5</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>25</td><td>30</td><td>0</td><td>20</td><td>5</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>25</td><td>60</td><td>0</td><td>35</td><td>5</td><td>50</td><td>15</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>25</td><td>20</td><td>0</td><td>20</td><td>5</td><td>15</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>25</td><td>20</td><td>0</td><td>20</td><td>5</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>40</td><td>25</td><td>0</td><td>25</td><td>5</td><td>25</td><td>15</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>15</td><td>20</td><td>0</td><td>20</td><td>5</td><td>15</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(炎纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(炎纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>70</td><td>20</td><td>0</td><td>10</td><td>10</td><td>25</td><td>25</td><td>100</td></tr>
 <tr><td>Belly</td><td>25</td><td>40</td><td>25</td><td>0</td><td>10</td><td>5</td><td>10</td><td>20</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>25</td><td>20</td><td>0</td><td>10</td><td>5</td><td>10</td><td>20</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>25</td><td>40</td><td>0</td><td>10</td><td>5</td><td>30</td><td>25</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>25</td><td>20</td><td>0</td><td>10</td><td>5</td><td>10</td><td>20</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>25</td><td>20</td><td>0</td><td>10</td><td>5</td><td>10</td><td>20</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>30</td><td>25</td><td>0</td><td>10</td><td>5</td><td>10</td><td>25</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>15</td><td>20</td><td>0</td><td>10</td><td>5</td><td>10</td><td>20</td><td>0</td></tr>
 </table>
@@ -95,11 +95,11 @@
 <tr><td>Head</td><td>200</td><td>２ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying<br>Deal at least 1 point of Dragon damage</td></tr>
 <tr><td>Torso</td><td>100</td><td></td></tr>
 <tr><td>Tail</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>180</td><td><div>
+<tr><td>Left Leg</td><td>180</td><td><div>
 <span><em>13</em>248</span><span><em>14</em>253</span><span><em>15</em>258</span><span><em>16</em>263</span><span><em>17</em>268</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>180</td><td><div>
+<tr><td>Right Leg</td><td>180</td><td><div>
 <span><em>13</em>248</span><span><em>14</em>253</span><span><em>15</em>258</span><span><em>16</em>263</span><span><em>17</em>268</span>
 </div>
 </td></tr>

--- a/mons/teo_ng.htm
+++ b/mons/teo_ng.htm
@@ -104,31 +104,31 @@
 <img id=icon src="../img/monsicons/teostra.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>37</td><td>40</td><td>35</td><td>0</td><td>30</td><td>10</td><td>20</td><td>15</td><td>100</td></tr>
 <tr><td>Belly</td><td>20</td><td>10</td><td>15</td><td>0</td><td>20</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Back</td><td>26</td><td>26</td><td>20</td><td>0</td><td>10</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>26</td><td>40</td><td>0</td><td>30</td><td>5</td><td>35</td><td>15</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>28</td><td>15</td><td>0</td><td>15</td><td>5</td><td>15</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>28</td><td>15</td><td>0</td><td>15</td><td>5</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>30</td><td>10</td><td>0</td><td>20</td><td>5</td><td>20</td><td>15</td><td>0</td></tr>
 <tr><td>Wing</td><td>15</td><td>22</td><td>20</td><td>0</td><td>20</td><td>5</td><td>15</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(炎纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(炎纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>47</td><td>50</td><td>45</td><td>0</td><td>10</td><td>10</td><td>20</td><td>20</td><td>100</td></tr>
 <tr><td>Belly</td><td>12</td><td>5</td><td>15</td><td>0</td><td>10</td><td>5</td><td>5</td><td>15</td><td>0</td></tr>
 <tr><td>Back</td><td>17</td><td>26</td><td>20</td><td>0</td><td>10</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>26</td><td>25</td><td>0</td><td>10</td><td>5</td><td>30</td><td>25</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>16</td><td>28</td><td>15</td><td>0</td><td>10</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>16</td><td>28</td><td>15</td><td>0</td><td>10</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>15</td><td>25</td><td>10</td><td>0</td><td>10</td><td>5</td><td>15</td><td>20</td><td>0</td></tr>
 <tr><td>Wing</td><td>13</td><td>22</td><td>20</td><td>0</td><td>10</td><td>5</td><td>10</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(頭部破壊)</th></tr>
+<tr class=l><th colspan=10>Hitzones(頭部破壊)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>42</td><td>45</td><td>40</td><td>0</td><td>30</td><td>10</td><td>20</td><td>15</td><td>100</td></tr>
 <tr><td>Belly</td><td>25</td><td>10</td><td>20</td><td>0</td><td>20</td><td>5</td><td>10</td><td>10</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>28</td><td>25</td><td>0</td><td>10</td><td>5</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>28</td><td>45</td><td>0</td><td>30</td><td>5</td><td>35</td><td>15</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>32</td><td>20</td><td>0</td><td>15</td><td>5</td><td>15</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>32</td><td>20</td><td>0</td><td>15</td><td>5</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>35</td><td>15</td><td>0</td><td>20</td><td>5</td><td>20</td><td>15</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>25</td><td>25</td><td>0</td><td>20</td><td>5</td><td>15</td><td>10</td><td>0</td></tr>
 </table>
@@ -139,8 +139,8 @@
 <tr><td>Head</td><td>900</td><td>２ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying<br>Deal at least 1 point of Dragon damage</td></tr>
 <tr><td>Torso</td><td>1000</td><td></td></tr>
 <tr><td>Tail</td><td>850</td><td></td></tr>
-<tr><td>Left Foot</td><td>750</td><td></td></tr>
-<tr><td>Right Foot</td><td>750</td><td></td></tr>
+<tr><td>Left Leg</td><td>750</td><td></td></tr>
+<tr><td>Right Leg</td><td>750</td><td></td></tr>
 <tr><td>Wing</td><td>700</td><td>２ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying</td></tr>
 <tr><td>Tail Cut</td><td>200</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>

--- a/mons/teo_nh.htm
+++ b/mons/teo_nh.htm
@@ -86,40 +86,40 @@
 <img id=icon src="../img/monsicons/teostra.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>70</td><td>20</td><td>0</td><td>35</td><td>5</td><td>25</td><td>15</td><td>100</td></tr>
 <tr><td>Belly</td><td>30</td><td>40</td><td>20</td><td>0</td><td>-10</td><td>5</td><td>-10</td><td>-5</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>20</td><td>20</td><td>0</td><td>-10</td><td>5</td><td>-10</td><td>-5</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>20</td><td>40</td><td>0</td><td>35</td><td>5</td><td>50</td><td>15</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>25</td><td>20</td><td>0</td><td>-10</td><td>5</td><td>-10</td><td>-5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>25</td><td>20</td><td>0</td><td>-10</td><td>5</td><td>-10</td><td>-5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>35</td><td>20</td><td>0</td><td>-10</td><td>5</td><td>-10</td><td>-5</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>15</td><td>25</td><td>0</td><td>20</td><td>5</td><td>15</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(炎纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(炎纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>65</td><td>20</td><td>0</td><td>10</td><td>5</td><td>25</td><td>25</td><td>100</td></tr>
 <tr><td>Belly</td><td>25</td><td>35</td><td>15</td><td>0</td><td>10</td><td>5</td><td>-15</td><td>-15</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>20</td><td>15</td><td>0</td><td>10</td><td>5</td><td>-15</td><td>-15</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>20</td><td>30</td><td>0</td><td>10</td><td>5</td><td>30</td><td>25</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>25</td><td>15</td><td>0</td><td>10</td><td>5</td><td>-15</td><td>-15</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>25</td><td>15</td><td>0</td><td>10</td><td>5</td><td>-15</td><td>-15</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>30</td><td>15</td><td>0</td><td>10</td><td>5</td><td>-15</td><td>-15</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>15</td><td>25</td><td>0</td><td>10</td><td>5</td><td>10</td><td>20</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(覇種)</th></tr>
+<tr class=l><th colspan=10>Hitzones(覇種)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>20</td><td>0</td><td>35</td><td>5</td><td>25</td><td>15</td><td>100</td></tr>
 <tr><td>Belly</td><td>30</td><td>40</td><td>20</td><td>0</td><td>-10</td><td>5</td><td>-10</td><td>-5</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>20</td><td>20</td><td>0</td><td>-10</td><td>5</td><td>-10</td><td>-5</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>20</td><td>40</td><td>0</td><td>35</td><td>5</td><td>50</td><td>15</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>35</td><td>25</td><td>20</td><td>0</td><td>-10</td><td>5</td><td>-10</td><td>-5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>35</td><td>25</td><td>20</td><td>0</td><td>-10</td><td>5</td><td>-10</td><td>-5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>35</td><td>20</td><td>0</td><td>-10</td><td>5</td><td>-10</td><td>-5</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>15</td><td>25</td><td>0</td><td>20</td><td>5</td><td>15</td><td>10</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(覇種)</th></tr>
+<tr class=l><th colspan=10>Hitzones(覇種)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>35</td><td>20</td><td>0</td><td>10</td><td>5</td><td>25</td><td>25</td><td>100</td></tr>
 <tr><td>Belly</td><td>25</td><td>35</td><td>15</td><td>0</td><td>10</td><td>5</td><td>-15</td><td>-15</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>20</td><td>15</td><td>0</td><td>10</td><td>5</td><td>-15</td><td>-15</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>20</td><td>30</td><td>0</td><td>10</td><td>5</td><td>30</td><td>25</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>25</td><td>15</td><td>0</td><td>10</td><td>5</td><td>-15</td><td>-15</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>25</td><td>15</td><td>0</td><td>10</td><td>5</td><td>-15</td><td>-15</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>30</td><td>15</td><td>0</td><td>10</td><td>5</td><td>-15</td><td>-15</td><td>0</td></tr>
 <tr><td>Wing</td><td>20</td><td>15</td><td>25</td><td>0</td><td>10</td><td>5</td><td>10</td><td>20</td><td>0</td></tr>
 </table>
@@ -130,8 +130,8 @@
 <tr><td>Head</td><td>500</td><td>２ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying<br>Deal at least 1 point of Dragon damage</td></tr>
 <tr><td>Torso</td><td>800</td><td></td></tr>
 <tr><td>Tail</td><td>250</td><td></td></tr>
-<tr><td>Left Foot</td><td>300</td><td></td></tr>
-<tr><td>Right Foot</td><td>300</td><td></td></tr>
+<tr><td>Left Leg</td><td>300</td><td></td></tr>
+<tr><td>Right Leg</td><td>300</td><td></td></tr>
 <tr><td>Wing</td><td>250</td><td>２ or more stagger(s) required<br>Cannot be broken when paralyzed, knocked down or flying</td></tr>
 <tr><td>-</td><td>200</td><td></td></tr>
 <tr><td>-</td><td>140</td><td></td></tr>

--- a/mons/tiga_n.htm
+++ b/mons/tiga_n.htm
@@ -79,23 +79,23 @@
 <img id=icon src="../img/monsicons/tigrex.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>65</td><td>55</td><td>40</td><td>0</td><td>15</td><td>30</td><td>20</td><td>5</td><td>110</td></tr>
 <tr><td>Neck</td><td>50</td><td>25</td><td>20</td><td>0</td><td>10</td><td>20</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Belly</td><td>25</td><td>30</td><td>20</td><td>15</td><td>15</td><td>25</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>Back</td><td>45</td><td>40</td><td>25</td><td>0</td><td>15</td><td>25</td><td>5</td><td>10</td><td>10</td></tr>
 <tr><td>Tail</td><td>25</td><td>20</td><td>15</td><td>0</td><td>5</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>15</td><td>20</td><td>0</td><td>15</td><td>20</td><td>15</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>15</td><td>20</td><td>0</td><td>15</td><td>20</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>30</td><td>30</td><td>0</td><td>5</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>80</td><td>70</td><td>45</td><td>0</td><td>15</td><td>35</td><td>20</td><td>5</td><td>150</td></tr>
 <tr><td>Neck</td><td>55</td><td>30</td><td>20</td><td>0</td><td>10</td><td>20</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Belly</td><td>30</td><td>35</td><td>20</td><td>15</td><td>15</td><td>25</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>Back</td><td>50</td><td>45</td><td>20</td><td>0</td><td>15</td><td>25</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>30</td><td>10</td><td>0</td><td>5</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>25</td><td>30</td><td>0</td><td>15</td><td>25</td><td>15</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>25</td><td>30</td><td>0</td><td>15</td><td>25</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>40</td><td>45</td><td>40</td><td>0</td><td>5</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -104,18 +104,18 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>250</td><td>２ stagger(s) required</td></tr>
 <tr><td>Belly</td><td>350</td><td></td></tr>
-<tr><td>首/背中</td><td>250</td><td></td></tr>
+<tr><td>Neck/Back</td><td>250</td><td></td></tr>
 <tr><td>Tail</td><td>250</td><td></td></tr>
-<tr><td>左前脚</td><td>350</td><td><div>
+<tr><td>Left Foreleg</td><td>350</td><td><div>
 <span><em>13</em>484</span><span><em>14</em>493</span><span><em>15</em>502</span><span><em>16</em>512</span><span><em>若12</em>474</span><span><em>若14</em>493</span>
 </div>
 １ stagger(s) required (Only one break required for rewards)</td></tr>
-<tr><td>左後脚</td><td>200</td><td></td></tr>
-<tr><td>右前脚</td><td>350</td><td><div>
+<tr><td>Left Hind Leg</td><td>200</td><td></td></tr>
+<tr><td>Right Foreleg</td><td>350</td><td><div>
 <span><em>13</em>484</span><span><em>14</em>493</span><span><em>15</em>502</span><span><em>16</em>512</span><span><em>若12</em>474</span><span><em>若14</em>493</span>
 </div>
 １ stagger(s) required</td></tr>
-<tr><td>右後脚</td><td>200</td><td></td></tr>
+<tr><td>Right Hind Leg</td><td>200</td><td></td></tr>
 <tr><td>Tail Cut</td><td>500</td><td><div>
 <span><em>若12</em>350</span><span><em>若14</em>350</span>
 </div>

--- a/mons/tiga_ng.htm
+++ b/mons/tiga_ng.htm
@@ -124,23 +124,23 @@
 <img id=icon src="../img/monsicons/tigrex.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>40</td><td>30</td><td>0</td><td>15</td><td>30</td><td>20</td><td>5</td><td>110</td></tr>
 <tr><td>Neck</td><td>30</td><td>25</td><td>20</td><td>0</td><td>10</td><td>20</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Belly</td><td>25</td><td>30</td><td>20</td><td>15</td><td>15</td><td>25</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>Back</td><td>35</td><td>40</td><td>25</td><td>0</td><td>15</td><td>25</td><td>5</td><td>10</td><td>10</td></tr>
 <tr><td>Tail</td><td>25</td><td>20</td><td>15</td><td>0</td><td>5</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>20</td><td>20</td><td>0</td><td>15</td><td>20</td><td>15</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>20</td><td>20</td><td>0</td><td>15</td><td>20</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>30</td><td>30</td><td>0</td><td>5</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>55</td><td>50</td><td>35</td><td>0</td><td>15</td><td>35</td><td>20</td><td>5</td><td>150</td></tr>
 <tr><td>Neck</td><td>45</td><td>35</td><td>20</td><td>0</td><td>10</td><td>20</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Belly</td><td>30</td><td>35</td><td>20</td><td>15</td><td>15</td><td>25</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>Back</td><td>40</td><td>40</td><td>20</td><td>0</td><td>15</td><td>25</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>30</td><td>10</td><td>0</td><td>5</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>25</td><td>25</td><td>0</td><td>15</td><td>25</td><td>15</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>25</td><td>25</td><td>0</td><td>15</td><td>25</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>35</td><td>40</td><td>40</td><td>0</td><td>5</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -149,12 +149,12 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>500</td><td>２ stagger(s) required</td></tr>
 <tr><td>Belly</td><td>550</td><td></td></tr>
-<tr><td>首/背中</td><td>450</td><td></td></tr>
+<tr><td>Neck/Back</td><td>450</td><td></td></tr>
 <tr><td>Tail</td><td>450</td><td></td></tr>
-<tr><td>左前脚</td><td>550</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
-<tr><td>左後脚</td><td>450</td><td></td></tr>
-<tr><td>右前脚</td><td>550</td><td>１ stagger(s) required</td></tr>
-<tr><td>右後脚</td><td>450</td><td></td></tr>
+<tr><td>Left Foreleg</td><td>550</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
+<tr><td>Left Hind Leg</td><td>450</td><td></td></tr>
+<tr><td>Right Foreleg</td><td>550</td><td>１ stagger(s) required</td></tr>
+<tr><td>Right Hind Leg</td><td>450</td><td></td></tr>
 <tr><td>Tail Cut</td><td>700</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/tigrex.png" width="400"/>

--- a/mons/tiga_nh.htm
+++ b/mons/tiga_nh.htm
@@ -83,23 +83,23 @@
 <img id=icon src="../img/monsicons/tigrex.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>35</td><td>20</td><td>0</td><td>10</td><td>-5</td><td>5</td><td>5</td><td>110</td></tr>
 <tr><td>Neck</td><td>35</td><td>25</td><td>20</td><td>0</td><td>5</td><td>25</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Belly</td><td>40</td><td>30</td><td>30</td><td>5</td><td>10</td><td>5</td><td>25</td><td>5</td><td>0</td></tr>
 <tr><td>Back</td><td>40</td><td>40</td><td>25</td><td>0</td><td>25</td><td>5</td><td>-5</td><td>5</td><td>10</td></tr>
 <tr><td>Tail</td><td>25</td><td>20</td><td>30</td><td>10</td><td>0</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>15</td><td>15</td><td>0</td><td>-5</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>15</td><td>15</td><td>0</td><td>-5</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>30</td><td>20</td><td>0</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>45</td><td>30</td><td>0</td><td>10</td><td>-5</td><td>5</td><td>5</td><td>150</td></tr>
 <tr><td>Neck</td><td>40</td><td>30</td><td>20</td><td>0</td><td>10</td><td>30</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Belly</td><td>40</td><td>30</td><td>40</td><td>5</td><td>10</td><td>5</td><td>30</td><td>5</td><td>0</td></tr>
 <tr><td>Back</td><td>40</td><td>40</td><td>20</td><td>0</td><td>30</td><td>5</td><td>-5</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>20</td><td>30</td><td>10</td><td>10</td><td>-5</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>25</td><td>25</td><td>0</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>25</td><td>25</td><td>0</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>40</td><td>30</td><td>0</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -108,12 +108,12 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>250</td><td>２ stagger(s) required</td></tr>
 <tr><td>Belly</td><td>350</td><td></td></tr>
-<tr><td>首/背中</td><td>250</td><td></td></tr>
+<tr><td>Neck/Back</td><td>250</td><td></td></tr>
 <tr><td>Tail</td><td>250</td><td></td></tr>
-<tr><td>左前脚</td><td>350</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
-<tr><td>左後脚</td><td>200</td><td></td></tr>
-<tr><td>右前脚</td><td>350</td><td>１ stagger(s) required</td></tr>
-<tr><td>右後脚</td><td>200</td><td></td></tr>
+<tr><td>Left Foreleg</td><td>350</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
+<tr><td>Left Hind Leg</td><td>200</td><td></td></tr>
+<tr><td>Right Foreleg</td><td>350</td><td>１ stagger(s) required</td></tr>
+<tr><td>Right Hind Leg</td><td>200</td><td></td></tr>
 <tr><td>Tail Cut</td><td>500</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/tigrex.png" width="400"/>

--- a/mons/tiga_ni.htm
+++ b/mons/tiga_ni.htm
@@ -112,23 +112,23 @@
 <img id=icon src="../img/monsicons/zenith_tigrex.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>40</td><td>30</td><td>0</td><td>10</td><td>20</td><td>10</td><td>0</td><td>110</td></tr>
 <tr><td>Neck</td><td>25</td><td>20</td><td>15</td><td>0</td><td>5</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>25</td><td>30</td><td>15</td><td>10</td><td>10</td><td>15</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>30</td><td>25</td><td>0</td><td>10</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>10</td><td>15</td><td>0</td><td>0</td><td>5</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>20</td><td>20</td><td>0</td><td>10</td><td>10</td><td>10</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>20</td><td>20</td><td>0</td><td>10</td><td>10</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>30</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>35</td><td>0</td><td>10</td><td>25</td><td>10</td><td>0</td><td>150</td></tr>
 <tr><td>Neck</td><td>30</td><td>25</td><td>20</td><td>0</td><td>5</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>
 <tr><td>Belly</td><td>25</td><td>30</td><td>20</td><td>10</td><td>10</td><td>20</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Back</td><td>30</td><td>30</td><td>20</td><td>0</td><td>10</td><td>20</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>10</td><td>15</td><td>0</td><td>0</td><td>10</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>25</td><td>25</td><td>0</td><td>10</td><td>15</td><td>10</td><td>5</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>25</td><td>25</td><td>0</td><td>10</td><td>15</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>30</td><td>30</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -137,12 +137,12 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>1000</td><td>２ stagger(s) required</td></tr>
 <tr><td>Belly</td><td>1500</td><td></td></tr>
-<tr><td>首/背中</td><td>750</td><td></td></tr>
+<tr><td>Neck/Back</td><td>750</td><td></td></tr>
 <tr><td>Tail</td><td>2000</td><td></td></tr>
-<tr><td>左前脚</td><td>2500</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
-<tr><td>左後脚</td><td>1000</td><td></td></tr>
-<tr><td>右前脚</td><td>2500</td><td>１ stagger(s) required</td></tr>
-<tr><td>右後脚</td><td>1000</td><td></td></tr>
+<tr><td>Left Foreleg</td><td>2500</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
+<tr><td>Left Hind Leg</td><td>1000</td><td></td></tr>
+<tr><td>Right Foreleg</td><td>2500</td><td>１ stagger(s) required</td></tr>
+<tr><td>Right Hind Leg</td><td>1000</td><td></td></tr>
 <tr><td>Tail Cut</td><td>2000</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/zenith_tigrex.png" width="400"/>

--- a/mons/tiga_nt.htm
+++ b/mons/tiga_nt.htm
@@ -104,23 +104,23 @@
 <img id=icon src="../img/monsicons/tigrex.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>40</td><td>30</td><td>0</td><td>15</td><td>30</td><td>20</td><td>5</td><td>110</td></tr>
 <tr><td>Neck</td><td>30</td><td>25</td><td>20</td><td>0</td><td>10</td><td>20</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Belly</td><td>25</td><td>30</td><td>20</td><td>15</td><td>15</td><td>25</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>Back</td><td>35</td><td>40</td><td>25</td><td>0</td><td>15</td><td>25</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>25</td><td>20</td><td>15</td><td>0</td><td>5</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>25</td><td>20</td><td>20</td><td>0</td><td>15</td><td>20</td><td>15</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>25</td><td>20</td><td>20</td><td>0</td><td>15</td><td>20</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>30</td><td>30</td><td>0</td><td>5</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info (Enraged)</th></tr>
+<tr class=l><th colspan=10>Hitzones (Enraged)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>55</td><td>50</td><td>35</td><td>0</td><td>15</td><td>35</td><td>20</td><td>5</td><td>150</td></tr>
 <tr><td>Neck</td><td>45</td><td>35</td><td>20</td><td>0</td><td>10</td><td>20</td><td>15</td><td>5</td><td>0</td></tr>
 <tr><td>Belly</td><td>30</td><td>35</td><td>20</td><td>15</td><td>15</td><td>25</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>Back</td><td>40</td><td>40</td><td>20</td><td>0</td><td>15</td><td>25</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>30</td><td>10</td><td>0</td><td>5</td><td>15</td><td>15</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>30</td><td>25</td><td>25</td><td>0</td><td>15</td><td>25</td><td>15</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>30</td><td>25</td><td>25</td><td>0</td><td>15</td><td>25</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>35</td><td>40</td><td>40</td><td>0</td><td>5</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
@@ -129,12 +129,12 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>250</td><td>２ stagger(s) required</td></tr>
 <tr><td>Belly</td><td>350</td><td></td></tr>
-<tr><td>首/背中</td><td>250</td><td></td></tr>
+<tr><td>Neck/Back</td><td>250</td><td></td></tr>
 <tr><td>Tail</td><td>250</td><td></td></tr>
-<tr><td>左前脚</td><td>350</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
-<tr><td>左後脚</td><td>200</td><td></td></tr>
-<tr><td>右前脚</td><td>350</td><td>１ stagger(s) required</td></tr>
-<tr><td>右後脚</td><td>200</td><td></td></tr>
+<tr><td>Left Foreleg</td><td>350</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
+<tr><td>Left Hind Leg</td><td>200</td><td></td></tr>
+<tr><td>Right Foreleg</td><td>350</td><td>１ stagger(s) required</td></tr>
+<tr><td>Right Hind Leg</td><td>200</td><td></td></tr>
 <tr><td>Tail Cut</td><td>500</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/tigrex.png" width="400"/>

--- a/mons/toa_ng.htm
+++ b/mons/toa_ng.htm
@@ -97,7 +97,7 @@
 <img id=icon src="../img/monsicons/toatesukatora.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>30</td><td>40</td><td>21</td><td>25</td><td>0</td><td>10</td><td>20</td><td>0</td><td>100</td></tr>
 <tr><td>？？</td><td>17</td><td>13</td><td>12</td><td>10</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>

--- a/mons/toa_nh.htm
+++ b/mons/toa_nh.htm
@@ -75,7 +75,7 @@
 <img id=icon src="../img/monsicons/toatesukatora.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>35</td><td>45</td><td>26</td><td>25</td><td>0</td><td>10</td><td>20</td><td>0</td><td>100</td></tr>
 <tr><td>？？</td><td>22</td><td>18</td><td>17</td><td>10</td><td>0</td><td>5</td><td>0</td><td>0</td><td>0</td></tr>

--- a/mons/torid_ng.htm
+++ b/mons/torid_ng.htm
@@ -122,7 +122,7 @@
 <img id=icon src="../img/monsicons/toridcless.webp" width="350"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>35</td><td>20</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td><td>100</td></tr>
 <tr><td>Chest</td><td>30</td><td>10</td><td>10</td><td>20</td><td>10</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
@@ -131,7 +131,7 @@
 <tr><td>Legs</td><td>15</td><td>20</td><td>10</td><td>5</td><td>10</td><td>0</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>35</td><td>35</td><td>35</td><td>0</td><td>20</td><td>0</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Armr</td><td>25</td><td>15</td><td>10</td><td>0</td><td>10</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info(Thunder Clad)</th></tr>
+<tr class=l><th colspan=10>Hitzones(Thunder Clad)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>45</td><td>30</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td><td>100</td></tr>
 <tr><td>Chest</td><td>40</td><td>20</td><td>20</td><td>20</td><td>10</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>

--- a/mons/torid_nh.htm
+++ b/mons/torid_nh.htm
@@ -75,7 +75,7 @@
 <img id=icon src="../img/monsicons/toridcless.webp" width="350"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>25</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td><td>100</td></tr>
 <tr><td>Chest</td><td>35</td><td>15</td><td>15</td><td>20</td><td>10</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
@@ -84,7 +84,7 @@
 <tr><td>Legs</td><td>20</td><td>25</td><td>15</td><td>5</td><td>10</td><td>0</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>40</td><td>40</td><td>40</td><td>0</td><td>20</td><td>0</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Armr</td><td>30</td><td>20</td><td>15</td><td>0</td><td>10</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info(Thunder Clad)</th></tr>
+<tr class=l><th colspan=10>Hitzones(Thunder Clad)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>50</td><td>35</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td><td>100</td></tr>
 <tr><td>Chest</td><td>45</td><td>25</td><td>25</td><td>20</td><td>10</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>

--- a/mons/torid_ni.htm
+++ b/mons/torid_ni.htm
@@ -111,7 +111,7 @@
 <img id=icon src="../img/monsicons/zenith_toridcless.webp" width="500"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>30</td><td>15</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td><td>100</td></tr>
 <tr><td>Chest</td><td>25</td><td>10</td><td>10</td><td>20</td><td>10</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
@@ -120,7 +120,7 @@
 <tr><td>Legs</td><td>15</td><td>20</td><td>10</td><td>5</td><td>10</td><td>0</td><td>10</td><td>0</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>30</td><td>30</td><td>0</td><td>20</td><td>0</td><td>20</td><td>0</td><td>0</td></tr>
 <tr><td>Tail Armr</td><td>20</td><td>10</td><td>10</td><td>0</td><td>10</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>Hitzone Info(Thunder Clad)</th></tr>
+<tr class=l><th colspan=10>Hitzones(Thunder Clad)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>35</td><td>25</td><td>5</td><td>20</td><td>0</td><td>10</td><td>0</td><td>100</td></tr>
 <tr><td>Chest</td><td>35</td><td>15</td><td>15</td><td>20</td><td>10</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>

--- a/mons/ura_ng.htm
+++ b/mons/ura_ng.htm
@@ -116,18 +116,18 @@
 <img id=icon src="../img/monsicons/uragaan.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>頭部</td><td>13</td><td>14</td><td>10</td><td>0</td><td>40</td><td>5</td><td>30</td><td>20</td><td>100</td></tr>
+<tr><td>Head</td><td>13</td><td>14</td><td>10</td><td>0</td><td>40</td><td>5</td><td>30</td><td>20</td><td>100</td></tr>
 <tr><td>？？</td><td>18</td><td>24</td><td>21</td><td>0</td><td>20</td><td>0</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>19</td><td>23</td><td>10</td><td>0</td><td>15</td><td>0</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>41</td><td>35</td><td>35</td><td>0</td><td>30</td><td>5</td><td>30</td><td>15</td><td>0</td></tr>
 <tr><td>？？</td><td>18</td><td>24</td><td>17</td><td>0</td><td>15</td><td>0</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>25</td><td>24</td><td>21</td><td>0</td><td>25</td><td>0</td><td>20</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>15</td><td>17</td><td>10</td><td>0</td><td>35</td><td>5</td><td>25</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(頭部破壊後)</th></tr>
+<tr class=l><th colspan=10>Hitzones(頭部破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>頭部</td><td>44</td><td>39</td><td>32</td><td>0</td><td>20</td><td>15</td><td>35</td><td>30</td><td>100</td></tr>
+<tr><td>Head</td><td>44</td><td>39</td><td>32</td><td>0</td><td>20</td><td>15</td><td>35</td><td>30</td><td>100</td></tr>
 <tr><td>？？</td><td>18</td><td>24</td><td>21</td><td>0</td><td>20</td><td>0</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>19</td><td>23</td><td>10</td><td>0</td><td>15</td><td>0</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>44</td><td>35</td><td>35</td><td>0</td><td>30</td><td>5</td><td>30</td><td>15</td><td>0</td></tr>

--- a/mons/ura_nh.htm
+++ b/mons/ura_nh.htm
@@ -75,18 +75,18 @@
 <img id=icon src="../img/monsicons/uragaan.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>頭部</td><td>17</td><td>18</td><td>10</td><td>0</td><td>40</td><td>5</td><td>30</td><td>20</td><td>100</td></tr>
+<tr><td>Head</td><td>17</td><td>18</td><td>10</td><td>0</td><td>40</td><td>5</td><td>30</td><td>20</td><td>100</td></tr>
 <tr><td>？？</td><td>23</td><td>27</td><td>23</td><td>0</td><td>20</td><td>0</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>20</td><td>22</td><td>10</td><td>0</td><td>15</td><td>0</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>50</td><td>41</td><td>41</td><td>0</td><td>30</td><td>5</td><td>30</td><td>15</td><td>0</td></tr>
 <tr><td>？？</td><td>20</td><td>27</td><td>17</td><td>0</td><td>15</td><td>0</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>32</td><td>27</td><td>23</td><td>0</td><td>25</td><td>0</td><td>20</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>20</td><td>22</td><td>10</td><td>0</td><td>35</td><td>5</td><td>25</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(頭部破壊後)</th></tr>
+<tr class=l><th colspan=10>Hitzones(頭部破壊後)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
-<tr><td>頭部</td><td>50</td><td>45</td><td>32</td><td>0</td><td>20</td><td>15</td><td>35</td><td>30</td><td>100</td></tr>
+<tr><td>Head</td><td>50</td><td>45</td><td>32</td><td>0</td><td>20</td><td>15</td><td>35</td><td>30</td><td>100</td></tr>
 <tr><td>？？</td><td>23</td><td>27</td><td>23</td><td>0</td><td>20</td><td>0</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>20</td><td>22</td><td>10</td><td>0</td><td>15</td><td>0</td><td>15</td><td>10</td><td>0</td></tr>
 <tr><td>？？</td><td>50</td><td>41</td><td>41</td><td>0</td><td>30</td><td>5</td><td>30</td><td>15</td><td>0</td></tr>

--- a/mons/valsa_ng.htm
+++ b/mons/valsa_ng.htm
@@ -99,7 +99,7 @@
 <img id=icon src="../img/monsicons/varusaburosu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>25</td><td>30</td><td>0</td><td>25</td><td>5</td><td>0</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>40</td><td>50</td><td>0</td><td>20</td><td>10</td><td>0</td><td>25</td><td>0</td></tr>
@@ -108,7 +108,7 @@
 <tr><td>Tail</td><td>55</td><td>55</td><td>55</td><td>0</td><td>25</td><td>5</td><td>0</td><td>25</td><td>0</td></tr>
 <tr><td>Wing</td><td>45</td><td>40</td><td>40</td><td>0</td><td>25</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>40</td><td>40</td><td>25</td><td>0</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(赤光)</th></tr>
+<tr class=l><th colspan=10>Hitzones(赤光)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>15</td><td>20</td><td>0</td><td>20</td><td>5</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>30</td><td>40</td><td>0</td><td>15</td><td>10</td><td>0</td><td>25</td><td>0</td></tr>
@@ -117,7 +117,7 @@
 <tr><td>Tail</td><td>45</td><td>45</td><td>50</td><td>0</td><td>15</td><td>5</td><td>0</td><td>25</td><td>0</td></tr>
 <tr><td>Wing</td><td>35</td><td>30</td><td>30</td><td>0</td><td>20</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>35</td><td>35</td><td>15</td><td>0</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(炎角)</th></tr>
+<tr class=l><th colspan=10>Hitzones(炎角)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>15</td><td>20</td><td>0</td><td>15</td><td>5</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>35</td><td>25</td><td>35</td><td>0</td><td>10</td><td>10</td><td>0</td><td>25</td><td>0</td></tr>
@@ -134,8 +134,8 @@
 <tr><td>Torso</td><td>800</td><td></td></tr>
 <tr><td>Left Wing</td><td>700</td><td></td></tr>
 <tr><td>Right Wing</td><td>700</td><td></td></tr>
-<tr><td>Left Foot</td><td>700</td><td></td></tr>
-<tr><td>Right Foot</td><td>800</td><td></td></tr>
+<tr><td>Left Leg</td><td>700</td><td></td></tr>
+<tr><td>Right Leg</td><td>800</td><td></td></tr>
 <tr><td>Neck</td><td>600</td><td></td></tr>
 <tr><td>Head</td><td>700</td><td>１ stagger(s) required to break Horn<br>２ stagger(s) required (Requires both for the reward)</td></tr>
 <tr><td>Tail</td><td>800</td><td></td></tr>

--- a/mons/valsa_nh.htm
+++ b/mons/valsa_nh.htm
@@ -77,7 +77,7 @@
 <img id=icon src="../img/monsicons/varusaburosu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>25</td><td>30</td><td>0</td><td>25</td><td>5</td><td>0</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>50</td><td>40</td><td>50</td><td>0</td><td>20</td><td>10</td><td>0</td><td>25</td><td>0</td></tr>
@@ -86,7 +86,7 @@
 <tr><td>Tail</td><td>55</td><td>55</td><td>55</td><td>0</td><td>25</td><td>5</td><td>0</td><td>25</td><td>0</td></tr>
 <tr><td>Wing</td><td>45</td><td>40</td><td>40</td><td>0</td><td>25</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Leg</td><td>40</td><td>40</td><td>25</td><td>0</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(赤光)</th></tr>
+<tr class=l><th colspan=10>Hitzones(赤光)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>15</td><td>20</td><td>0</td><td>20</td><td>5</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>40</td><td>30</td><td>40</td><td>0</td><td>15</td><td>10</td><td>0</td><td>25</td><td>0</td></tr>
@@ -95,7 +95,7 @@
 <tr><td>Tail</td><td>45</td><td>45</td><td>50</td><td>0</td><td>15</td><td>5</td><td>0</td><td>25</td><td>0</td></tr>
 <tr><td>Wing</td><td>35</td><td>30</td><td>30</td><td>0</td><td>20</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>35</td><td>35</td><td>20</td><td>0</td><td>0</td><td>15</td><td>0</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(炎角)</th></tr>
+<tr class=l><th colspan=10>Hitzones(炎角)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>15</td><td>15</td><td>20</td><td>0</td><td>15</td><td>5</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Neck</td><td>35</td><td>25</td><td>35</td><td>0</td><td>10</td><td>10</td><td>0</td><td>25</td><td>0</td></tr>
@@ -112,8 +112,8 @@
 <tr><td>Torso</td><td>600</td><td></td></tr>
 <tr><td>Left Wing</td><td>400</td><td></td></tr>
 <tr><td>Right Wing</td><td>400</td><td></td></tr>
-<tr><td>Left Foot</td><td>400</td><td></td></tr>
-<tr><td>Right Foot</td><td>500</td><td></td></tr>
+<tr><td>Left Leg</td><td>400</td><td></td></tr>
+<tr><td>Right Leg</td><td>500</td><td></td></tr>
 <tr><td>Neck</td><td>400</td><td></td></tr>
 <tr><td>Head</td><td>500</td><td>１ stagger(s) required to break Horn<br>２ stagger(s) required (Requires both for the reward)</td></tr>
 <tr><td>Tail</td><td>550</td><td></td></tr>

--- a/mons/vol_n.htm
+++ b/mons/vol_n.htm
@@ -79,7 +79,7 @@
 <img id=icon src="../img/monsicons/volganos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>30</td><td>30</td><td>0</td><td>20</td><td>5</td><td>5</td><td>15</td><td>200</td></tr>
 <tr><td>Neck</td><td>35</td><td>35</td><td>20</td><td>0</td><td>25</td><td>15</td><td>5</td><td>10</td><td>0</td></tr>
@@ -96,11 +96,11 @@
 <tr><td>Torso</td><td>250</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>100</td><td></td></tr>
 <tr><td>Right Wing</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>250</td><td><div>
+<tr><td>Left Leg</td><td>250</td><td><div>
 <span><em>13</em>345</span><span><em>14</em>352</span><span><em>15</em>359</span><span><em>16</em>365</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>250</td><td><div>
+<tr><td>Right Leg</td><td>250</td><td><div>
 <span><em>13</em>345</span><span><em>14</em>352</span><span><em>15</em>359</span><span><em>16</em>365</span>
 </div>
 </td></tr>

--- a/mons/vol_ng.htm
+++ b/mons/vol_ng.htm
@@ -104,7 +104,7 @@
 <img id=icon src="../img/monsicons/volganos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>40</td><td>25</td><td>0</td><td>20</td><td>5</td><td>5</td><td>15</td><td>200</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>20</td><td>0</td><td>25</td><td>15</td><td>5</td><td>10</td><td>0</td></tr>
@@ -121,8 +121,8 @@
 <tr><td>Torso</td><td>600</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>300</td><td></td></tr>
 <tr><td>Right Wing</td><td>300</td><td></td></tr>
-<tr><td>Left Foot</td><td>500</td><td></td></tr>
-<tr><td>Right Foot</td><td>500</td><td></td></tr>
+<tr><td>Left Leg</td><td>500</td><td></td></tr>
+<tr><td>Right Leg</td><td>500</td><td></td></tr>
 <tr><td>Neck</td><td>400</td><td></td></tr>
 <tr><td>Head</td><td>350</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>350</td><td></td></tr>

--- a/mons/vol_nh.htm
+++ b/mons/vol_nh.htm
@@ -83,7 +83,7 @@
 <img id=icon src="../img/monsicons/volganos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>30</td><td>50</td><td>-5</td><td>10</td><td>0</td><td>15</td><td>0</td><td>200</td></tr>
 <tr><td>Neck</td><td>45</td><td>35</td><td>20</td><td>10</td><td>5</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
@@ -100,8 +100,8 @@
 <tr><td>Torso</td><td>250</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>100</td><td></td></tr>
 <tr><td>Right Wing</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>250</td><td></td></tr>
-<tr><td>Right Foot</td><td>250</td><td></td></tr>
+<tr><td>Left Leg</td><td>250</td><td></td></tr>
+<tr><td>Right Leg</td><td>250</td><td></td></tr>
 <tr><td>Neck</td><td>250</td><td></td></tr>
 <tr><td>Head</td><td>200</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>180</td><td></td></tr>

--- a/mons/vol_nt.htm
+++ b/mons/vol_nt.htm
@@ -104,7 +104,7 @@
 <img id=icon src="../img/monsicons/volganos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>40</td><td>25</td><td>0</td><td>20</td><td>5</td><td>5</td><td>15</td><td>200</td></tr>
 <tr><td>Neck</td><td>20</td><td>20</td><td>20</td><td>0</td><td>25</td><td>15</td><td>5</td><td>10</td><td>0</td></tr>
@@ -121,8 +121,8 @@
 <tr><td>Torso</td><td>250</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>100</td><td></td></tr>
 <tr><td>Right Wing</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>250</td><td></td></tr>
-<tr><td>Right Foot</td><td>250</td><td></td></tr>
+<tr><td>Left Leg</td><td>250</td><td></td></tr>
+<tr><td>Right Leg</td><td>250</td><td></td></tr>
 <tr><td>Neck</td><td>250</td><td></td></tr>
 <tr><td>Head</td><td>200</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>180</td><td></td></tr>

--- a/mons/volaka_n.htm
+++ b/mons/volaka_n.htm
@@ -77,7 +77,7 @@
 <img id=icon src="../img/monsicons/redvolganos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>25</td><td>30</td><td>30</td><td>0</td><td>5</td><td>5</td><td>20</td><td>5</td><td>200</td></tr>
 <tr><td>Neck</td><td>35</td><td>35</td><td>20</td><td>0</td><td>5</td><td>5</td><td>25</td><td>5</td><td>0</td></tr>
@@ -94,11 +94,11 @@
 <tr><td>Torso</td><td>250</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>100</td><td></td></tr>
 <tr><td>Right Wing</td><td>100</td><td></td></tr>
-<tr><td>Left Foot</td><td>250</td><td><div>
+<tr><td>Left Leg</td><td>250</td><td><div>
 <span><em>11</em>332</span><span><em>14</em>352</span><span><em>15</em>359</span>
 </div>
 </td></tr>
-<tr><td>Right Foot</td><td>250</td><td><div>
+<tr><td>Right Leg</td><td>250</td><td><div>
 <span><em>11</em>332</span><span><em>14</em>352</span><span><em>15</em>359</span>
 </div>
 </td></tr>

--- a/mons/volaka_ng.htm
+++ b/mons/volaka_ng.htm
@@ -103,7 +103,7 @@
 <img id=icon src="../img/monsicons/redvolganos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>35</td><td>20</td><td>0</td><td>5</td><td>5</td><td>20</td><td>5</td><td>200</td></tr>
 <tr><td>Neck</td><td>25</td><td>20</td><td>35</td><td>0</td><td>5</td><td>5</td><td>25</td><td>5</td><td>0</td></tr>
@@ -120,8 +120,8 @@
 <tr><td>Torso</td><td>650</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>450</td><td></td></tr>
 <tr><td>Right Wing</td><td>450</td><td></td></tr>
-<tr><td>Left Foot</td><td>600</td><td></td></tr>
-<tr><td>Right Foot</td><td>600</td><td></td></tr>
+<tr><td>Left Leg</td><td>600</td><td></td></tr>
+<tr><td>Right Leg</td><td>600</td><td></td></tr>
 <tr><td>Neck</td><td>500</td><td></td></tr>
 <tr><td>Head</td><td>500</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>400</td><td></td></tr>

--- a/mons/volaka_nh.htm
+++ b/mons/volaka_nh.htm
@@ -92,7 +92,7 @@
 <img id=icon src="../img/monsicons/redvolganos.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>40</td><td>30</td><td>0</td><td>5</td><td>5</td><td>25</td><td>5</td><td>200</td></tr>
 <tr><td>Neck</td><td>35</td><td>30</td><td>35</td><td>0</td><td>5</td><td>5</td><td>25</td><td>5</td><td>0</td></tr>
@@ -109,8 +109,8 @@
 <tr><td>Torso</td><td>450</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>450</td><td></td></tr>
 <tr><td>Right Wing</td><td>450</td><td></td></tr>
-<tr><td>Left Foot</td><td>600</td><td></td></tr>
-<tr><td>Right Foot</td><td>600</td><td></td></tr>
+<tr><td>Left Leg</td><td>600</td><td></td></tr>
+<tr><td>Right Leg</td><td>600</td><td></td></tr>
 <tr><td>Neck</td><td>500</td><td></td></tr>
 <tr><td>Head</td><td>450</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>400</td><td></td></tr>

--- a/mons/volgin_nh.htm
+++ b/mons/volgin_nh.htm
@@ -82,7 +82,7 @@
 <img id=icon src="../img/monsicons/aruganosu.webp" width="250"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>35</td><td>30</td><td>0</td><td>0</td><td>25</td><td>10</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>30</td><td>35</td><td>20</td><td>0</td><td>0</td><td>25</td><td>10</td><td>0</td><td>0</td></tr>
@@ -99,8 +99,8 @@
 <tr><td>Torso</td><td>500</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>400</td><td></td></tr>
 <tr><td>Right Wing</td><td>400</td><td></td></tr>
-<tr><td>Left Foot</td><td>500</td><td></td></tr>
-<tr><td>Right Foot</td><td>500</td><td></td></tr>
+<tr><td>Left Leg</td><td>500</td><td></td></tr>
+<tr><td>Right Leg</td><td>500</td><td></td></tr>
 <tr><td>Neck</td><td>500</td><td></td></tr>
 <tr><td>Head</td><td>400</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>350</td><td></td></tr>

--- a/mons/volkin_nh.htm
+++ b/mons/volkin_nh.htm
@@ -82,7 +82,7 @@
 <img id=icon src="../img/monsicons/goruganosu.webp" width="250"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>35</td><td>20</td><td>30</td><td>0</td><td>0</td><td>0</td><td>10</td><td>25</td><td>100</td></tr>
 <tr><td>Neck</td><td>35</td><td>30</td><td>20</td><td>0</td><td>0</td><td>0</td><td>10</td><td>25</td><td>0</td></tr>
@@ -99,8 +99,8 @@
 <tr><td>Torso</td><td>500</td><td>２ stagger(s) required</td></tr>
 <tr><td>Left Wing</td><td>400</td><td></td></tr>
 <tr><td>Right Wing</td><td>400</td><td></td></tr>
-<tr><td>Left Foot</td><td>500</td><td></td></tr>
-<tr><td>Right Foot</td><td>500</td><td></td></tr>
+<tr><td>Left Leg</td><td>500</td><td></td></tr>
+<tr><td>Right Leg</td><td>500</td><td></td></tr>
 <tr><td>Neck</td><td>500</td><td></td></tr>
 <tr><td>Head</td><td>400</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>350</td><td></td></tr>

--- a/mons/yama_n.htm
+++ b/mons/yama_n.htm
@@ -62,15 +62,15 @@
 <img id=icon src="../img/monsicons/yamatsukami.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>60</td><td>70</td><td>50</td><td>0</td><td>0</td><td>0</td><td>30</td><td>35</td><td>0</td></tr>
 <tr><td>Back</td><td>60</td><td>70</td><td>25</td><td>0</td><td>0</td><td>0</td><td>10</td><td>15</td><td>0</td></tr>
-<tr><td>目</td><td>100</td><td>100</td><td>60</td><td>5</td><td>0</td><td>0</td><td>10</td><td>20</td><td>0</td></tr>
+<tr><td>Eye</td><td>100</td><td>100</td><td>60</td><td>5</td><td>0</td><td>0</td><td>10</td><td>20</td><td>0</td></tr>
 <tr><td>Torso</td><td>80</td><td>70</td><td>20</td><td>0</td><td>0</td><td>0</td><td>15</td><td>25</td><td>0</td></tr>
-<tr><td>口中</td><td>90</td><td>80</td><td>90</td><td>0</td><td>10</td><td>0</td><td>70</td><td>35</td><td>0</td></tr>
-<tr><td>触角</td><td>60</td><td>50</td><td>30</td><td>0</td><td>0</td><td>0</td><td>10</td><td>30</td><td>0</td></tr>
-<tr><td>触手</td><td>50</td><td>40</td><td>20</td><td>0</td><td>0</td><td>0</td><td>20</td><td>30</td><td>0</td></tr>
+<tr><td>Mouth Inside</td><td>90</td><td>80</td><td>90</td><td>0</td><td>10</td><td>0</td><td>70</td><td>35</td><td>0</td></tr>
+<tr><td>Feeler</td><td>60</td><td>50</td><td>30</td><td>0</td><td>0</td><td>0</td><td>10</td><td>30</td><td>0</td></tr>
+<tr><td>Tentacle</td><td>50</td><td>40</td><td>20</td><td>0</td><td>0</td><td>0</td><td>20</td><td>30</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
@@ -78,11 +78,11 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>200</td><td></td></tr>
 <tr><td>Back</td><td>500</td><td></td></tr>
-<tr><td>目</td><td>200</td><td></td></tr>
+<tr><td>Eye</td><td>200</td><td></td></tr>
 <tr><td>Torso</td><td>500</td><td></td></tr>
-<tr><td>口中</td><td>150</td><td></td></tr>
-<tr><td>触角</td><td>200</td><td></td></tr>
-<tr><td>触手</td><td>300</td><td></td></tr>
+<tr><td>Mouth Inside</td><td>150</td><td></td></tr>
+<tr><td>Feeler</td><td>200</td><td></td></tr>
+<tr><td>Tentacle</td><td>300</td><td></td></tr>
 <tr><td>触手破壊</td><td>300</td><td>８ stagger(s) required</td></tr>
 </table>
 <!-- <img id=hitzones src="../img/monszones/yamatsukami.png" width="400"/> !-->

--- a/mons/yama_nh.htm
+++ b/mons/yama_nh.htm
@@ -76,24 +76,24 @@
 <img id=icon src="../img/monsicons/yamatsukami.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>60</td><td>50</td><td>0</td><td>0</td><td>15</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>50</td><td>60</td><td>25</td><td>0</td><td>0</td><td>20</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>目</td><td>100</td><td>100</td><td>45</td><td>15</td><td>0</td><td>25</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Eye</td><td>100</td><td>100</td><td>45</td><td>15</td><td>0</td><td>25</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>80</td><td>70</td><td>20</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>口中</td><td>90</td><td>80</td><td>40</td><td>0</td><td>0</td><td>20</td><td>30</td><td>0</td><td>0</td></tr>
-<tr><td>触角</td><td>50</td><td>60</td><td>30</td><td>0</td><td>0</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
-<tr><td>触手</td><td>40</td><td>50</td><td>20</td><td>0</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(赤膜時)</th></tr>
+<tr><td>Mouth Inside</td><td>90</td><td>80</td><td>40</td><td>0</td><td>0</td><td>20</td><td>30</td><td>0</td><td>0</td></tr>
+<tr><td>Feeler</td><td>50</td><td>60</td><td>30</td><td>0</td><td>0</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
+<tr><td>Tentacle</td><td>40</td><td>50</td><td>20</td><td>0</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(赤膜時)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>60</td><td>45</td><td>0</td><td>0</td><td>15</td><td>30</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>50</td><td>60</td><td>20</td><td>0</td><td>0</td><td>20</td><td>10</td><td>0</td><td>0</td></tr>
-<tr><td>目</td><td>100</td><td>100</td><td>40</td><td>15</td><td>0</td><td>25</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Eye</td><td>100</td><td>100</td><td>40</td><td>15</td><td>0</td><td>25</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>80</td><td>70</td><td>15</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>口中</td><td>90</td><td>80</td><td>35</td><td>0</td><td>0</td><td>20</td><td>30</td><td>0</td><td>0</td></tr>
-<tr><td>触角</td><td>50</td><td>60</td><td>25</td><td>0</td><td>0</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
-<tr><td>触手</td><td>40</td><td>50</td><td>15</td><td>0</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
+<tr><td>Mouth Inside</td><td>90</td><td>80</td><td>35</td><td>0</td><td>0</td><td>20</td><td>30</td><td>0</td><td>0</td></tr>
+<tr><td>Feeler</td><td>50</td><td>60</td><td>25</td><td>0</td><td>0</td><td>15</td><td>20</td><td>0</td><td>0</td></tr>
+<tr><td>Tentacle</td><td>40</td><td>50</td><td>15</td><td>0</td><td>0</td><td>15</td><td>10</td><td>0</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
@@ -101,11 +101,11 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>300</td><td></td></tr>
 <tr><td>Back</td><td>500</td><td></td></tr>
-<tr><td>目</td><td>450</td><td></td></tr>
+<tr><td>Eye</td><td>450</td><td></td></tr>
 <tr><td>Torso</td><td>500</td><td></td></tr>
-<tr><td>口中</td><td>300</td><td></td></tr>
-<tr><td>触角</td><td>400</td><td></td></tr>
-<tr><td>触手</td><td>500</td><td></td></tr>
+<tr><td>Mouth Inside</td><td>300</td><td></td></tr>
+<tr><td>Feeler</td><td>400</td><td></td></tr>
+<tr><td>Tentacle</td><td>500</td><td></td></tr>
 <tr><td>触手破壊</td><td>300</td><td>８ stagger(s) required</td></tr>
 </table>
 <!-- <img id=hitzones src="../img/monszones/yamatsukami.png" width="400"/> !-->

--- a/mons/yamac_ng.htm
+++ b/mons/yamac_ng.htm
@@ -98,33 +98,33 @@
 <img id=icon src="../img/monsicons/yamakurai.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>50</td><td>45</td><td>0</td><td>5</td><td>50</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>10</td><td>25</td><td>35</td><td>0</td><td>5</td><td>25</td><td>0</td><td>0</td></tr>
-<tr><td>目</td><td>65</td><td>60</td><td>60</td><td>30</td><td>0</td><td>20</td><td>30</td><td>10</td><td>0</td></tr>
+<tr><td>Eye</td><td>65</td><td>60</td><td>60</td><td>30</td><td>0</td><td>20</td><td>30</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>45</td><td>50</td><td>30</td><td>25</td><td>0</td><td>5</td><td>5</td><td>10</td><td>0</td></tr>
-<tr><td>口中</td><td>60</td><td>55</td><td>45</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>触角</td><td>35</td><td>40</td><td>35</td><td>30</td><td>0</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
-<tr><td>触手</td><td>30</td><td>35</td><td>30</td><td>25</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り)</th></tr>
+<tr><td>Mouth Inside</td><td>60</td><td>55</td><td>45</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Feeler</td><td>35</td><td>40</td><td>35</td><td>30</td><td>0</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
+<tr><td>Tentacle</td><td>30</td><td>35</td><td>30</td><td>25</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(怒り)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>50</td><td>45</td><td>0</td><td>5</td><td>50</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>10</td><td>25</td><td>35</td><td>0</td><td>5</td><td>25</td><td>0</td><td>0</td></tr>
-<tr><td>目</td><td>65</td><td>60</td><td>60</td><td>30</td><td>0</td><td>20</td><td>30</td><td>10</td><td>0</td></tr>
+<tr><td>Eye</td><td>65</td><td>60</td><td>60</td><td>30</td><td>0</td><td>20</td><td>30</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>45</td><td>50</td><td>30</td><td>25</td><td>0</td><td>5</td><td>5</td><td>10</td><td>0</td></tr>
-<tr><td>口中</td><td>60</td><td>55</td><td>45</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>触角</td><td>35</td><td>40</td><td>35</td><td>30</td><td>0</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
-<tr><td>触手</td><td>30</td><td>35</td><td>30</td><td>25</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(紅葉)</th></tr>
+<tr><td>Mouth Inside</td><td>60</td><td>55</td><td>45</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Feeler</td><td>35</td><td>40</td><td>35</td><td>30</td><td>0</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
+<tr><td>Tentacle</td><td>30</td><td>35</td><td>30</td><td>25</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(紅葉)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>40</td><td>45</td><td>50</td><td>45</td><td>0</td><td>5</td><td>50</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>10</td><td>25</td><td>35</td><td>0</td><td>5</td><td>25</td><td>0</td><td>0</td></tr>
-<tr><td>目</td><td>65</td><td>60</td><td>60</td><td>30</td><td>0</td><td>20</td><td>30</td><td>10</td><td>0</td></tr>
+<tr><td>Eye</td><td>65</td><td>60</td><td>60</td><td>30</td><td>0</td><td>20</td><td>30</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>45</td><td>50</td><td>30</td><td>25</td><td>0</td><td>5</td><td>5</td><td>10</td><td>0</td></tr>
-<tr><td>口中</td><td>60</td><td>55</td><td>45</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>触角</td><td>35</td><td>40</td><td>35</td><td>30</td><td>0</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
-<tr><td>触手</td><td>30</td><td>35</td><td>30</td><td>25</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
+<tr><td>Mouth Inside</td><td>60</td><td>55</td><td>45</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Feeler</td><td>35</td><td>40</td><td>35</td><td>30</td><td>0</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
+<tr><td>Tentacle</td><td>30</td><td>35</td><td>30</td><td>25</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
@@ -132,11 +132,11 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>300</td><td></td></tr>
 <tr><td>Back</td><td>500</td><td></td></tr>
-<tr><td>目</td><td>450</td><td></td></tr>
+<tr><td>Eye</td><td>450</td><td></td></tr>
 <tr><td>Torso</td><td>500</td><td></td></tr>
-<tr><td>口中</td><td>300</td><td></td></tr>
-<tr><td>触角</td><td>400</td><td></td></tr>
-<tr><td>触手</td><td>500</td><td>８ stagger(s) required</td></tr>
+<tr><td>Mouth Inside</td><td>300</td><td></td></tr>
+<tr><td>Feeler</td><td>400</td><td></td></tr>
+<tr><td>Tentacle</td><td>500</td><td>８ stagger(s) required</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/yamakurai.png" width="400"/>
 <script type="text/javascript" src="hover.js"></script>

--- a/mons/yamac_nh.htm
+++ b/mons/yamac_nh.htm
@@ -76,33 +76,33 @@
 <img id=icon src="../img/monsicons/yamakurai.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>65</td><td>60</td><td>45</td><td>0</td><td>5</td><td>50</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>35</td><td>25</td><td>35</td><td>35</td><td>0</td><td>5</td><td>25</td><td>0</td><td>0</td></tr>
-<tr><td>目</td><td>80</td><td>75</td><td>65</td><td>30</td><td>0</td><td>20</td><td>30</td><td>10</td><td>0</td></tr>
+<tr><td>Eye</td><td>80</td><td>75</td><td>65</td><td>30</td><td>0</td><td>20</td><td>30</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>60</td><td>65</td><td>35</td><td>25</td><td>0</td><td>5</td><td>5</td><td>10</td><td>0</td></tr>
-<tr><td>口中</td><td>70</td><td>65</td><td>55</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>触角</td><td>50</td><td>55</td><td>40</td><td>30</td><td>0</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
-<tr><td>触手</td><td>35</td><td>40</td><td>35</td><td>25</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(怒り)</th></tr>
+<tr><td>Mouth Inside</td><td>70</td><td>65</td><td>55</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Feeler</td><td>50</td><td>55</td><td>40</td><td>30</td><td>0</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
+<tr><td>Tentacle</td><td>35</td><td>40</td><td>35</td><td>25</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(怒り)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>65</td><td>60</td><td>45</td><td>0</td><td>5</td><td>50</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>35</td><td>25</td><td>35</td><td>35</td><td>0</td><td>5</td><td>25</td><td>0</td><td>0</td></tr>
-<tr><td>目</td><td>80</td><td>75</td><td>65</td><td>30</td><td>0</td><td>20</td><td>30</td><td>10</td><td>0</td></tr>
+<tr><td>Eye</td><td>80</td><td>75</td><td>65</td><td>30</td><td>0</td><td>20</td><td>30</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>60</td><td>65</td><td>35</td><td>25</td><td>0</td><td>5</td><td>5</td><td>10</td><td>0</td></tr>
-<tr><td>口中</td><td>70</td><td>65</td><td>55</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>触角</td><td>50</td><td>55</td><td>40</td><td>30</td><td>0</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
-<tr><td>触手</td><td>35</td><td>40</td><td>35</td><td>25</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(紅葉)</th></tr>
+<tr><td>Mouth Inside</td><td>70</td><td>65</td><td>55</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Feeler</td><td>50</td><td>55</td><td>40</td><td>30</td><td>0</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
+<tr><td>Tentacle</td><td>35</td><td>40</td><td>35</td><td>25</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
+<tr class=l><th colspan=10>Hitzones(紅葉)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>50</td><td>65</td><td>60</td><td>45</td><td>0</td><td>5</td><td>50</td><td>0</td><td>0</td></tr>
 <tr><td>Back</td><td>35</td><td>25</td><td>35</td><td>35</td><td>0</td><td>5</td><td>25</td><td>0</td><td>0</td></tr>
-<tr><td>目</td><td>80</td><td>75</td><td>65</td><td>30</td><td>0</td><td>20</td><td>30</td><td>10</td><td>0</td></tr>
+<tr><td>Eye</td><td>80</td><td>75</td><td>65</td><td>30</td><td>0</td><td>20</td><td>30</td><td>10</td><td>0</td></tr>
 <tr><td>Torso</td><td>60</td><td>65</td><td>35</td><td>25</td><td>0</td><td>5</td><td>5</td><td>10</td><td>0</td></tr>
-<tr><td>口中</td><td>70</td><td>65</td><td>55</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
-<tr><td>触角</td><td>50</td><td>55</td><td>40</td><td>30</td><td>0</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
-<tr><td>触手</td><td>35</td><td>40</td><td>35</td><td>25</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
+<tr><td>Mouth Inside</td><td>70</td><td>65</td><td>55</td><td>15</td><td>0</td><td>0</td><td>5</td><td>0</td><td>0</td></tr>
+<tr><td>Feeler</td><td>50</td><td>55</td><td>40</td><td>30</td><td>0</td><td>0</td><td>15</td><td>5</td><td>0</td></tr>
+<tr><td>Tentacle</td><td>35</td><td>40</td><td>35</td><td>25</td><td>0</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
 </table>
 <table id=down>
 <col class=c1><col class=c2n><col class=c3>
@@ -110,11 +110,11 @@
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>300</td><td></td></tr>
 <tr><td>Back</td><td>500</td><td></td></tr>
-<tr><td>目</td><td>450</td><td></td></tr>
+<tr><td>Eye</td><td>450</td><td></td></tr>
 <tr><td>Torso</td><td>500</td><td></td></tr>
-<tr><td>口中</td><td>300</td><td></td></tr>
-<tr><td>触角</td><td>400</td><td></td></tr>
-<tr><td>触手</td><td>500</td><td>８ stagger(s) required</td></tr>
+<tr><td>Mouth Inside</td><td>300</td><td></td></tr>
+<tr><td>Feeler</td><td>400</td><td></td></tr>
+<tr><td>Tentacle</td><td>500</td><td>８ stagger(s) required</td></tr>
 </table>
 <img id=hitzones src="../img/monszones/yamakurai.png" width="400"/>
 <script type="text/javascript" src="hover.js"></script>

--- a/mons/yao_n.htm
+++ b/mons/yao_n.htm
@@ -81,7 +81,7 @@
 <img id=icon src="../img/monsicons/ceanataur.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Whole Body</td><td>80</td><td>110</td><td>65</td><td>30</td><td>5</td><td>60</td><td>0</td><td>20</td><td>200</td></tr>
 </table>

--- a/mons/zena_ng.htm
+++ b/mons/zena_ng.htm
@@ -102,7 +102,7 @@
 <img id=icon src="../img/monsicons/zenaserisu.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>？？</td><td>35</td><td>40</td><td>25</td><td>0</td><td>0</td><td>25</td><td>20</td><td>0</td><td>100</td></tr>
 <tr><td>？？</td><td>25</td><td>20</td><td>15</td><td>0</td><td>0</td><td>15</td><td>5</td><td>0</td><td>0</td></tr>

--- a/mons/zeruK_ng.htm
+++ b/mons/zeruK_ng.htm
@@ -106,7 +106,7 @@
 <img id=icon src="../img/monsicons/musou_zerureusu.webp" width="500"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>20</td><td>35</td><td>20</td><td>0</td><td>20</td><td>0</td><td>30</td><td>20</td><td>100</td></tr>
 <tr><td>Neck</td><td>25</td><td>25</td><td>25</td><td>0</td><td>10</td><td>0</td><td>0</td><td>10</td><td>0</td></tr>
@@ -123,8 +123,8 @@
 <tr><td>Torso</td><td>850</td><td></td></tr>
 <tr><td>Left Wing</td><td>750</td><td></td></tr>
 <tr><td>Right Wing</td><td>750</td><td></td></tr>
-<tr><td>Left Foot</td><td>700</td><td></td></tr>
-<tr><td>Right Foot</td><td>700</td><td></td></tr>
+<tr><td>Left Leg</td><td>700</td><td></td></tr>
+<tr><td>Right Leg</td><td>700</td><td></td></tr>
 <tr><td>Neck</td><td>600</td><td></td></tr>
 <tr><td>Head</td><td>800</td><td></td></tr>
 <tr><td>Tail</td><td>800</td><td></td></tr>

--- a/mons/zeru_ng.htm
+++ b/mons/zeru_ng.htm
@@ -99,7 +99,7 @@
 <img id=icon src="../img/monsicons/zerureusu.webp" width="300"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>50</td><td>20</td><td>0</td><td>20</td><td>0</td><td>40</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>25</td><td>30</td><td>25</td><td>0</td><td>10</td><td>0</td><td>0</td><td>25</td><td>0</td></tr>
@@ -108,7 +108,7 @@
 <tr><td>Tail</td><td>50</td><td>30</td><td>30</td><td>0</td><td>20</td><td>0</td><td>40</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>25</td><td>50</td><td>0</td><td>20</td><td>0</td><td>40</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>40</td><td>30</td><td>25</td><td>0</td><td>10</td><td>0</td><td>30</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(対斬強化)</th></tr>
+<tr class=l><th colspan=10>Hitzones(対斬強化)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>50</td><td>20</td><td>0</td><td>20</td><td>0</td><td>40</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>25</td><td>30</td><td>25</td><td>0</td><td>10</td><td>0</td><td>0</td><td>25</td><td>0</td></tr>
@@ -117,7 +117,7 @@
 <tr><td>Tail</td><td>15</td><td>30</td><td>30</td><td>0</td><td>20</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>25</td><td>50</td><td>0</td><td>20</td><td>0</td><td>40</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>30</td><td>25</td><td>0</td><td>10</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(対打強化)</th></tr>
+<tr class=l><th colspan=10>Hitzones(対打強化)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>15</td><td>20</td><td>0</td><td>20</td><td>0</td><td>10</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>25</td><td>30</td><td>25</td><td>0</td><td>10</td><td>0</td><td>0</td><td>25</td><td>0</td></tr>
@@ -126,7 +126,7 @@
 <tr><td>Tail</td><td>50</td><td>30</td><td>30</td><td>0</td><td>20</td><td>0</td><td>40</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>25</td><td>50</td><td>0</td><td>20</td><td>0</td><td>40</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>40</td><td>30</td><td>25</td><td>0</td><td>10</td><td>0</td><td>30</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(対弾強化)</th></tr>
+<tr class=l><th colspan=10>Hitzones(対弾強化)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>50</td><td>20</td><td>0</td><td>20</td><td>0</td><td>40</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>25</td><td>30</td><td>25</td><td>0</td><td>10</td><td>0</td><td>0</td><td>25</td><td>0</td></tr>
@@ -135,7 +135,7 @@
 <tr><td>Tail</td><td>50</td><td>30</td><td>30</td><td>0</td><td>20</td><td>0</td><td>40</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>25</td><td>15</td><td>0</td><td>20</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>40</td><td>30</td><td>25</td><td>0</td><td>10</td><td>0</td><td>30</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(？？)</th></tr>
+<tr class=l><th colspan=10>Hitzones(？？)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>100</td></tr>
 <tr><td>Neck</td><td>10</td><td>10</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
@@ -152,8 +152,8 @@
 <tr><td>Torso</td><td>850</td><td></td></tr>
 <tr><td>Left Wing</td><td>750</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>750</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>700</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
-<tr><td>Right Foot</td><td>700</td><td>１ stagger(s) required</td></tr>
+<tr><td>Left Leg</td><td>700</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
+<tr><td>Right Leg</td><td>700</td><td>１ stagger(s) required</td></tr>
 <tr><td>Neck</td><td>600</td><td></td></tr>
 <tr><td>Head</td><td>800</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>800</td><td></td></tr>

--- a/mons/zeru_nh.htm
+++ b/mons/zeru_nh.htm
@@ -70,7 +70,7 @@
 <img id=icon src="../img/monsicons/zerureusu.webp" width="300"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>50</td><td>20</td><td>0</td><td>20</td><td>0</td><td>40</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>25</td><td>30</td><td>25</td><td>0</td><td>10</td><td>0</td><td>0</td><td>25</td><td>0</td></tr>
@@ -79,7 +79,7 @@
 <tr><td>Tail</td><td>50</td><td>30</td><td>30</td><td>0</td><td>20</td><td>0</td><td>40</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>25</td><td>50</td><td>0</td><td>20</td><td>0</td><td>40</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>40</td><td>30</td><td>25</td><td>0</td><td>10</td><td>0</td><td>30</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(対斬強化)</th></tr>
+<tr class=l><th colspan=10>Hitzones(対斬強化)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>50</td><td>20</td><td>0</td><td>20</td><td>0</td><td>40</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>25</td><td>30</td><td>25</td><td>0</td><td>10</td><td>0</td><td>0</td><td>25</td><td>0</td></tr>
@@ -88,7 +88,7 @@
 <tr><td>Tail</td><td>15</td><td>30</td><td>30</td><td>0</td><td>20</td><td>0</td><td>10</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>25</td><td>50</td><td>0</td><td>20</td><td>0</td><td>40</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>15</td><td>30</td><td>25</td><td>0</td><td>10</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(対打強化)</th></tr>
+<tr class=l><th colspan=10>Hitzones(対打強化)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>15</td><td>20</td><td>0</td><td>20</td><td>0</td><td>10</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>25</td><td>30</td><td>25</td><td>0</td><td>10</td><td>0</td><td>0</td><td>25</td><td>0</td></tr>
@@ -97,7 +97,7 @@
 <tr><td>Tail</td><td>50</td><td>30</td><td>30</td><td>0</td><td>20</td><td>0</td><td>40</td><td>5</td><td>0</td></tr>
 <tr><td>Wing</td><td>25</td><td>25</td><td>50</td><td>0</td><td>20</td><td>0</td><td>40</td><td>5</td><td>0</td></tr>
 <tr><td>Leg</td><td>40</td><td>30</td><td>25</td><td>0</td><td>10</td><td>0</td><td>30</td><td>15</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(対弾強化)</th></tr>
+<tr class=l><th colspan=10>Hitzones(対弾強化)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>30</td><td>50</td><td>20</td><td>0</td><td>20</td><td>0</td><td>40</td><td>10</td><td>100</td></tr>
 <tr><td>Neck</td><td>25</td><td>30</td><td>25</td><td>0</td><td>10</td><td>0</td><td>0</td><td>25</td><td>0</td></tr>
@@ -114,8 +114,8 @@
 <tr><td>Torso</td><td>500</td><td></td></tr>
 <tr><td>Left Wing</td><td>500</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
 <tr><td>Right Wing</td><td>500</td><td>１ stagger(s) required</td></tr>
-<tr><td>Left Foot</td><td>400</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
-<tr><td>Right Foot</td><td>400</td><td>１ stagger(s) required</td></tr>
+<tr><td>Left Leg</td><td>400</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
+<tr><td>Right Leg</td><td>400</td><td>１ stagger(s) required</td></tr>
 <tr><td>Neck</td><td>300</td><td></td></tr>
 <tr><td>Head</td><td>500</td><td>２ stagger(s) required</td></tr>
 <tr><td>Tail</td><td>500</td><td></td></tr>

--- a/mons/zin_ng.htm
+++ b/mons/zin_ng.htm
@@ -117,39 +117,39 @@
 <img id=icon src="../img/monsicons/zinogre.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>39</td><td>39</td><td>42</td><td>10</td><td>10</td><td>0</td><td>5</td><td>15</td><td>100</td></tr>
 <tr><td>Torso</td><td>15</td><td>15</td><td>18</td><td>5</td><td>5</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Back</td><td>27</td><td>24</td><td>21</td><td>10</td><td>20</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>15</td><td>18</td><td>18</td><td>5</td><td>5</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>15</td><td>18</td><td>18</td><td>5</td><td>5</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>27</td><td>27</td><td>21</td><td>5</td><td>5</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>26</td><td>26</td><td>18</td><td>5</td><td>5</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>15</td><td>13</td><td>10</td><td>7</td><td>10</td><td>0</td><td>5</td><td>12</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(雷纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(雷纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>39</td><td>39</td><td>42</td><td>10</td><td>10</td><td>0</td><td>10</td><td>15</td><td>120</td></tr>
 <tr><td>Torso</td><td>18</td><td>18</td><td>21</td><td>5</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>Back</td><td>42</td><td>39</td><td>33</td><td>15</td><td>25</td><td>0</td><td>5</td><td>30</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>26</td><td>28</td><td>18</td><td>5</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>26</td><td>28</td><td>18</td><td>5</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>30</td><td>30</td><td>24</td><td>10</td><td>10</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>27</td><td>27</td><td>22</td><td>10</td><td>10</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>15</td><td>13</td><td>10</td><td>7</td><td>10</td><td>0</td><td>5</td><td>12</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(極)</th></tr>
+<tr class=l><th colspan=10>Hitzones(極)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>29</td><td>34</td><td>17</td><td>10</td><td>10</td><td>0</td><td>10</td><td>15</td><td>100</td></tr>
 <tr><td>Torso</td><td>13</td><td>13</td><td>16</td><td>5</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>Back</td><td>36</td><td>32</td><td>25</td><td>15</td><td>25</td><td>0</td><td>5</td><td>30</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>20</td><td>23</td><td>12</td><td>5</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>20</td><td>23</td><td>12</td><td>5</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>27</td><td>30</td><td>10</td><td>10</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>23</td><td>21</td><td>17</td><td>10</td><td>10</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>12</td><td>10</td><td>5</td><td>7</td><td>10</td><td>0</td><td>5</td><td>12</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(極雷纏)</th></tr>
+<tr class=l><th colspan=10>Hitzones(極雷纏)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>27</td><td>30</td><td>15</td><td>10</td><td>5</td><td>0</td><td>10</td><td>10</td><td>100</td></tr>
 <tr><td>Torso</td><td>11</td><td>11</td><td>13</td><td>5</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Back</td><td>31</td><td>8</td><td>20</td><td>10</td><td>20</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>16</td><td>18</td><td>10</td><td>5</td><td>5</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>16</td><td>18</td><td>10</td><td>5</td><td>5</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>21</td><td>25</td><td>30</td><td>5</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Tail</td><td>20</td><td>17</td><td>13</td><td>5</td><td>5</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>10</td><td>10</td><td>5</td><td>4</td><td>10</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
@@ -159,12 +159,12 @@
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>1300</td><td>１ stagger(s) required for first partbreak stage<br>２ stagger(s) required</td></tr>
-<tr><td>胴体？</td><td>1400</td><td></td></tr>
-<tr><td>背中？</td><td>600</td><td></td></tr>
-<tr><td>左前脚？</td><td>850</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
-<tr><td>右前脚？</td><td>850</td><td>１ stagger(s) required</td></tr>
-<tr><td>左後脚？</td><td>1150</td><td></td></tr>
-<tr><td>右後脚？</td><td>1150</td><td></td></tr>
+<tr><td>Torso?</td><td>1400</td><td></td></tr>
+<tr><td>Back?</td><td>600</td><td></td></tr>
+<tr><td>Left Foreleg?</td><td>850</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
+<tr><td>Right Foreleg?</td><td>850</td><td>１ stagger(s) required</td></tr>
+<tr><td>Left Hind Leg?</td><td>1150</td><td></td></tr>
+<tr><td>Right Hind Leg?</td><td>1150</td><td></td></tr>
 <tr><td>？？</td><td>600</td><td></td></tr>
 <tr><td>Tail</td><td>2800</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>

--- a/mons/zin_nh.htm
+++ b/mons/zin_nh.htm
@@ -76,21 +76,21 @@
 <img id=icon src="../img/monsicons/zinogre.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>45</td><td>42</td><td>10</td><td>10</td><td>0</td><td>5</td><td>15</td><td>100</td></tr>
 <tr><td>Torso</td><td>21</td><td>21</td><td>18</td><td>5</td><td>5</td><td>0</td><td>5</td><td>5</td><td>0</td></tr>
 <tr><td>Back</td><td>32</td><td>29</td><td>26</td><td>10</td><td>20</td><td>0</td><td>5</td><td>25</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>21</td><td>21</td><td>18</td><td>5</td><td>5</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>21</td><td>21</td><td>18</td><td>5</td><td>5</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>32</td><td>32</td><td>24</td><td>5</td><td>5</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>25</td><td>25</td><td>5</td><td>5</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>21</td><td>19</td><td>10</td><td>7</td><td>10</td><td>0</td><td>5</td><td>12</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(雷纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(雷纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>45</td><td>45</td><td>42</td><td>10</td><td>10</td><td>0</td><td>10</td><td>15</td><td>120</td></tr>
 <tr><td>Torso</td><td>25</td><td>25</td><td>21</td><td>5</td><td>10</td><td>0</td><td>5</td><td>10</td><td>0</td></tr>
 <tr><td>Back</td><td>42</td><td>39</td><td>33</td><td>15</td><td>25</td><td>0</td><td>5</td><td>30</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>26</td><td>28</td><td>18</td><td>5</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>26</td><td>28</td><td>18</td><td>5</td><td>5</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>36</td><td>36</td><td>28</td><td>10</td><td>10</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
 <tr><td>Tail</td><td>30</td><td>25</td><td>25</td><td>10</td><td>10</td><td>0</td><td>5</td><td>15</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>21</td><td>19</td><td>10</td><td>7</td><td>10</td><td>0</td><td>5</td><td>12</td><td>0</td></tr>
@@ -100,12 +100,12 @@
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>600</td><td>１ stagger(s) required for first partbreak stage<br>２ stagger(s) required</td></tr>
-<tr><td>胴体？</td><td>700</td><td></td></tr>
-<tr><td>背中？</td><td>450</td><td></td></tr>
-<tr><td>左前脚？</td><td>550</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
-<tr><td>右前脚？</td><td>550</td><td>１ stagger(s) required</td></tr>
-<tr><td>左後脚？</td><td>600</td><td></td></tr>
-<tr><td>右後脚？</td><td>600</td><td></td></tr>
+<tr><td>Torso?</td><td>700</td><td></td></tr>
+<tr><td>Back?</td><td>450</td><td></td></tr>
+<tr><td>Left Foreleg?</td><td>550</td><td>１ stagger(s) required (Only one break required for rewards)</td></tr>
+<tr><td>Right Foreleg?</td><td>550</td><td>１ stagger(s) required</td></tr>
+<tr><td>Left Hind Leg?</td><td>600</td><td></td></tr>
+<tr><td>Right Hind Leg?</td><td>600</td><td></td></tr>
 <tr><td>？？</td><td>500</td><td></td></tr>
 <tr><td>Tail</td><td>1200</td><td>Reach the required HP threshold and deal enough Cutting damage</td></tr>
 </table>

--- a/mons/zingoku_ng.htm
+++ b/mons/zingoku_ng.htm
@@ -97,21 +97,21 @@
 <img id=icon src="../img/monsicons/stygianzinogre.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>39</td><td>35</td><td>35</td><td>5</td><td>10</td><td>20</td><td>0</td><td>5</td><td>100</td></tr>
 <tr><td>Torso</td><td>15</td><td>15</td><td>13</td><td>5</td><td>10</td><td>10</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Back</td><td>20</td><td>20</td><td>21</td><td>10</td><td>20</td><td>15</td><td>0</td><td>20</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>16</td><td>15</td><td>14</td><td>5</td><td>10</td><td>10</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>16</td><td>15</td><td>14</td><td>5</td><td>10</td><td>10</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>19</td><td>19</td><td>18</td><td>5</td><td>10</td><td>10</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>22</td><td>22</td><td>15</td><td>5</td><td>15</td><td>10</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>15</td><td>18</td><td>10</td><td>7</td><td>10</td><td>20</td><td>0</td><td>7</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(龍纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(龍纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>34</td><td>30</td><td>35</td><td>5</td><td>10</td><td>25</td><td>0</td><td>5</td><td>120</td></tr>
 <tr><td>Torso</td><td>13</td><td>15</td><td>16</td><td>5</td><td>10</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Back</td><td>38</td><td>35</td><td>29</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>16</td><td>17</td><td>13</td><td>5</td><td>10</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>16</td><td>17</td><td>13</td><td>5</td><td>10</td><td>20</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>20</td><td>20</td><td>18</td><td>5</td><td>20</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>19</td><td>19</td><td>17</td><td>10</td><td>15</td><td>15</td><td>0</td><td>15</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>15</td><td>18</td><td>5</td><td>5</td><td>20</td><td>25</td><td>0</td><td>17</td><td>0</td></tr>
@@ -121,12 +121,12 @@
 <tr class=l><th colspan=3>Stagger Resistance (Resistance x # of times Staggered)</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>1400</td><td></td></tr>
-<tr><td>胴体？</td><td>1500</td><td></td></tr>
-<tr><td>背中？</td><td>650</td><td></td></tr>
-<tr><td>左前脚？</td><td>850</td><td></td></tr>
-<tr><td>右前脚？</td><td>850</td><td></td></tr>
-<tr><td>左後脚？</td><td>1200</td><td></td></tr>
-<tr><td>右後脚？</td><td>1200</td><td></td></tr>
+<tr><td>Torso?</td><td>1500</td><td></td></tr>
+<tr><td>Back?</td><td>650</td><td></td></tr>
+<tr><td>Left Foreleg?</td><td>850</td><td></td></tr>
+<tr><td>Right Foreleg?</td><td>850</td><td></td></tr>
+<tr><td>Left Hind Leg?</td><td>1200</td><td></td></tr>
+<tr><td>Right Hind Leg?</td><td>1200</td><td></td></tr>
 <tr><td>？？</td><td>650</td><td></td></tr>
 <tr><td>Tail</td><td>2800</td><td></td></tr>
 </table>

--- a/mons/zingoku_nh.htm
+++ b/mons/zingoku_nh.htm
@@ -75,21 +75,21 @@
 <img id=icon src="../img/monsicons/stygianzinogre.webp" width="400"/>
 <hr><table id=niku>
 <col class=c1><col class=c2n span=9>
-<tr class=l><th colspan=10>Hitzone Info</th></tr>
+<tr class=l><th colspan=10>Hitzones</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>49</td><td>45</td><td>45</td><td>5</td><td>10</td><td>35</td><td>0</td><td>10</td><td>100</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>18</td><td>5</td><td>10</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Back</td><td>25</td><td>25</td><td>26</td><td>10</td><td>25</td><td>25</td><td>0</td><td>25</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>21</td><td>20</td><td>19</td><td>5</td><td>10</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>21</td><td>20</td><td>19</td><td>5</td><td>10</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>24</td><td>24</td><td>24</td><td>5</td><td>10</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>27</td><td>27</td><td>22</td><td>5</td><td>20</td><td>10</td><td>0</td><td>20</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>25</td><td>23</td><td>20</td><td>7</td><td>10</td><td>25</td><td>0</td><td>7</td><td>0</td></tr>
-<tr class=l><th colspan=10>肉質(龍纏い)</th></tr>
+<tr class=l><th colspan=10>Hitzones(龍纏い)</th></tr>
 <tr><th>Part</th><th>Cutting</th><th>Impact</th><th>Shot</th><th>Fire</th><th>Water</th><th>Thndr</th><th>Dragon</th><th>Ice</th><th>Stun</th></tr>
 <tr><td>Head</td><td>39</td><td>35</td><td>35</td><td>5</td><td>10</td><td>30</td><td>0</td><td>10</td><td>120</td></tr>
 <tr><td>Torso</td><td>20</td><td>20</td><td>16</td><td>5</td><td>10</td><td>15</td><td>0</td><td>5</td><td>0</td></tr>
 <tr><td>Back</td><td>35</td><td>35</td><td>34</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>Fore Leg</td><td>21</td><td>22</td><td>18</td><td>5</td><td>10</td><td>25</td><td>0</td><td>10</td><td>0</td></tr>
+<tr><td>Foreleg</td><td>21</td><td>22</td><td>18</td><td>5</td><td>10</td><td>25</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Hind Leg</td><td>25</td><td>25</td><td>23</td><td>5</td><td>25</td><td>15</td><td>0</td><td>10</td><td>0</td></tr>
 <tr><td>Tail</td><td>24</td><td>24</td><td>22</td><td>10</td><td>20</td><td>15</td><td>0</td><td>20</td><td>0</td></tr>
 <tr><td>Tail Tip</td><td>20</td><td>23</td><td>10</td><td>5</td><td>25</td><td>25</td><td>0</td><td>17</td><td>0</td></tr>
@@ -99,12 +99,12 @@
 <tr class=l><th colspan=3>Stagger Resistance</th></tr>
 <tr><th>Part</th><th>Tolerance</th><th>Part Break Info</th></tr>
 <tr><td>Head</td><td>650</td><td></td></tr>
-<tr><td>胴体？</td><td>700</td><td></td></tr>
-<tr><td>背中？</td><td>400</td><td></td></tr>
-<tr><td>左前脚？</td><td>550</td><td></td></tr>
-<tr><td>右前脚？</td><td>550</td><td></td></tr>
-<tr><td>左後脚？</td><td>600</td><td></td></tr>
-<tr><td>右後脚？</td><td>600</td><td></td></tr>
+<tr><td>Torso?</td><td>700</td><td></td></tr>
+<tr><td>Back?</td><td>400</td><td></td></tr>
+<tr><td>Left Foreleg?</td><td>550</td><td></td></tr>
+<tr><td>Right Foreleg?</td><td>550</td><td></td></tr>
+<tr><td>Left Hind Leg?</td><td>600</td><td></td></tr>
+<tr><td>Right Hind Leg?</td><td>600</td><td></td></tr>
 <tr><td>？？</td><td>500</td><td></td></tr>
 <tr><td>Tail</td><td>1200</td><td></td></tr>
 </table>


### PR DESCRIPTION
Changelog:

* Translated all untranslated hitzones and stagger zones (hopefully)
* Corrected all instances of "Foot" to "Leg" (in JP, all but one of these were "脚", which is unambiguously "leg", and the one exception used "足", which can still mean "leg")
* Corrected all instances of "Fore Leg" to "Foreleg"
* Changed "Hitzone Info" to "Hitzones" to more closely match the Japanese "肉質"
* Changed "Sub-Tail" to "Subtail" (original JP word is fictional; change based on aesthetic preference)
* Changed Deviljho's "Fore Leg" to "Hand" and "Hind Leg" to "Leg" (no idea why the JP had the arms as legs; now matches Abiorugu)
* Changed Gogomoa's "Forearm" to "Arm", "Fore Leg" to "Arm", and "Hind Leg" to "Leg"

To Do:

* Translate attacks
* Translate other miscellany

Notes:

* Yes, "Wingleg" is the literal translation of Gore Magala's untranslated hitzone. The original word, 翼脚, is made-up.
* For whatever reason, "Foreleg" has no space but "Hind Leg" does. Asymmetrical, but that's the way it is according to the OED.
* I've only touched stuff in the \mons folder so far.
* It were more correct to translate 翼膜 as "patagium" instead of "webbing", but I followed the existing convention.