### PR TITLE
Fix: Missing info and incorrect terminology.

### DIFF
--- a/koneta/doc-sword.htm
+++ b/koneta/doc-sword.htm
@@ -135,7 +135,7 @@ a:visited { color: #D37AFF;}
 
 <h4>●　Sharpness Multiplier</h4>
 <table border=1 cellspacing=0 cellpadding=2 class=hosoku>
-<tr><th>Sharpness Level</th><th>Bounced Multiplier</th><th>Sharpness Multiplier</th><th>Element Multiplier</th><th>Ab Status Multiplier</th><th>Affinity Correction</th></tr>
+<tr><th>Sharpness Level</th><th>Bounced Multiplier</th><th>Sharpness Multiplier</th><th>Element Multiplier</th><th>Ab Status Multiplier</th><th>Affinity Increase</th></tr>
 <tr><td>Level 0 （Red）</td><td class=n>0.5x</td><td class=n>0.6x</td><td class=n>0.6x</td><td class=n>1.0x</td><td>Not Activated</td></tr>
 <tr><td>Level 1 （Orange）</td><td class=n>0.75x</td><td class=n>0.85x</td><td class=n>0.85x</td><td class=n>1.0x</td><td>Not Activated</td></tr>
 <tr><td>Level 2 （Yellow）</td><td class=n>1.0x</td><td class=n>1.1x</td><td class=n>1.1x</td><td class=n>1.0x</td><td>Not Activated</td></tr>

--- a/koneta/skill.htm
+++ b/koneta/skill.htm
@@ -334,7 +334,7 @@ a:visited { color: #D37AFF;}
 <tr><td class=t>All Res-10</td><td class=n>-15</td><td>Decreases all elemental resistances by 10.</td></tr>
 <tr><td class=t>All Res-20</td><td class=n>-20</td><td>Decreases all elemental resistances by 20.</td></tr>
 <tr class=l><td class=g rowspan=6>Fire Res</td><td class=g rowspan=6>○</td><td class=t>Fire Res+30</td><td class=n>20</td><td>Increases fire resistance by 30.</td></tr>
-<tr><td class=t>Fire Res+20</td><td class=n>15</td><tdIncreases fire resistance by 20.</td></tr>
+<tr><td class=t>Fire Res+20</td><td class=n>15</td><td>Increases fire resistance by 20.</td></tr>
 <tr><td class=t>Fire Res+10</td><td class=n>10</td><td>Increases fire resistance by 10.</td></tr>
 <tr><td class=t>Fire Res-10</td><td class=n>-10</td><td>Decreases fire resistance by 10.</td></tr>
 <tr><td class=t>Fire Res-20</td><td class=n>-15</td><td>Decreases fire resistance by 20.</td></tr>


### PR DESCRIPTION
Fixed a ">" missing in the skill information that caused the Fire Res+20 skill to not display its effects.. though painfully obvious what it does in the first place.

Also changed Affinity Correction to Affinity Increase on the weapon info page.